### PR TITLE
fix(firefox): Stop extending `AbortController` to fix crash in content scripts

### DIFF
--- a/src/client/utils/ContentScriptContext.ts
+++ b/src/client/utils/ContentScriptContext.ts
@@ -193,5 +193,3 @@ export class ContentScriptContext implements AbortController {
     this.onInvalidated(() => removeEventListener('message', cb));
   }
 }
-
-export interface ContentScriptController extends AbortController {}

--- a/src/client/utils/ContentScriptContext.ts
+++ b/src/client/utils/ContentScriptContext.ts
@@ -3,23 +3,23 @@ import { browser } from '../browser';
 import { logger } from './logger';
 
 /**
- * Extends [`AbortController`](https://developer.mozilla.org/en-US/docs/Web/API/AbortController).
+ * Implements [`AbortController`](https://developer.mozilla.org/en-US/docs/Web/API/AbortController).
  * Used to detect and stop content script code when the script is invalidated.
  *
  * It also provides several utilities like `ctx.setTimeout` and `ctx.setInterval` that should be used in
  * content scripts instead of `window.setTimeout` or `window.setInterval`.
  */
-export class ContentScriptContext extends AbortController {
+export class ContentScriptContext implements AbortController {
   private static SCRIPT_STARTED_MESSAGE_TYPE = 'wxt:content-script-started';
 
   #isTopFrame = window.self === window.top;
+  #abortController: AbortController;
 
   constructor(
     private readonly contentScriptName: string,
     public readonly options?: Omit<ContentScriptDefinition, 'main'>,
   ) {
-    super();
-
+    this.#abortController = new AbortController();
     if (this.#isTopFrame) {
       this.#stopOldScripts();
     }
@@ -27,6 +27,14 @@ export class ContentScriptContext extends AbortController {
       // Run on next tick so the listener it adds isn't triggered by stopOldScript
       this.#listenForNewerScripts();
     });
+  }
+
+  get signal() {
+    return this.#abortController.signal;
+  }
+
+  abort(reason?: any): void {
+    return this.#abortController.abort(reason);
   }
 
   get isInvalid(): boolean {
@@ -185,3 +193,5 @@ export class ContentScriptContext extends AbortController {
     this.onInvalidated(() => removeEventListener('message', cb));
   }
 }
+
+export interface ContentScriptController extends AbortController {}


### PR DESCRIPTION
Instead of extending it, we're now implementing it and creating a abort controller internally... I wonder if we should also stop using a class now, since WXT doesn't use classes internally anywhere else.

```
[wxt] The content script "example-tsx" crashed on startup! TypeError: this.setTimeout is not a function


... this.contentScriptName=I,this.options=Re,wS(this,No)&&dh(this,zo,MS).call(this),this.setTimeout(()=>{dh(this,Ho,LS).call(this)})} ...
```

For some reason, when you extend abort controller, `this` is an abort controller, not your class, in Firefox.