### PR TITLE
fix: Import client utils when getting entrypoint config

### DIFF
--- a/src/core/build/__tests__/findEntrypoints.test.ts
+++ b/src/core/build/__tests__/findEntrypoints.test.ts
@@ -9,13 +9,13 @@ import {
 import { resolve } from 'path';
 import { findEntrypoints } from '../findEntrypoints';
 import fs from 'fs-extra';
-import { importTsFile } from '../../utils/importTsFile';
+import { importEntrypointFile } from '../../utils/importEntrypointFile';
 import glob from 'fast-glob';
 import { fakeInternalConfig } from '../../../testing/fake-objects';
 import { unnormalizePath } from '../../utils/paths';
 
-vi.mock('../../utils/importTsFile');
-const importTsFileMock = vi.mocked(importTsFile);
+vi.mock('../../utils/importEntrypointFile');
+const importTsFileMock = vi.mocked(importEntrypointFile);
 
 vi.mock('fast-glob');
 const globMock = vi.mocked(glob);

--- a/src/core/build/__tests__/findEntrypoints.test.ts
+++ b/src/core/build/__tests__/findEntrypoints.test.ts
@@ -15,7 +15,7 @@ import { fakeInternalConfig } from '../../../testing/fake-objects';
 import { unnormalizePath } from '../../utils/paths';
 
 vi.mock('../../utils/importEntrypointFile');
-const importTsFileMock = vi.mocked(importEntrypointFile);
+const importEntrypointFileMock = vi.mocked(importEntrypointFile);
 
 vi.mock('fast-glob');
 const globMock = vi.mocked(glob);
@@ -191,13 +191,16 @@ describe('findEntrypoints', () => {
         matches: ['<all_urls>'],
       };
       globMock.mockResolvedValueOnce([path]);
-      importTsFileMock.mockResolvedValue(options);
+      importEntrypointFileMock.mockResolvedValue(options);
 
       const entrypoints = await findEntrypoints(config);
 
       expect(entrypoints).toHaveLength(1);
       expect(entrypoints[0]).toEqual({ ...expected, options });
-      expect(importTsFileMock).toBeCalledWith(expected.inputPath, config);
+      expect(importEntrypointFileMock).toBeCalledWith(
+        expected.inputPath,
+        config,
+      );
     },
   );
 
@@ -218,13 +221,16 @@ describe('findEntrypoints', () => {
         type: 'module',
       };
       globMock.mockResolvedValueOnce([path]);
-      importTsFileMock.mockResolvedValue(options);
+      importEntrypointFileMock.mockResolvedValue(options);
 
       const entrypoints = await findEntrypoints(config);
 
       expect(entrypoints).toHaveLength(1);
       expect(entrypoints[0]).toEqual({ ...expected, options });
-      expect(importTsFileMock).toBeCalledWith(expected.inputPath, config);
+      expect(importEntrypointFileMock).toBeCalledWith(
+        expected.inputPath,
+        config,
+      );
     },
   );
 
