### PR TITLE
feat: Add `isolateEvents` option to `createContentScripUi`

### DIFF
--- a/docs/guide/content-script-ui.md
+++ b/docs/guide/content-script-ui.md
@@ -8,9 +8,9 @@ Each has their own set of advantages and disadvantages.
 
 | Method     | Isolated Styles |   Isolated Events   | HMR | Use page's context |
 | ---------- | :-------------: | :-----------------: | :-: | :----------------: |
-| Integrated |       ❌        |        ❌           | ❌  |         ✅         |
+| Integrated |       ❌        |          ❌         | ❌  |         ✅         |
 | ShadowRoot |       ✅        | ✅ (off by default) | ❌  |         ✅         |
-| IFrame     |       ✅        |        ✅           | ✅  |         ❌         |
+| IFrame     |       ✅        |          ✅         | ✅  |         ❌         |
 
 ## Integrated
 

--- a/docs/guide/content-script-ui.md
+++ b/docs/guide/content-script-ui.md
@@ -178,10 +178,6 @@ export default defineContentScript({
         app.textContent = 'Hello world!';
         container.append(app);
       },
-      // Optional: isolateEvents specifies which events to isolate. Default is false (no isolation).
-      // Set true to isolate default events (keydown, keyup, keypress).
-      // Alternatively, provide an array of specific event names, e.g., ['click', 'mousedown', 'mouseup'].
-      isolateEvents: true,
     });
 
     // 4. Mount the UI

--- a/docs/guide/content-script-ui.md
+++ b/docs/guide/content-script-ui.md
@@ -6,11 +6,11 @@ There are three ways to mount a UI inside a content script:
 
 Each has their own set of advantages and disadvantages.
 
-| Method     | Isolated Styles | HMR | Use page's context |
-| ---------- | :-------------: | :-: | :----------------: |
-| Integrated |       ❌        | ❌  |         ✅         |
-| ShadowRoot |       ✅        | ❌  |         ✅         |
-| IFrame     |       ✅        | ✅  |         ❌         |
+| Method     | Isolated Styles | Isolated Events  | HMR | Use page's context |
+| ---------- | :-------------: | :--------------: | :-: | :----------------: |
+| Integrated |       ❌        |        ❌        | ❌  |         ✅         |
+| ShadowRoot |       ✅        | ✅ (default off) | ❌  |         ✅         |
+| IFrame     |       ✅        |        ✅        | ✅  |         ❌         |
 
 ## Integrated
 
