### PR TITLE
ci: Automatically sync GitHub releases with `CHANGELOG.md` on push

### DIFF
--- a/.github/workflows/sync-releases.yml
+++ b/.github/workflows/sync-releases.yml
@@ -2,7 +2,7 @@ name: Sync Releases
 on:
   push:
     branches:
-      - update-releases
+      - main
     paths:
       - CHANGELOG.md
 

--- a/.github/workflows/sync-releases.yml
+++ b/.github/workflows/sync-releases.yml
@@ -1,0 +1,21 @@
+name: Sync Releases
+on:
+  push:
+    branches:
+      - update-releases
+    paths:
+      - CHANGELOG.md
+
+jobs:
+  sync:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v3
+      - uses: pnpm/action-setup@v2
+        with:
+          version: 8
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 18
+          cache: pnpm
+      - run: pnpm sync-releases all


### PR DESCRIPTION
This closes #212 