### PR TITLE
fix: Allow actions without a popup

### DIFF
--- a/src/core/types/external.ts
+++ b/src/core/types/external.ts
@@ -468,17 +468,13 @@ export interface ExcludableEntrypoint {
 export type UserManifest = Partial<
   Omit<
     Manifest.WebExtensionManifest,
-    | 'action'
     | 'background'
-    | 'browser_action'
     | 'chrome_url_overrides'
     | 'devtools_page'
     | 'manifest_version'
     | 'options_page'
     | 'options_ui'
     | 'sandbox'
-    | 'page_action'
-    | 'popup'
     | 'sidepanel'
     | 'sidebar_action'
   >

--- a/src/core/utils/manifest.ts
+++ b/src/core/utils/manifest.ts
@@ -214,18 +214,23 @@ function addEntrypoints(
       config.outDir,
       '.html',
     );
-    const options: Manifest.ActionManifest = {
-      default_icon: popup.options.defaultIcon,
-      default_title: popup.options.defaultTitle,
-      browser_style: popup.options.browserStyle,
-    };
+    const options: Manifest.ActionManifest = {};
+    if (popup.options.defaultIcon)
+      options.default_icon = popup.options.defaultIcon;
+    if (popup.options.defaultTitle)
+      options.default_title = popup.options.defaultTitle;
+    if (popup.options.browserStyle)
+      options.browser_style = popup.options.browserStyle;
     if (manifest.manifest_version === 3) {
       manifest.action = {
+        ...(manifest.action ?? {}),
         ...options,
         default_popup,
       };
     } else {
-      manifest[popup.options.mv2Key ?? 'browser_action'] = {
+      const key = popup.options.mv2Key ?? 'browser_action';
+      manifest[key] = {
+        ...(manifest[key] ?? {}),
         ...options,
         default_popup,
       };


### PR DESCRIPTION
This closes #179. Allow adding `action`, `browser_action`, and `page_action` fields to the manifest in the `wxt.config.ts` file. This allows the use of the action APIs without the a popup.