@@ -149,7 +149,7 @@ export default defineContentScript({
 
 Often in web extensions, you don't want your content script's CSS affecting the page, or vise-versa. The [`ShadowRoot`](https://developer.mozilla.org/en-US/docs/Web/API/ShadowRoot) API is ideal for this.
 
-WXT provides a helper function, [`createContentScriptUi`](/api/wxt/client/functions/createContentScriptUi), that abstracts all the `ShadowRoot` setup away, making it easy to create UIs with isolated CSS.
+WXT provides a helper function, [`createContentScriptUi`](/api/wxt/client/functions/createContentScriptUi), that abstracts all the `ShadowRoot` setup away, making it easy to create UIs with isolated CSS. It also supports an optional `isolateEvents` parameter to further isolate user interactions.
 
 To use `createContentScriptUi`, follow these steps:
 
@@ -178,6 +178,10 @@ export default defineContentScript({
         app.textContent = 'Hello world!';
         container.append(app);
       },
+      // Optional: isolateEvents specifies which events to isolate. Default is false (no isolation).
+      // Set true to isolate default events (keydown, keyup, keypress).
+      // Alternatively, provide an array of specific event names, e.g., ['click', 'mousedown', 'mouseup'].
+      isolateEvents: true,
     });
 
     // 4. Mount the UI

--- a/docs/guide/content-script-ui.md
+++ b/docs/guide/content-script-ui.md
@@ -6,11 +6,11 @@ There are three ways to mount a UI inside a content script:
 
 Each has their own set of advantages and disadvantages.
 
-| Method     | Isolated Styles | Isolated Events  | HMR | Use page's context |
-| ---------- | :-------------: | :--------------: | :-: | :----------------: |
-| Integrated |       ❌        |        ❌        | ❌  |         ✅         |
-| ShadowRoot |       ✅        | ✅ (default off) | ❌  |         ✅         |
-| IFrame     |       ✅        |        ✅        | ✅  |         ❌         |
+| Method     | Isolated Styles |   Isolated Events   | HMR | Use page's context |
+| ---------- | :-------------: | :-----------------: | :-: | :----------------: |
+| Integrated |       ❌        |        ❌           | ❌  |         ✅         |
+| ShadowRoot |       ✅        | ✅ (off by default) | ❌  |         ✅         |
+| IFrame     |       ✅        |        ✅           | ✅  |         ❌         |
 
 ## Integrated
 

--- a/docs/guide/content-script-ui.md
+++ b/docs/guide/content-script-ui.md
@@ -8,9 +8,9 @@ Each has their own set of advantages and disadvantages.
 
 | Method     | Isolated Styles |   Isolated Events   | HMR | Use page's context |
 | ---------- | :-------------: | :-----------------: | :-: | :----------------: |
-| Integrated |       ❌        |          ❌         | ❌  |         ✅         |
+| Integrated |       ❌        |         ❌          | ❌  |         ✅         |
 | ShadowRoot |       ✅        | ✅ (off by default) | ❌  |         ✅         |
-| IFrame     |       ✅        |          ✅         | ✅  |         ❌         |
+| IFrame     |       ✅        |         ✅          | ✅  |         ❌         |
 
 ## Integrated
 

--- a/package.json
+++ b/package.json
@@ -105,7 +105,7 @@
   "dependencies": {
     "@types/webextension-polyfill": "^0.10.5",
     "@webext-core/fake-browser": "^1.3.1",
-    "@webext-core/isolated-element": "^1.0.4",
+    "@webext-core/isolated-element": "^1.1.1",
     "@webext-core/match-patterns": "^1.0.3",
     "async-mutex": "^0.4.0",
     "c12": "^1.5.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,8 +15,8 @@ importers:
         specifier: ^1.3.1
         version: 1.3.1
       '@webext-core/isolated-element':
-        specifier: ^1.0.4
-        version: 1.0.4
+        specifier: ^1.1.1
+        version: 1.1.1
       '@webext-core/match-patterns':
         specifier: ^1.0.3
         version: 1.0.3
@@ -1413,8 +1413,8 @@ packages:
       lodash.merge: 4.6.2
     dev: false
 
-  /@webext-core/isolated-element@1.0.4:
-    resolution: {integrity: sha512-jbkG+7b6Ty4fNo2o53rokCTkNRinI/0tneJSyuUCJfPzAFtyylF3IxH/WhXykXC+1Ca8ouQnjbEcpYt9IFNcUg==}
+  /@webext-core/isolated-element@1.1.1:
+    resolution: {integrity: sha512-kn5OURB8FaEB0oSZdf1jc1PyohWXbWQbdhXfAS2d3AxxkP8HlYfhB75fhZJ3GceZvFf8in4bZNJbOvcArSFxCg==}
     dev: false
 
   /@webext-core/match-patterns@1.0.3:

--- a/src/client/content-scripts/__tests__/content-script-ui.test.ts
+++ b/src/client/content-scripts/__tests__/content-script-ui.test.ts
@@ -332,4 +332,53 @@ describe('createContentScriptUi', () => {
       expect(document.querySelector('test-app')).toBeDefined();
     });
   });
+
+  describe('isolateEvents', () => {
+    it('should call createIsolatedElement with isolateEvents=false by default', async () => {
+      await createContentScriptUi(createCtx(), {
+        name: 'test-app',
+        type: 'inline',
+        mount: testApp,
+      });
+
+      expect(createIsolatedElementMock).toBeCalledTimes(1);
+      expect(createIsolatedElementMock).toBeCalledWith(
+        expect.not.objectContaining({
+          isolateEvents: true,
+        }),
+      );
+    });
+
+    it('should call createIsolatedElement with isolateEvents=true when isolateEvents=true', async () => {
+      await createContentScriptUi(createCtx(), {
+        name: 'test-app',
+        type: 'inline',
+        isolateEvents: true,
+        mount: testApp,
+      });
+
+      expect(createIsolatedElementMock).toBeCalledTimes(1);
+      expect(createIsolatedElementMock).toBeCalledWith(
+        expect.objectContaining({
+          isolateEvents: true,
+        }),
+      );
+    });
+
+    it('should call createIsolatedElement with isolateEvents=events when isolateEvents=events', async () => {
+      await createContentScriptUi(createCtx(), {
+        name: 'test-app',
+        type: 'inline',
+        isolateEvents: ['click', 'keydown'],
+        mount: testApp,
+      });
+
+      expect(createIsolatedElementMock).toBeCalledTimes(1);
+      expect(createIsolatedElementMock).toBeCalledWith(
+        expect.objectContaining({
+          isolateEvents: ['click', 'keydown'],
+        }),
+      );
+    });
+  });
 });

