### PR TITLE
fix(storage): Support multiple `:` characters in storage keys

### DIFF
--- a/src/__tests__/storage.test.ts
+++ b/src/__tests__/storage.test.ts
@@ -22,6 +22,15 @@ describe('Storage Utils', () => {
           expect(actual).toBe(expected);
         });
 
+        it('should return the value if multiple : are use in the key', async () => {
+          const expected = 'value';
+          await fakeBrowser.storage[storageArea].set({ 'some:key': expected });
+
+          const actual = await storage.getItem(`${storageArea}:some:key`);
+
+          expect(actual).toBe(expected);
+        });
+
         it("should return null if the value doesn't exist", async () => {
           const actual = await storage.getItem(`${storageArea}:count`);
 

--- a/src/storage.ts
+++ b/src/storage.ts
@@ -26,7 +26,9 @@ function createStorage(): WxtStorage {
     return driver;
   };
   const resolveKey = (key: string) => {
-    const [driverArea, driverKey] = key.split(':', 2);
+    const deliminatorIndex = key.indexOf(':');
+    const driverArea = key.substring(0, deliminatorIndex);
+    const driverKey = key.substring(deliminatorIndex + 1);
     if (driverKey == null)
       throw Error(
         `Storage key should be in the form of "area:key", but recieved "${key}"`,


### PR DESCRIPTION
This closes #302 