### PR TITLE
fix: Support `react-refresh` when pre-rendering HTML pages in dev mode

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -2,5 +2,7 @@ coverage:
   status:
     project:
       default:
-        target: 80%
-        threshold: 1%
+        informational: true
+    patch:
+      default:
+        informational: true

--- a/.prettierignore
+++ b/.prettierignore
@@ -13,3 +13,4 @@ CHANGELOG.md
 *.txt
 _gitignore
 _redirects
+*.svelte

--- a/src/core/vite-plugins/devHtmlPrerender.ts
+++ b/src/core/vite-plugins/devHtmlPrerender.ts
@@ -132,10 +132,17 @@ export function devHtmlPrerender(config: InternalConfig): vite.PluginOption {
         if (id === `/${virtualReactRefreshId}`) {
           return resolvedVirtualReactRefreshId;
         }
+        // Ignore chunk contents when pre-rendering
+        if (id.startsWith('/chunks/')) {
+          return '\0noop';
+        }
       },
       load(id) {
         if (id === resolvedVirtualReactRefreshId) {
           return reactRefreshPreamble;
+        }
+        if (id === '\0noop') {
+          return '';
         }
       },
     },

--- a/src/core/vite-plugins/devHtmlPrerender.ts
+++ b/src/core/vite-plugins/devHtmlPrerender.ts
@@ -1,5 +1,5 @@
 import * as vite from 'vite';
-import { InternalConfig, WxtDevServer } from '../types';
+import { InternalConfig } from '../types';
 import { getEntrypointName } from '../utils/entrypoints';
 import { parseHTML } from 'linkedom';
 import { dirname, isAbsolute, relative, resolve } from 'path';

--- a/src/core/vite-plugins/devHtmlPrerender.ts
+++ b/src/core/vite-plugins/devHtmlPrerender.ts
@@ -1,71 +1,146 @@
 import * as vite from 'vite';
-import { InternalConfig } from '../types';
+import { InternalConfig, WxtDevServer } from '../types';
 import { getEntrypointName } from '../utils/entrypoints';
 import { parseHTML } from 'linkedom';
 import { dirname, isAbsolute, relative, resolve } from 'path';
 
+// Cache the preamble script for all devHtmlPrerender plugins, not just one
+let reactRefreshPreamble = '';
+
 /**
  * Pre-renders the HTML entrypoints when building the extension to connect to the dev server.
  */
