### PR TITLE
feat: Add `alias` config for customizing path aliases

### DIFF
--- a/demo/src/entrypoints/background.ts
+++ b/demo/src/entrypoints/background.ts
@@ -1,3 +1,5 @@
+import messages from 'public/_locales/en/messages.json';
+
 export default defineBackground(() => {
   console.log(browser.runtime.id);
   logId();
@@ -6,6 +8,7 @@ export default defineBackground(() => {
     chrome: __IS_CHROME__,
     firefox: __IS_FIREFOX__,
     manifestVersion: __MANIFEST_VERSION__,
+    messages,
   });
 
   // @ts-expect-error: should only accept entrypoints or public assets

--- a/demo/wxt.config.ts
+++ b/demo/wxt.config.ts
@@ -11,4 +11,7 @@ export default defineConfig({
       },
     ],
   },
+  alias: {
+    public: 'src/public',
+  },
 });

--- a/e2e/tests/typescript-project.test.ts
+++ b/e2e/tests/typescript-project.test.ts
@@ -315,4 +315,53 @@ describe('TypeScript Project', () => {
       }"
     `);
   });
+
+  it('should add additional path aliases listed in the alias config, preventing defaults from being overridden', async () => {
+    const project = new TestProject();
+    project.setConfigFileConfig({
+      srcDir: 'src',
+      alias: {
+        example: 'example',
+        '@': 'ignored-path',
+      },
+    });
+
+    await project.build();
+
+    const output = await project.serializeFile('.wxt/tsconfig.json');
+    expect(output).toMatchInlineSnapshot(`
+      ".wxt/tsconfig.json
+      ----------------------------------------
+      {
+        \\"compilerOptions\\": {
+          \\"target\\": \\"ESNext\\",
+          \\"module\\": \\"ESNext\\",
+          \\"moduleResolution\\": \\"Bundler\\",
+          \\"noEmit\\": true,
+          \\"esModuleInterop\\": true,
+          \\"forceConsistentCasingInFileNames\\": true,
+          \\"resolveJsonModule\\": true,
+          \\"strict\\": true,
+          \\"skipLibCheck\\": true,
+          \\"paths\\": {
+            \\"example\\": [\\"../example\\"],
+            \\"example/*\\": [\\"../example/*\\"],
+            \\"@\\": [\\"../src\\"],
+            \\"@/*\\": [\\"../src/*\\"],
+            \\"~\\": [\\"../src\\"],
+            \\"~/*\\": [\\"../src/*\\"],
+            \\"@@\\": [\\"..\\"],
+            \\"@@/*\\": [\\"../*\\"],
+            \\"~~\\": [\\"..\\"],
+            \\"~~/*\\": [\\"../*\\"]
+          }
+        },
+        \\"include\\": [
+          \\"../**/*\\",
+          \\"./wxt.d.ts\\"
+        ],
+        \\"exclude\\": [\\"../.output\\"]
+      }"
+    `);
+  });
 });

--- a/src/core/utils/building/get-internal-config.ts
+++ b/src/core/utils/building/get-internal-config.ts
@@ -112,6 +112,13 @@ export async function getInternalConfig(
       template: mergedConfig.analysis?.template ?? 'treemap',
     },
     userConfigMetadata: userConfigMetadata ?? {},
+    alias: {
+      ...mergedConfig.alias,
+      '~': srcDir,
+      '@': srcDir,
+      '~~': root,
+      '@@': root,
+    },
   };
 
   finalConfig.vite = (env) =>
@@ -186,6 +193,10 @@ function mergeInlineConfig(
       enabled: inlineConfig.analysis?.enabled ?? userConfig.analysis?.enabled,
       template:
         inlineConfig.analysis?.template ?? userConfig.analysis?.template,
+    },
+    alias: {
+      ...userConfig.alias,
+      ...inlineConfig.alias,
     },
   };
 }

--- a/src/core/utils/building/get-internal-config.ts
+++ b/src/core/utils/building/get-internal-config.ts
@@ -80,6 +80,16 @@ export async function getInternalConfig(
     overrides: inlineConfig.runner,
     defaults: userConfig.runner,
   });
+  // Make sure alias are absolute
+  const alias = Object.fromEntries(
+    Object.entries({
+      ...mergedConfig.alias,
+      '@': srcDir,
+      '~': srcDir,
+      '@@': root,
+      '~~': root,
+    }).map(([key, value]) => [key, path.resolve(root, value)]),
+  );
 
   const finalConfig: InternalConfig = {
     browser,
@@ -112,13 +122,7 @@ export async function getInternalConfig(
       template: mergedConfig.analysis?.template ?? 'treemap',
     },
     userConfigMetadata: userConfigMetadata ?? {},
-    alias: {
-      ...mergedConfig.alias,
-      '~': srcDir,
-      '@': srcDir,
-      '~~': root,
-      '@@': root,
-    },
+    alias,
   };
 
   finalConfig.vite = (env) =>

--- a/src/core/utils/testing/fake-objects.ts
+++ b/src/core/utils/testing/fake-objects.ts
@@ -244,5 +244,6 @@ export const fakeInternalConfig = fakeObjectCreator<InternalConfig>(() => {
     },
     transformManifest: () => {},
     userConfigMetadata: {},
+    alias: {},
   };
 });

--- a/src/core/vite-plugins/tsconfigPaths.ts
+++ b/src/core/vite-plugins/tsconfigPaths.ts
@@ -7,12 +7,7 @@ export function tsconfigPaths(config: InternalConfig): vite.Plugin {
     async config() {
       return {
         resolve: {
-          alias: {
-            '@@': config.root,
-            '~~': config.root,
-            '@': config.srcDir,
-            '~': config.srcDir,
-          },
+          alias: config.alias,
         },
       };
     },

--- a/src/types/external.ts
+++ b/src/types/external.ts
@@ -190,6 +190,22 @@ export interface InlineConfig {
      */
     template?: PluginVisualizerOptions['template'];
   };
+  /**
+   * Add additional paths to the `.wxt/tsconfig.json`. Use this instead of overwriting the `paths`
+   * in the root `tsconfig.json` if you want to add new paths.
+   *
+   * Passed into Vite's
+   * [`resolve.alias`](https://vitejs.dev/config/shared-options.html#resolve-alias) option and used
+   * to generate the `.wxt/tsconfig.json`.
+   *
+   * The key is the import alias and the value is either a relative path to the root directory or an absolute path.
+   *
+   * @example
+   * {
+   *   "testing": "src/utils/testing.ts"
+   * }
+   */
+  alias?: Record<string, string>;
 }
 
 export interface WxtInlineViteConfig

--- a/src/types/internal.ts
+++ b/src/types/internal.ts
@@ -49,6 +49,10 @@ export interface InternalConfig {
     template: NonNullable<PluginVisualizerOptions['template']>;
   };
   userConfigMetadata: Omit<ResolvedConfig<UserConfig>, 'config'>;
+  /**
+   * Import aliases to absolute paths.
+   */
+  alias: Record<string, string>;
 }
 
 export interface FsCache {


### PR DESCRIPTION
Allow adding custom aliases relative to the project's root directory.

See E2E test changes for an example.