### PR TITLE
fix: Only use type imports for Vite

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -74,3 +74,5 @@ jobs:
         working-directory: templates/${{ matrix.template }}
       - run: pnpm build
         working-directory: templates/${{ matrix.template }}
+        env:
+          VITE_CJS_TRACE: true

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -75,4 +75,5 @@ jobs:
       - run: pnpm build
         working-directory: templates/${{ matrix.template }}
         env:
+          # Debug Vite 5's deprecated CJS support
           VITE_CJS_TRACE: true

--- a/src/core/builders/vite/plugins/bundleAnalysis.ts
+++ b/src/core/builders/vite/plugins/bundleAnalysis.ts
@@ -1,4 +1,4 @@
-import * as vite from 'vite';
+import type * as vite from 'vite';
 import { visualizer } from 'rollup-plugin-visualizer';
 
 let increment = 0;

--- a/src/core/builders/vite/plugins/cssEntrypoints.ts
+++ b/src/core/builders/vite/plugins/cssEntrypoints.ts
@@ -1,4 +1,4 @@
-import * as vite from 'vite';
+import type * as vite from 'vite';
 import { Entrypoint, InternalConfig } from '~/types';
 import { getEntrypointBundlePath } from '~/core/utils/entrypoints';
 

--- a/src/core/builders/vite/plugins/devHtmlPrerender.ts
+++ b/src/core/builders/vite/plugins/devHtmlPrerender.ts
@@ -1,4 +1,4 @@
-import * as vite from 'vite';
+import type * as vite from 'vite';
 import { InternalConfig } from '~/types';
 import { getEntrypointName } from '~/core/utils/entrypoints';
 import { parseHTML } from 'linkedom';

--- a/src/core/builders/vite/plugins/entrypointGroupGlobals.ts
+++ b/src/core/builders/vite/plugins/entrypointGroupGlobals.ts
@@ -1,4 +1,4 @@
-import * as vite from 'vite';
+import type * as vite from 'vite';
 import { EntrypointGroup } from '~/types';
 import { getEntrypointGlobals } from '~/core/utils/globals';
 

--- a/src/core/builders/vite/plugins/excludeBrowserPolyfill.ts
+++ b/src/core/builders/vite/plugins/excludeBrowserPolyfill.ts
@@ -1,5 +1,5 @@
 import { InternalConfig } from '~/types';
-import * as vite from 'vite';
+import type * as vite from 'vite';
 
 /**
  * Apply the experimental config for disabling the polyfill. It works by aliasing the

--- a/src/core/builders/vite/plugins/globals.ts
+++ b/src/core/builders/vite/plugins/globals.ts
@@ -1,4 +1,4 @@
-import * as vite from 'vite';
+import type * as vite from 'vite';
 import { InternalConfig } from '~/types';
 import { getGlobals } from '~/core/utils/globals';
 

--- a/src/core/builders/vite/plugins/multipageMove.ts
+++ b/src/core/builders/vite/plugins/multipageMove.ts
@@ -1,4 +1,4 @@
-import * as vite from 'vite';
+import type * as vite from 'vite';
 import { Entrypoint, InternalConfig } from '~/types';
 import { dirname, extname, resolve, join } from 'node:path';
 import { getEntrypointBundlePath } from '~/core/utils/entrypoints';

--- a/src/core/builders/vite/plugins/tsconfigPaths.ts
+++ b/src/core/builders/vite/plugins/tsconfigPaths.ts
@@ -1,5 +1,5 @@
 import { InternalConfig } from '~/types';
-import * as vite from 'vite';
+import type * as vite from 'vite';
 
 export function tsconfigPaths(
   config: Omit<InternalConfig, 'builder'>,

--- a/src/core/builders/vite/plugins/unimport.ts
+++ b/src/core/builders/vite/plugins/unimport.ts
@@ -1,7 +1,7 @@
 import { createUnimport } from 'unimport';
 import { InternalConfig } from '~/types';
 import { getUnimportOptions } from '~/core/utils/unimport';
-import * as vite from 'vite';
+import type * as vite from 'vite';
 import { extname } from 'path';
 
 const ENABLED_EXTENSIONS = new Set([

--- a/src/core/builders/vite/plugins/webextensionPolyfillAlias.ts
+++ b/src/core/builders/vite/plugins/webextensionPolyfillAlias.ts
@@ -1,5 +1,5 @@
 import path from 'node:path';
-import * as vite from 'vite';
+import type * as vite from 'vite';
 import { InternalConfig } from '~/types';
 
 /**

--- a/src/core/builders/vite/plugins/webextensionPolyfillInlineDeps.ts
+++ b/src/core/builders/vite/plugins/webextensionPolyfillInlineDeps.ts
@@ -1,4 +1,4 @@
-import * as vite from 'vite';
+import type * as vite from 'vite';
 
 /**
  * Add all deps that import `webextension-polyfill` to `test.server.deps.inline`.

--- a/src/testing/wxt-vitest-plugin.ts
+++ b/src/testing/wxt-vitest-plugin.ts
@@ -1,4 +1,4 @@
-import * as vite from 'vite';
+import type * as vite from 'vite';
 import {
   unimport,
   download,


### PR DESCRIPTION
This closes #277.