### PR TITLE
chore: Run E2E tests in parallel

### DIFF
--- a/vitest.workspace.ts
+++ b/vitest.workspace.ts
@@ -41,7 +41,6 @@ export default defineWorkspace([
     test: {
       name: 'e2e',
       dir: 'e2e',
-      singleThread: true,
       testTimeout: 120e3,
     },
     plugins: [testSeed()],


### PR DESCRIPTION
This will hopefully speed up the windows-tests job in CI.

> *Edit: Doesn't appear to have much effect, but this will improve local tests speeds as well.*

They were originally separate because the directories the tests create were conflicting, but that was solved a while back.