-export function devHtmlPrerender(config: InternalConfig): vite.Plugin {
-  return {
-    apply: 'build',
-    name: 'wxt:dev-html-prerender',
-    config() {
-      return {
-        resolve: {
-          alias: {
-            '@wxt/reload-html': resolve(
-              config.root,
-              'node_modules/wxt/dist/virtual-modules/reload-html.js',
-            ),
-          },
-        },
-      };
-    },
-    async transform(html, id) {
-      const server = config.server;
-      if (config.command !== 'serve' || server == null || !id.endsWith('.html'))
-        return;
+export function devHtmlPrerender(config: InternalConfig): vite.PluginOption {
+  const htmlReloadId = '@wxt/reload-html';
+  const resolvedHtmlReloadId = resolve(
+    config.root,
+    'node_modules/wxt/dist/virtual-modules/reload-html.js',
+  );
+  const virtualReactRefreshId = '@wxt/virtual-react-refresh';
+  const resolvedVirtualReactRefreshId = '\0' + virtualReactRefreshId;
 
-      const originalUrl = `${server.origin}${id}`;
-      const name = getEntrypointName(config.entrypointsDir, id);
-      const url = `${server.origin}/${name}.html`;
-      const serverHtml = await server.transformIndexHtml(
-        url,
-        html,
-        originalUrl,
-      );
-      const { document } = parseHTML(serverHtml);
+  const pointToDevServer = (
+    document: Document,
+    server: WxtDevServer,
+    htmlPath: string,
+    querySelector: string,
+    attr: string,
+  ): void => {
+    document.querySelectorAll(querySelector).forEach((element) => {
+      const src = element.getAttribute(attr);
+      if (!src) return;
 
-      const pointToDevServer = (querySelector: string, attr: string): void => {
-        document.querySelectorAll(querySelector).forEach((element) => {
-          const src = element.getAttribute(attr);
-          if (!src) return;
-
-          if (isAbsolute(src)) {
-            element.setAttribute(attr, server.origin + src);
-          } else if (src.startsWith('.')) {
-            const abs = resolve(dirname(id), src);
-            const pathname = relative(config.root, abs);
-            element.setAttribute(attr, `${server.origin}/${pathname}`);
-          }
-        });
-      };
-      pointToDevServer('script[type=module]', 'src');
-      pointToDevServer('link[rel=stylesheet]', 'href');
-
-      // Add a script to add page reloading
-      const reloader = document.createElement('script');
-      reloader.src = '@wxt/reload-html';
-      reloader.type = 'module';
-      document.head.appendChild(reloader);
-
-      const newHtml = document.toString();
-      config.logger.debug('Transformed ' + id);
-      config.logger.debug('Old HTML:\n' + html);
-      config.logger.debug('New HTML:\n' + newHtml);
-      return newHtml;
-    },
+      if (isAbsolute(src)) {
+        element.setAttribute(attr, server.origin + src);
+      } else if (src.startsWith('.')) {
+        const abs = resolve(dirname(htmlPath), src);
+        const pathname = relative(config.root, abs);
+        element.setAttribute(attr, `${server.origin}/${pathname}`);
+      }
+    });
   };
+
+  return [
+    {
+      apply: 'build',
+      name: 'wxt:dev-html-prerender',
+      config() {
+        return {
+          resolve: {
+            alias: {
+              [htmlReloadId]: resolvedHtmlReloadId,
+            },
+          },
+        };
+      },
+      // Convert scripts like src="./main.tsx" -> src="http://localhost:3000/entrypoints/popup/main.tsx"
+      // before the paths are replaced with their bundled path
+      transform(code, id) {
+        const server = config.server;
+        if (
+          config.command !== 'serve' ||
+          server == null ||
+          !id.endsWith('.html')
+        )
+          return;
+
+        const { document } = parseHTML(code);
+        pointToDevServer(document, server, id, 'script[type=module]', 'src');
+        pointToDevServer(document, server, id, 'link[rel=stylesheet]', 'href');
+
+        // Add a script to add page reloading
+        const reloader = document.createElement('script');
+        reloader.src = htmlReloadId;
+        reloader.type = 'module';
+        document.head.appendChild(reloader);
+
+        const newHtml = document.toString();
+        config.logger.debug('transform ' + id);
+        config.logger.debug('Old HTML:\n' + code);
+        config.logger.debug('New HTML:\n' + newHtml);
+        return newHtml;
+      },
+
+      // Pass the HTML through the dev server to add dev-mode specific code
+      async transformIndexHtml(html, ctx) {
+        const server = config.server;
+        if (config.command !== 'serve' || server == null) return;
+
+        const originalUrl = `${server.origin}${ctx.path}`;
+        const name = getEntrypointName(config.entrypointsDir, ctx.filename);
+        const url = `${server.origin}/${name}.html`;
+        const serverHtml = await server.transformIndexHtml(
+          url,
+          html,
+          originalUrl,
+        );
+        const { document } = parseHTML(serverHtml);
+
+        // React pages include a preamble as an unsafe-inline type="module" script to enable fast refresh, as shown here:
+        // https://github.com/wxt-dev/wxt/issues/157#issuecomment-1756497616
+        // Since unsafe-inline scripts are blocked by MV3 CSPs, we need to virtualize it.
+        const reactRefreshScript = Array.from(
+          document.querySelectorAll('script[type=module]'),
+        ).find((script) => script.innerHTML.includes('@react-refresh'));
+        if (reactRefreshScript) {
+          // Save preamble to serve from server
+          reactRefreshPreamble = reactRefreshScript.innerHTML;
+
+          // Replace unsafe inline script
+          const virtualScript = document.createElement('script');
+          virtualScript.type = 'module';
+          virtualScript.src = `${server.origin}/${virtualReactRefreshId}`;
+          reactRefreshScript.replaceWith(virtualScript);
+        }
+
+        // Change /@vite/client -> http://localhost:3000/@vite/client
+        const viteClientScript = document.querySelector<HTMLScriptElement>(
+          "script[src='/@vite/client']",
+        );
+        if (viteClientScript) {
+          viteClientScript.src = `${server.origin}${viteClientScript.src}`;
+        }
+
+        const newHtml = document.toString();
+        config.logger.debug('transformIndexHtml ' + ctx.filename);
+        config.logger.debug('Old HTML:\n' + html);
+        config.logger.debug('New HTML:\n' + newHtml);
+        return newHtml;
+      },
+    },
+    {
+      name: 'wxt:virtualize-react-refresh',
+      apply: 'serve',
+      resolveId(id) {
+        if (id === `/${virtualReactRefreshId}`) {
+          return resolvedVirtualReactRefreshId;
+        }
+      },
+      load(id) {
+        if (id === resolvedVirtualReactRefreshId) {
+          return reactRefreshPreamble;
+        }
+      },
+    },
+  ];
 }

--- a/templates/svelte/src/entrypoints/popup/App.svelte
+++ b/templates/svelte/src/entrypoints/popup/App.svelte
@@ -12,7 +12,7 @@
       <img src={svelteLogo} class="logo svelte" alt="Svelte Logo" />
     </a>
   </div>
-  <h1>WXT 2 + Svelte</h1>
+  <h1>WXT + Svelte</h1>
 
   <div class="card">
     <Counter />


### PR DESCRIPTION
This closes #157.

Make sure the react-refresh preamble is added to the pre-rendered HTML file correctly. Couple of changes here:

1. Use `transformIndexHtml` hook instead of `transform`, and the preamble was added
2. Some dev scripts needed to be added to `transform` to bundle them all together before vite transforms the index.html, so I added `transform` back
3. The preamble was added as a inline script, which extension CSP's don't allow, so it had to be virtualized on the server
4. Other misc tweaks to prevent errors.

### Todo

- [x] Fix react refresh and test against template
- [x] Test against vue template
- [x] Test against solid template
- [x] Test against svelte template
- [x] Test against vanilla template
- [x] Make sure no warnings show up
   > Seeing one when opening the popup: "Failed to load url /chunks/popup-8bf139d1.js (resolved id: /chunks/popup-8bf139d1.js). Does the file exist?"