### PR TITLE
feat: List `bun` as an experimental option in `wxt init`

### DIFF
--- a/src/core/initialize.ts
+++ b/src/core/initialize.ts
@@ -41,9 +41,13 @@ export async function initialize(options: {
         type: () => (options.packageManager == null ? 'select' : undefined),
         message: 'Package Manager',
         choices: [
-          { title: 'npm', value: 'npm' },
-          { title: 'pnpm', value: 'pnpm' },
-          { title: 'yarn', value: 'yarn' },
+          { title: pc.red('npm'), value: 'npm' },
+          { title: pc.yellow('pnpm'), value: 'pnpm' },
+          { title: pc.cyan('yarn'), value: 'yarn' },
+          {
+            title: `${pc.magenta('bun')}${pc.gray(' (experimental)')}`,
+            value: 'bun',
+          },
         ],
       },
     ],


### PR DESCRIPTION
> [!WARNING]
> Bun is not 100% compatible with WXT. When running scripts, `bun run --bun wxt ...` is not supported yet. See #222 for more details.

https://github.com/wxt-dev/wxt/assets/10101283/a6db94bb-2d95-4f06-9116-bc57c606fcf3