@@ -551,7 +557,7 @@ describe('findEntrypoints', () => {
   describe('include option', () => {
     it("should filter out the background when include doesn't contain the target browser", async () => {
       globMock.mockResolvedValueOnce(['background.ts']);
-      importTsFileMock.mockResolvedValue({
+      importEntrypointFileMock.mockResolvedValue({
         include: ['not' + config.browser],
       });
 
@@ -562,7 +568,7 @@ describe('findEntrypoints', () => {
 
     it("should filter out content scripts when include doesn't contain the target browser", async () => {
       globMock.mockResolvedValueOnce(['example.content.ts']);
-      importTsFileMock.mockResolvedValue({
+      importEntrypointFileMock.mockResolvedValue({
         include: ['not' + config.browser],
       });
 
@@ -626,7 +632,7 @@ describe('findEntrypoints', () => {
   describe('exclude option', () => {
     it('should filter out the background when exclude contains the target browser', async () => {
       globMock.mockResolvedValueOnce(['background.ts']);
-      importTsFileMock.mockResolvedValue({
+      importEntrypointFileMock.mockResolvedValue({
         exclude: [config.browser],
       });
 
@@ -637,7 +643,7 @@ describe('findEntrypoints', () => {
 
     it('should filter out content scripts when exclude contains the target browser', async () => {
       globMock.mockResolvedValueOnce(['example.content.ts']);
-      importTsFileMock.mockResolvedValue({
+      importEntrypointFileMock.mockResolvedValue({
         exclude: [config.browser],
       });
 

--- a/src/core/build/findEntrypoints.ts
+++ b/src/core/build/findEntrypoints.ts
@@ -15,7 +15,7 @@ import fs from 'fs-extra';
 import { minimatch } from 'minimatch';
 import { parseHTML } from 'linkedom';
 import JSON5 from 'json5';
-import { importTsFile } from '../utils/importTsFile';
+import { importEntrypointFile } from '../utils/importEntrypointFile';
 import glob from 'fast-glob';
 import { getEntrypointName } from '../utils/entrypoints';
 import { VIRTUAL_NOOP_BACKGROUND_MODULE_ID } from '../vite-plugins/noopBackground';
@@ -287,10 +287,8 @@ async function getBackgroundEntrypoint(
 ): Promise<BackgroundEntrypoint> {
   let options: Omit<BackgroundScriptDefintition, 'main'> = {};
   if (path !== VIRTUAL_NOOP_BACKGROUND_MODULE_ID) {
-    const defaultExport = await importTsFile<BackgroundScriptDefintition>(
-      path,
-      config,
-    );
+    const defaultExport =
+      await importEntrypointFile<BackgroundScriptDefintition>(path, config);
     if (defaultExport == null) {
       throw Error('Background script does not have a default export');
     }
@@ -314,10 +312,8 @@ async function getContentScriptEntrypoint(
   name: string,
   path: string,
 ): Promise<ContentScriptEntrypoint> {
-  const { main: _, ...options } = await importTsFile<ContentScriptDefinition>(
-    path,
-    config,
-  );
+  const { main: _, ...options } =
+    await importEntrypointFile<ContentScriptDefinition>(path, config);
   if (options == null) {
     throw Error(`Content script ${name} does not have a default export`);
   }

--- a/src/core/utils/importEntrypointFile.ts
+++ b/src/core/utils/importEntrypointFile.ts
@@ -5,7 +5,7 @@ import fs from 'fs-extra';
 import { resolve } from 'path';
 import transform from 'jiti/dist/babel';
 import { getUnimportOptions } from './auto-imports';
-import { removeImportStatements } from './strings';
+import { removeProjectImportStatements } from './strings';
 import { normalizePath } from './paths';
 
 /**
@@ -23,7 +23,7 @@ import { normalizePath } from './paths';
  * Downside is that code cannot be executed outside of the main fucntion for the entrypoint,
  * otherwise you will see "xxx is not defined" errors for any imports used outside of main function.
  */
-export async function importTsFile<T>(
+export async function importEntrypointFile<T>(
   path: string,
   config: InternalConfig,
 ): Promise<T> {
@@ -39,7 +39,7 @@ export async function importTsFile<T>(
   await unimport.init();
 
   const text = await fs.readFile(path, 'utf-8');
-  const textNoImports = removeImportStatements(text);
+  const textNoImports = removeProjectImportStatements(text);
   const { code } = await unimport.injectImports(textNoImports);
   config.logger.debug(
     ['Text:', text, 'No imports:', textNoImports, 'Code:', code].join('\n'),

--- a/src/core/utils/strings.ts
+++ b/src/core/utils/strings.ts
@@ -15,3 +15,14 @@ export function removeImportStatements(text: string): string {
     '',
   );
 }
+
+/**
+ * Removes imports, ensuring that some of WXT's client imports are present, so that entrypoints can be parsed if auto-imports are disabled.
+ */
+export function removeProjectImportStatements(text: string): string {
+  const noImports = removeImportStatements(text);
+
+  return `import { defineContentScript, defineBackground } from 'wxt/client';
+
+${noImports}`;
+}


### PR DESCRIPTION
If you have auto-imports disabled, WXT couldn't parse your entrypoints because the definition functions were missing, like `defineContentScript`, since those functions were auto-imported before. Now, we manually add those imports to the file before importing it to get it's config.