--- a/src/client/content-scripts/__tests__/content-script-ui.test.ts
+++ b/src/client/content-scripts/__tests__/content-script-ui.test.ts
@@ -5,6 +5,7 @@ import { ContentScriptContext } from '~/client/content-scripts/content-script-co
 import { createIsolatedElement } from '@webext-core/isolated-element';
 import { mock } from 'vitest-mock-extended';
 import { browser } from '~/browser';
+import { faker } from '@faker-js/faker';
 
 vi.mock('@webext-core/isolated-element', async () => {
   const { vi } = await import('vitest');
@@ -333,52 +334,25 @@ describe('createContentScriptUi', () => {
     });
   });
 
-  describe('isolateEvents', () => {
-    it('should call createIsolatedElement with isolateEvents=false by default', async () => {
-      await createContentScriptUi(createCtx(), {
-        name: 'test-app',
-        type: 'inline',
-        mount: testApp,
-      });
-
-      expect(createIsolatedElementMock).toBeCalledTimes(1);
-      expect(createIsolatedElementMock).toBeCalledWith(
-        expect.not.objectContaining({
-          isolateEvents: true,
-        }),
-      );
+  it('should forward isolateEvents into createIsolatedElement', async () => {
+    const isolateEvents = faker.helpers.arrayElement([
+      undefined,
+      true,
+      false,
+      ['click', 'keydown'],
+    ]);
+    await createContentScriptUi(createCtx(), {
+      name: 'test-app',
+      type: 'inline',
+      mount: testApp,
+      isolateEvents,
     });
 
-    it('should call createIsolatedElement with isolateEvents=true when isolateEvents=true', async () => {
-      await createContentScriptUi(createCtx(), {
-        name: 'test-app',
-        type: 'inline',
-        isolateEvents: true,
-        mount: testApp,
-      });
-
-      expect(createIsolatedElementMock).toBeCalledTimes(1);
-      expect(createIsolatedElementMock).toBeCalledWith(
-        expect.objectContaining({
-          isolateEvents: true,
-        }),
-      );
-    });
-
-    it('should call createIsolatedElement with isolateEvents=events when isolateEvents=events', async () => {
-      await createContentScriptUi(createCtx(), {
-        name: 'test-app',
-        type: 'inline',
-        isolateEvents: ['click', 'keydown'],
-        mount: testApp,
-      });
-
-      expect(createIsolatedElementMock).toBeCalledTimes(1);
-      expect(createIsolatedElementMock).toBeCalledWith(
-        expect.objectContaining({
-          isolateEvents: ['click', 'keydown'],
-        }),
-      );
-    });
+    expect(createIsolatedElementMock).toBeCalledTimes(1);
+    expect(createIsolatedElementMock).toBeCalledWith(
+      expect.objectContaining({
+        isolateEvents,
+      }),
+    );
   });
 });

--- a/src/client/content-scripts/content-script-ui.ts
+++ b/src/client/content-scripts/content-script-ui.ts
@@ -10,8 +10,8 @@ import {
 } from '../utils/content-script-ui';
 
 /**
- * Utility for mounting content script UI's with isolated styles. Automatically removed from the DOM
- * when the content script's context is invalidated.
+ * Utility for mounting content script UI's with isolated styles and controlled event bubbling.
+ * Automatically removed from the DOM when the content script's context is invalidated.
  *
  * See https://wxt.dev/guide/content-script-ui.html for full documentation.
  *
@@ -31,7 +31,8 @@ import {
  *         const app = document.createElement("div");
  *         app.textContent = "Content Script UI";
  *         container.append(app);
- *       }
+ *       },
+         isolateEvents: true, // or array of event names to isolate, e.g., ['click', 'keydown']
  *     })
  *     ui.mount();
  *   }
@@ -56,6 +57,7 @@ export async function createContentScriptUi<TApp>(
       textContent: css.join('\n').trim(),
     },
     mode: 'open',
+    isolateEvents: options.isolateEvents,
   });
 
   let mounted: TApp;
@@ -170,4 +172,9 @@ export type ContentScriptUiOptions<TApp> = ContentScriptPositioningOptions &
      * See https://wxt.dev/guide/content-script-ui.html for more info.
      */
     css?: string;
+    /**
+     * Optional array of event names to prevent from bubbling up from the isolated element.
+     * If true, prevents a default set of events. If array, prevents specified events.
+     */
+    isolateEvents?: boolean | string[];
   };

--- a/src/client/content-scripts/content-script-ui.ts
+++ b/src/client/content-scripts/content-script-ui.ts
@@ -32,7 +32,6 @@ import {
  *         app.textContent = "Content Script UI";
  *         container.append(app);
  *       },
-         isolateEvents: true, // or array of event names to isolate, e.g., ['click', 'keydown']
  *     })
  *     ui.mount();
  *   }

