### PR TITLE
fix!: Remove `lib` from `.wxt/tsconfig.json`

### DIFF
--- a/e2e/tests/typescript-project.test.ts
+++ b/e2e/tests/typescript-project.test.ts
@@ -252,7 +252,6 @@ describe('TypeScript Project', () => {
           \\"forceConsistentCasingInFileNames\\": true,
           \\"resolveJsonModule\\": true,
           \\"strict\\": true,
-          \\"lib\\": [\\"DOM\\", \\"WebWorker\\"],
           \\"skipLibCheck\\": true,
           \\"paths\\": {
             \\"@\\": [\\"..\\"],
@@ -296,7 +295,6 @@ describe('TypeScript Project', () => {
           \\"forceConsistentCasingInFileNames\\": true,
           \\"resolveJsonModule\\": true,
           \\"strict\\": true,
-          \\"lib\\": [\\"DOM\\", \\"WebWorker\\"],
           \\"skipLibCheck\\": true,
           \\"paths\\": {
             \\"@\\": [\\"../src\\"],

--- a/src/core/utils/building/generate-wxt-dir.ts
+++ b/src/core/utils/building/generate-wxt-dir.ts
@@ -209,7 +209,6 @@ async function writeTsConfigFile(
     "forceConsistentCasingInFileNames": true,
     "resolveJsonModule": true,
     "strict": true,
-    "lib": ["ESNext", "DOM", "WebWorker"],
     "skipLibCheck": true,
     "paths": {
       "@": ["${srcPath}"],

--- a/src/core/utils/building/generate-wxt-dir.ts
+++ b/src/core/utils/building/generate-wxt-dir.ts
@@ -209,7 +209,7 @@ async function writeTsConfigFile(
     "forceConsistentCasingInFileNames": true,
     "resolveJsonModule": true,
     "strict": true,
-    "lib": ["ESNext","DOM", "WebWorker"],
+    "lib": ["ESNext", "DOM", "WebWorker"],
     "skipLibCheck": true,
     "paths": {
       "@": ["${srcPath}"],

--- a/src/core/utils/building/generate-wxt-dir.ts
+++ b/src/core/utils/building/generate-wxt-dir.ts
@@ -135,7 +135,7 @@ declare module "wxt/browser" {
   const overrides = messages.map((message) => {
     return `    /**
      * ${message.description ?? 'No message description.'}
-     * 
+     *
      * "${message.message}"
      */
     getMessage(
@@ -209,7 +209,7 @@ async function writeTsConfigFile(
     "forceConsistentCasingInFileNames": true,
     "resolveJsonModule": true,
     "strict": true,
-    "lib": ["DOM", "WebWorker"],
+    "lib": ["ESNext","DOM", "WebWorker"],
     "skipLibCheck": true,
     "paths": {
       "@": ["${srcPath}"],

--- a/src/core/utils/building/generate-wxt-dir.ts
+++ b/src/core/utils/building/generate-wxt-dir.ts
@@ -135,7 +135,7 @@ declare module "wxt/browser" {
   const overrides = messages.map((message) => {
     return `    /**
      * ${message.description ?? 'No message description.'}
-     *
+     * 
      * "${message.message}"
      */
     getMessage(


### PR DESCRIPTION
`lib` is mismatched cause we manual set `lib` option so that override the default value which effected by `target` option.

<img width="826" alt="image" src="https://github.com/wxt-dev/wxt/assets/34713301/e8a6b599-a684-4182-912d-e6c437c77dac">

