### PR TITLE
docs: Update sidepanel availability

### DIFF
--- a/demo/src/entrypoints/sidepanel.html
+++ b/demo/src/entrypoints/sidepanel.html
@@ -1,0 +1,11 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Sidebar</title>
+  </head>
+  <body>
+    <p>Example</p>
+  </body>
+</html>

--- a/docs/entrypoints/sidepanel.md
+++ b/docs/entrypoints/sidepanel.md
@@ -1,9 +1,9 @@
 # Side Panel
 
-[Chrome Docs](https://developer.chrome.com/docs/extensions/reference/sidePanel/)
+[Chrome Docs](https://developer.chrome.com/docs/extensions/reference/sidePanel/) &bull; [Firefox Docs](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/user_interface/Sidebars)
 
-:::tip Chromium Only
-Firefox does not support sidepanel pages.
+:::warning
+Chrome Manfest V2 does not support for side panels.
 :::
 
 ## Filenames


### PR DESCRIPTION
Side panels are supported by firefox, both MV2 and MV3. WXT already supports them, but it's docs were wrong.

This closes #248.