--- a/src/client/content-scripts/content-script-ui.ts
+++ b/src/client/content-scripts/content-script-ui.ts
@@ -173,8 +173,12 @@ export type ContentScriptUiOptions<TApp> = ContentScriptPositioningOptions &
      */
     css?: string;
     /**
-     * Optional array of event names to prevent from bubbling up from the isolated element.
-     * If true, prevents a default set of events. If array, prevents specified events.
+     * When enabled, `event.stopPropagation` will be called on events trying to bubble out of the
+     * shadow root.
+     *
+     * - Set to `true` to stop the propagation of a default set of events,
+     *   `["keyup", "keydown", "keypress"]`
+     * - Set to an array of event names to stop the propagation of a custom list of events
      */
     isolateEvents?: boolean | string[];
   };


### PR DESCRIPTION
This PR introduces notable changes to the Content Script UI documentation and test suite:

1. **Documentation Update:**
   Added 'Isolated Events' column to the tables in the documentation to reflect the new `isolateEvents` parameter (also add the parameter to the shadow DOM part documentation):

   | Method     | Isolated Styles | Isolated Events   | HMR | Use page's context |
   | ---------- | :-------------: | :---------------: | :-: | :----------------: |
   | Integrated |       ❌        |         ❌        | ❌  |         ✅         |
   | ShadowRoot |       ✅        | ✅ (default off)  | ❌  |         ✅         |
   | IFrame     |       ✅        |         ✅        | ✅  |         ❌         |

2. **Test Code Update:**
   Updated tests to verify default behavior and parameter passing for `isolateEvents`. Actual event isolation is not tested due to the mocked nature of `createIsolatedElement`.