### PR TITLE
fix: Catch duplicate entrypoint names before loading their config

### DIFF
--- a/src/core/utils/building/__tests__/find-entrypoints.test.ts
+++ b/src/core/utils/building/__tests__/find-entrypoints.test.ts
@@ -569,8 +569,13 @@ describe('findEntrypoints', () => {
     ].map(unnormalizePath);
 
     await expect(() => findEntrypoints(config)).rejects.toThrowError(
-      'Multiple entrypoints with the name "popup" detected, but only one is allowed: ' +
-        expectedPaths.join(', '),
+      [
+        'Multiple entrypoints with the same name detected, only one entrypoint for each name is allowed.',
+        '',
+        '- popup',
+        `  - ${unnormalizePath('src/entrypoints/popup.html')}`,
+        `  - ${unnormalizePath('src/entrypoints/popup/index.html')}`,
+      ].join('\n'),
     );
   });
 

--- a/src/core/utils/building/__tests__/find-entrypoints.test.ts
+++ b/src/core/utils/building/__tests__/find-entrypoints.test.ts
@@ -562,7 +562,11 @@ describe('findEntrypoints', () => {
   });
 
   it('should not allow multiple entrypoints with the same name', async () => {
-    globMock.mockResolvedValueOnce(['popup.html', 'popup/index.html']);
+    globMock.mockResolvedValueOnce([
+      'popup.html',
+      'popup/index.html',
+      'popup/index.ts',
+    ]);
 
     await expect(() => findEntrypoints(config)).rejects.toThrowError(
       [
@@ -571,6 +575,7 @@ describe('findEntrypoints', () => {
         '- popup',
         `  - ${unnormalizePath('src/entrypoints/popup.html')}`,
         `  - ${unnormalizePath('src/entrypoints/popup/index.html')}`,
+        `  - ${unnormalizePath('src/entrypoints/popup/index.ts')}`,
       ].join('\n'),
     );
   });

--- a/src/core/utils/building/__tests__/find-entrypoints.test.ts
+++ b/src/core/utils/building/__tests__/find-entrypoints.test.ts
@@ -563,15 +563,21 @@ describe('findEntrypoints', () => {
 
   it('should not allow multiple entrypoints with the same name', async () => {
     globMock.mockResolvedValueOnce([
+      'options/index.html',
+      'options/index.jsx',
       'popup.html',
       'popup/index.html',
       'popup/index.ts',
+      'ui.html',
     ]);
 
     await expect(() => findEntrypoints(config)).rejects.toThrowError(
       [
         'Multiple entrypoints with the same name detected, only one entrypoint for each name is allowed.',
         '',
+        '- options',
+        `  - ${unnormalizePath('src/entrypoints/options/index.html')}`,
+        `  - ${unnormalizePath('src/entrypoints/options/index.jsx')}`,
         '- popup',
         `  - ${unnormalizePath('src/entrypoints/popup.html')}`,
         `  - ${unnormalizePath('src/entrypoints/popup/index.html')}`,

--- a/src/core/utils/building/__tests__/find-entrypoints.test.ts
+++ b/src/core/utils/building/__tests__/find-entrypoints.test.ts
@@ -563,10 +563,6 @@ describe('findEntrypoints', () => {
 
   it('should not allow multiple entrypoints with the same name', async () => {
     globMock.mockResolvedValueOnce(['popup.html', 'popup/index.html']);
-    const expectedPaths = [
-      'src/entrypoints/popup.html',
-      'src/entrypoints/popup/index.html',
-    ].map(unnormalizePath);
 
     await expect(() => findEntrypoints(config)).rejects.toThrowError(
       [


### PR DESCRIPTION
This closes #275. I also refactored the glob detection to only find valid entrypoints in the first place, so we don't need to worry about ignored files anymore.