### PR TITLE
feat: Add config to customize `outDir`

### DIFF
--- a/e2e/tests/output-structure.test.ts
+++ b/e2e/tests/output-structure.test.ts
@@ -208,4 +208,17 @@ describe('Output Directory Structure', () => {
     );
     expect(await project.fileExists('.output/chrome-mv3/unlisted.js'));
   });
+
+  it("should output to a custom directory when overriding 'outDir'", async () => {
+    const project = new TestProject();
+    project.setConfigFileConfig({
+      outDir: 'dist',
+    });
+
+    await project.build();
+
+    expect(await project.fileExists('dist/chrome-mv3/manifest.json')).toBe(
+      true,
+    );
+  });
 });

--- a/src/core/utils/building/get-internal-config.ts
+++ b/src/core/utils/building/get-internal-config.ts
@@ -15,6 +15,7 @@ import { createFsCache } from '~/core/utils/cache';
 import consola, { LogLevels } from 'consola';
 import * as plugins from '~/core/vite-plugins';
 import defu from 'defu';
+import { NullablyRequired } from '../types';
 
 /**
  * Given an inline config, discover the config file if necessary, merge the results, resolve any
@@ -70,7 +71,7 @@ export async function getInternalConfig(
   );
   const publicDir = path.resolve(srcDir, mergedConfig.publicDir ?? 'public');
   const typesDir = path.resolve(wxtDir, 'types');
-  const outBaseDir = path.resolve(root, '.output');
+  const outBaseDir = path.resolve(root, mergedConfig.outDir ?? '.output');
   const outDir = path.resolve(outBaseDir, `${browser}-mv${manifestVersion}`);
 
   const runnerConfig = await loadConfig<ExtensionRunnerConfig>({
@@ -151,7 +152,7 @@ async function resolveManifestConfig(
 function mergeInlineConfig(
   inlineConfig: InlineConfig,
   userConfig: UserConfig,
-): InlineConfig {
+): NullablyRequired<InlineConfig> {
   let imports: InlineConfig['imports'];
   if (inlineConfig.imports === false || userConfig.imports === false) {
     imports = false;
@@ -196,6 +197,7 @@ function mergeInlineConfig(
     publicDir: inlineConfig.publicDir ?? userConfig.publicDir,
     runner,
     srcDir: inlineConfig.srcDir ?? userConfig.srcDir,
+    outDir: inlineConfig.outDir ?? userConfig.outDir,
     vite: viteConfig,
     zip,
     analysis: {
@@ -211,14 +213,16 @@ function mergeInlineConfig(
       ...userConfig.experimental,
       ...inlineConfig.experimental,
     },
+    transformManifest: undefined,
   };
 }
 
 function resolveInternalZipConfig(
   root: string,
   mergedConfig: InlineConfig,
-): InternalConfig['zip'] {
+): NullablyRequired<InternalConfig['zip']> {
   return {
+    name: undefined,
     sourcesTemplate: '{{name}}-{{version}}-sources.zip',
     artifactTemplate: '{{name}}-{{version}}-{{browser}}.zip',
     sourcesRoot: root,

--- a/src/core/utils/types.ts
+++ b/src/core/utils/types.ts
@@ -1,0 +1,8 @@
+/**
+ * Remove optional from key, but keep undefined if present
+ *
+ * @example
+ * type Test = NullablyRequired<{a?: string, b: number}>
+ * // type Test = {a: string | undefined, b: number}
+ */
+export type NullablyRequired<T> = { [K in keyof Required<T>]: T[K] };

--- a/src/types/external.ts
+++ b/src/types/external.ts
@@ -31,6 +31,12 @@ export interface InlineConfig {
    */
   entrypointsDir?: string;
   /**
+   * Output directory that stored build folders and ZIPs.
+   *
+   * @default ".output"
+   */
+  outDir?: string;
+  /**
    * > Only available when using the JS API. Not available in `wxt.config.ts` files
    *
    * Path to `wxt.config.ts` file or `false` to disable config file discovery.


### PR DESCRIPTION
This closes #257.

```ts
// wxt.config.ts
import { defineConfig } from 'wxt';

export default defineConfig({
  outDir: "dist",
});
```