### PR TITLE
docs: Use example tags to automate relevant example lists

### DIFF
--- a/docs/.vitepress/components/ExampleList.vue
+++ b/docs/.vitepress/components/ExampleList.vue
@@ -1,0 +1,34 @@
+<script lang="ts" setup>
+import { ref, onMounted, computed } from 'vue';
+
+const props = defineProps<{
+  tag?: string;
+}>();
+
+const examples = ref();
+onMounted(async () => {
+  const res = await fetch(
+    'https://raw.githubusercontent.com/wxt-dev/wxt-examples/main/examples.json',
+  );
+  examples.value = await res.json();
+});
+
+const filteredExamples = computed(() => {
+  if (props.tag == null) return examples.value;
+
+  return examples.value.filter((example) => {
+    return example.tags?.includes(props.tag);
+  });
+});
+</script>
+
+<template>
+  <ul>
+    <li v-if="examples == null">Loading...</li>
+    <template v-else>
+      <li v-for="example of filteredExamples">
+        <a :href="example.url" target="_blank">{{ example.name }}</a>
+      </li>
+    </template>
+  </ul>
+</template>

--- a/docs/.vitepress/theme/index.ts
+++ b/docs/.vitepress/theme/index.ts
@@ -2,6 +2,7 @@ import DefaultTheme from 'vitepress/theme';
 import Icon from '../components/Icon.vue';
 import EntrypointPatterns from '../components/EntrypointPatterns.vue';
 import UsingWxtSection from '../components/UsingWxtSection.vue';
+import ExampleList from '../components/ExampleList.vue';
 import './custom.css';
 
 export default {
@@ -10,5 +11,6 @@ export default {
     ctx.app.component('Icon', Icon);
     ctx.app.component('EntrypointPatterns', EntrypointPatterns);
     ctx.app.component('UsingWxtSection', UsingWxtSection);
+    ctx.app.component('ExampleList', ExampleList);
   },
 };

--- a/docs/entrypoints/devtools.md
+++ b/docs/entrypoints/devtools.md
@@ -37,4 +37,4 @@ Chrome extensions allow you to add panels and side panes to the devtools window.
 
 See the WXT's examples for a full walkthrough of extending the devtools window:
 
-- [Devtools Setup](https://github.com/wxt-dev/wxt-examples/tree/main/examples/vanilla-devtools#readme)
+<ExampleList tag="devtools" />

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -2,26 +2,6 @@
 
 Simple walkthroughs to accomplish common tasks or patterns with WXT.
 
-<script lang="ts" setup>
-import { ref, onMounted } from 'vue';
-
-const examples = ref()
-onMounted(async () => {
-    const res = await fetch("https://raw.githubusercontent.com/wxt-dev/wxt-examples/main/examples.json");
-    examples.value = await res.json();
-})
-
-</script>
-
-<ul>
-    <li v-if="examples == null">
-        Loading...
-    </li>
-    <template v-else>
-        <li v-for="example of examples">
-        <a :href="example.url" target="_blank">{{ example.name }}</a>
-        </li>
-    </template>
-</ul>
+<ExampleList />
 
 > Full code available at [`wxt-dev/wxt-examples`](https://github.com/wxt-dev/wxt-examples)

--- a/docs/guide/manifest.md
+++ b/docs/guide/manifest.md
@@ -122,5 +122,4 @@ export default defineConfig({
 
 See the official localization examples for more details:
 
-- [I18n](https://github.com/wxt-dev/wxt-examples/tree/main/examples/vanilla-i18n#readme)
-- [Vue I18n](https://github.com/wxt-dev/wxt-examples/tree/main/examples/vue-i18n#readme)
+<ExampleList tag="i18n" />

--- a/docs/guide/testing.md
+++ b/docs/guide/testing.md
@@ -6,9 +6,7 @@ WXT officially supports [Vitest](https://vitest.dev/) for unit tests and either 
 
 For details setting up each testing framework, see the official examples:
 
-- [Vitest example](https://github.com/wxt-dev/wxt-examples/tree/main/examples/vanilla-vitest#readme)
-- [Playwright example](https://github.com/wxt-dev/wxt-examples/tree/main/examples/vanilla-playwright#readme)
-- [Puppeteer example](https://github.com/wxt-dev/wxt-examples/tree/main/examples/vanilla-puppeteer#readme)
+<ExampleList tag="testing" />
 
 ### Unofficial Frameworks
 


### PR DESCRIPTION
I added [the ability to add frontmatter to examples](https://github.com/wxt-dev/wxt-examples/commit/98d37533bd9ec7c0ed2aa32048cfabbdce0e6433), so now we can filter example lists down based on the new `tag` frontmatter.

So as more examples are added, they will automatically show up on the docs website.