### PR TITLE
fix: Use `execaCommand` instead of `node:child_process`

### DIFF
--- a/e2e/tests/init.test.ts
+++ b/e2e/tests/init.test.ts
@@ -40,5 +40,5 @@ describe('Init command', () => {
         "wxt.config.ts",
       ]
     `);
-  }, 30e3);
+  });
 });

--- a/e2e/utils.ts
+++ b/e2e/utils.ts
@@ -1,7 +1,7 @@
 import { dirname, join, relative, resolve } from 'path';
 import fs from 'fs-extra';
 import glob from 'fast-glob';
-import { execSync } from 'child_process';
+import { execaCommand } from 'execa';
 import { InlineConfig, UserConfig, build } from '../src';
 import { normalizePath } from '../src/core/utils/paths';
 
@@ -72,8 +72,8 @@ export class TestProject {
       await fs.ensureDir(fileDir);
       await fs.writeFile(filePath, content ?? '', 'utf-8');
     }
-    execSync('npm i --ignore-scripts', { cwd: this.root });
 
+    await execaCommand('npm i --ignore-scripts', { cwd: this.root });
     await build({ ...config, root: this.root });
   }
 

--- a/src/core/build.ts
+++ b/src/core/build.ts
@@ -11,7 +11,7 @@ import fs from 'fs-extra';
 import { groupEntrypoints } from './utils/groupEntrypoints';
 import { formatDuration } from './utils/formatDuration';
 import { printBuildSummary } from './log/printBuildSummary';
-import { execSync } from 'node:child_process';
+import { execaCommand } from 'execa';
 import glob from 'fast-glob';
 import { unnormalizePath } from './utils/paths';
 
@@ -135,7 +135,7 @@ async function combineAnalysisStats(config: InternalConfig): Promise<void> {
   });
   const absolutePaths = unixFiles.map(unnormalizePath);
 
-  execSync(
+  await execaCommand(
     `rollup-plugin-visualizer ${absolutePaths.join(' ')} --template ${
       config.analysis.template
     }`,


### PR DESCRIPTION
Helps speed up windows and prevent hanging child processes