### PR TITLE
chore: Update `scripts/build.ts` show current build step in progress, not completed count

### DIFF
--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -29,9 +29,9 @@ const preset = {
 } satisfies tsup.Options;
 
 function spinnerPMap(configs: tsup.Options[]) {
-  let completed = 0;
+  let progress = 1;
   const updateSpinner = () => {
-    spinner.text = `${spinnerText} [${completed}/${configs.length}]`;
+    spinner.text = `${spinnerText} [${progress}/${configs.length}]`;
   };
   updateSpinner();
 
@@ -39,7 +39,7 @@ function spinnerPMap(configs: tsup.Options[]) {
     config,
     async (config) => {
       const res = await tsup.build(config);
-      completed++;
+      progress++;
       updateSpinner();
       return res;
     },


### PR DESCRIPTION
Before, you would see progress track the number of complete build steps, like this:

```
- Building
- Building [1/4]
- Building [2/4]
- Building [3/4]
- Build complete
```

But that's not very satisfying because it never prints [4/4]! Nor does it make as much sense to me as it used to.

This PR changes these labels from printing the "number of completed steps" to the "current step in progress", which makes console output look like this instead:

```
- Building
- Building [1/4]
- Building [2/4]
- Building [3/4]
- Building [4/4]
- Build complete
```

> The first `building` line without a progress indicator is shown during build prep, while we calculate the number of build steps.

### Todo

- [x] `scripts/build.ts` (builds WXT package for NPM)
- [x] ~~_`src/core/utils/building/build-entrypoints.ts` (Build progress for a project using WXT)_~~ Already behaves like this