### PR TITLE
fix!: Output content script CSS to `content-scripts/<name>.css`

### DIFF
--- a/e2e/tests/manifest-content.test.ts
+++ b/e2e/tests/manifest-content.test.ts
@@ -251,18 +251,18 @@ describe('Manifest Content', () => {
     expect(manifest.content_scripts).toContainEqual({
       matches: ['*://duckduckgo.com/*'],
       run_at: 'document_end',
-      css: ['assets/four.css'],
+      css: ['content-scripts/four.css'],
       js: ['content-scripts/four.js'],
     });
     expect(manifest.content_scripts).toContainEqual({
       matches: ['*://google.com/*'],
       run_at: 'document_end',
-      css: ['assets/three.css', 'assets/two.css'],
+      css: ['content-scripts/three.css', 'content-scripts/two.css'],
       js: ['content-scripts/three.js', 'content-scripts/two.js'],
     });
     expect(manifest.content_scripts).toContainEqual({
       matches: ['*://google.com/*'],
-      css: ['assets/one.css'],
+      css: ['content-scripts/one.css'],
       js: ['content-scripts/one.js'],
     });
   });

--- a/e2e/tests/output-structure.test.ts
+++ b/e2e/tests/output-structure.test.ts
@@ -17,7 +17,7 @@ describe('Output Directory Structure', () => {
     `);
   });
 
-  it('should output separate CSS files for each content script', async () => {
+  it.only('should output separate CSS files for each content script', async () => {
     const project = new TestProject();
     project.addFile(
       'entrypoints/one.content/index.ts',
@@ -49,19 +49,19 @@ describe('Output Directory Structure', () => {
         '.output/chrome-mv3/content-scripts/two.js',
       ]),
     ).toMatchInlineSnapshot(`
-      ".output/chrome-mv3/assets/one.css
+      ".output/chrome-mv3/content-scripts/one.css
       ----------------------------------------
       body{color:#00f}
-
-      ================================================================================
-      .output/chrome-mv3/assets/two.css
-      ----------------------------------------
-      body{color:red}
 
       ================================================================================
       .output/chrome-mv3/content-scripts/one.js
       ----------------------------------------
       <contents-ignored>
+      ================================================================================
+      .output/chrome-mv3/content-scripts/two.css
+      ----------------------------------------
+      body{color:red}
+
       ================================================================================
       .output/chrome-mv3/content-scripts/two.js
       ----------------------------------------
@@ -69,7 +69,7 @@ describe('Output Directory Structure', () => {
       ================================================================================
       .output/chrome-mv3/manifest.json
       ----------------------------------------
-      {\\"manifest_version\\":3,\\"name\\":\\"E2E Extension\\",\\"description\\":\\"Example description\\",\\"version\\":\\"0.0.0\\",\\"version_name\\":\\"0.0.0-test\\",\\"content_scripts\\":[{\\"matches\\":[\\"*://*/*\\"],\\"css\\":[\\"assets/one.css\\",\\"assets/two.css\\"],\\"js\\":[\\"content-scripts/one.js\\",\\"content-scripts/two.js\\"]}]}"
+      {\\"manifest_version\\":3,\\"name\\":\\"E2E Extension\\",\\"description\\":\\"Example description\\",\\"version\\":\\"0.0.0\\",\\"version_name\\":\\"0.0.0-test\\",\\"content_scripts\\":[{\\"matches\\":[\\"*://*/*\\"],\\"css\\":[\\"content-scripts/one.css\\",\\"content-scripts/two.css\\"],\\"js\\":[\\"content-scripts/one.js\\",\\"content-scripts/two.js\\"]}]}"
     `);
   });
 

--- a/e2e/tests/output-structure.test.ts
+++ b/e2e/tests/output-structure.test.ts
@@ -17,7 +17,7 @@ describe('Output Directory Structure', () => {
     `);
   });
 
-  it.only('should output separate CSS files for each content script', async () => {
+  it('should output separate CSS files for each content script', async () => {
     const project = new TestProject();
     project.addFile(
       'entrypoints/one.content/index.ts',

--- a/src/core/build/buildEntrypoints.ts
+++ b/src/core/build/buildEntrypoints.ts
@@ -84,10 +84,15 @@ async function buildSingleEntrypoint(
             config.outDir,
             '.js',
           ),
-          // Output content script CSS to assets/ with a hash to prevent conflicts. Defaults to
-          // "[name].[ext]" in lib mode, which usually results in "style.css". That means multiple
-          // content scripts with styles would overwrite each other if it weren't changed below.
-          assetFileNames: `assets/${entrypoint.name}.[ext]`,
+          // Output content script CSS to `content-scripts/`, but all other scripts are written to
+          // `assets/`.
+          assetFileNames: ({ name }) => {
+            if (entrypoint.type === 'content-script' && name?.endsWith('css')) {
+              return `content-scripts/${entrypoint.name}.[ext]`;
+            } else {
+              return `assets/${entrypoint.name}.[ext]`;
+            }
+          },
         },
       },
     },

--- a/src/core/utils/manifest.ts
+++ b/src/core/utils/manifest.ts
@@ -416,9 +416,8 @@ export function getContentScriptCssFiles(
   const allChunks = buildOutput.steps.flatMap((step) => step.chunks);
 
   contentScripts.forEach((script) => {
-    // TODO: optimize and remove loop with a map
     const relatedCss = allChunks.find(
-      (chunk) => chunk.fileName === `assets/${script.name}.css`,
+      (chunk) => chunk.fileName === `content-scripts/${script.name}.css`,
     );
     if (relatedCss) css.push(relatedCss.fileName);
   });

--- a/src/testing/fake-objects.ts
+++ b/src/testing/fake-objects.ts
@@ -240,5 +240,6 @@ export const fakeInternalConfig = fakeObjectCreator<InternalConfig>(() => {
       name: faker.person.firstName().toLowerCase(),
     },
     transformManifest: () => {},
+    userConfigMetadata: {},
   };
 });


### PR DESCRIPTION
BREAKING CHANGE: Content script CSS used to be output to `assets/<name>.css`, but is now `content-scripts/<name>.css` to match the docs.