### PR TITLE
chore: Speed up CI using `pnpm` instead of `npm`

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -62,9 +62,9 @@ jobs:
       - uses: actions/checkout@v3
       - uses: ./.github/actions/setup
       - run: pnpm pack
-      - run: pnpm --ignore-workspace i
+      - run: npm i
         working-directory: templates/${{ matrix.template }}
-      - run: pnpm --ignore-workspace i -D ../../wxt-*.tgz
+      - run: npm i -D ../../wxt-*.tgz
         working-directory: templates/${{ matrix.template }}
       - run: pnpm compile
         if: matrix.template != 'svelte'

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -62,15 +62,15 @@ jobs:
       - uses: actions/checkout@v3
       - uses: ./.github/actions/setup
       - run: pnpm pack
-      - run: npm i
+      - run: pnpm --ignore-workspace i
         working-directory: templates/${{ matrix.template }}
-      - run: npm i -D ../../wxt-*.tgz
+      - run: pnpm --ignore-workspace i -D ../../wxt-*.tgz
         working-directory: templates/${{ matrix.template }}
-      - run: npm run compile
+      - run: pnpm compile
         if: matrix.template != 'svelte'
         working-directory: templates/${{ matrix.template }}
-      - run: npm run check
+      - run: pnpm check
         if: matrix.template == 'svelte'
         working-directory: templates/${{ matrix.template }}
-      - run: npm run build
+      - run: pnpm build
         working-directory: templates/${{ matrix.template }}

--- a/e2e/utils.ts
+++ b/e2e/utils.ts
@@ -77,7 +77,9 @@ export class TestProject {
       await fs.writeFile(filePath, content ?? '', 'utf-8');
     }
 
-    await execaCommand('npm i --ignore-scripts', { cwd: this.root });
+    await execaCommand('pnpm --ignore-workspace i --ignore-scripts', {
+      cwd: this.root,
+    });
     await build({ ...config, root: this.root });
   }
 


### PR DESCRIPTION
E2E tests and templates aren't apart of the PNPM workspace, so running `pnpm i` inside those folders caused the command to fail. We can use the `--ignore-workspace` flag to ignore the workspace and treat them as individual projects, speeding up those checks.

| | Before | After |
| --- | --- | --- |
| tests | 1:11 | 1:05 |
| windows-tests | 2:39 | 1:40 |