### PR TITLE
feat(DX): Add `ctrl+E`/`cmd+E` shortcut to reload extension during development

### DIFF
--- a/docs/guide/development.md
+++ b/docs/guide/development.md
@@ -57,3 +57,9 @@ export default defineRunnerConfig({
 :::tip
 When configuring browser binaries, it's helpful to put them in `~/web-ext.config.ts` instead of the project directory's `web-ext.config.ts` file. When placed in your home directory (`~/`), this config will be used by all WXT projects, so you only need to configure the binaries once.
 :::
+
+## Reload Extension Manually
+
+To manually reload an extension, you normally have to visit `chrome://extensions` and click the reload button for your extension.
+
+WXT provides a keyboard shortcut, `ctrl+E` for Windows/Linux and `cmd+E` for Mac, that will cause the extension to reload immediately, without visiting `chrome://extensions`. This will save you time.

--- a/docs/guide/development.md
+++ b/docs/guide/development.md
@@ -58,8 +58,12 @@ export default defineRunnerConfig({
 When configuring browser binaries, it's helpful to put them in `~/web-ext.config.ts` instead of the project directory's `web-ext.config.ts` file. When placed in your home directory (`~/`), this config will be used by all WXT projects, so you only need to configure the binaries once.
 :::
 
-## Reload Extension Manually
+## Reload the Extension
 
-To manually reload an extension, you normally have to visit `chrome://extensions` and click the reload button for your extension.
+Normally, to manually reload an extension, you have to visit `chrome://extensions` and click the reload button for your extension.
 
-WXT provides a keyboard shortcut, `ctrl+E` for Windows/Linux and `cmd+E` for Mac, that will cause the extension to reload immediately, without visiting `chrome://extensions`. This will save you time.
+When running `wxt` command to start the dev server, WXT adds a keyboard shortcut, `ctrl+E` for Windows/Linux and `cmd+E` for Mac, that reloads the extension when pressed, without visiting `chrome://extensions`.
+
+:::note
+This shortcut is only available during development, and is not be added to your extension when running `wxt build` or `wxt-zip`.
+:::

--- a/src/core/utils/__tests__/manifest.test.ts
+++ b/src/core/utils/__tests__/manifest.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from 'vitest';
+import { generateMainfest } from '../manifest';
+import {
+  fakeArray,
+  fakeBuildOutput,
+  fakeEntrypoint,
+  fakeInternalConfig,
+} from '../testing/fake-objects';
+
+describe('Manifest Utils', () => {
+  describe('generateManifest', () => {
+    describe('Development reload command', () => {
+      const reloadCommandName = 'wxt:reload-extension';
+      const reloadCommand = {
+        suggested_key: {
+          default: 'Ctrl+E',
+        },
+      };
+
+      it('should include a command for reloading the extension', async () => {
+        const config = fakeInternalConfig({ command: 'serve' });
+        const output = fakeBuildOutput();
+        const entrypoints = fakeArray(fakeEntrypoint);
+
+        const actual = await generateMainfest(entrypoints, output, config);
+
+        expect(actual.commands).toMatchObject({
+          [reloadCommandName]: reloadCommand,
+        });
+      });
+
+      it('should not override any existing commands when adding the one to reload the extension', async () => {
+        const customCommandName = 'custom-command';
+        const customCommand = {
+          description: 'Some other command',
+          suggested_key: {
+            default: 'Ctrl+H',
+          },
+        };
+        const config = fakeInternalConfig({
+          command: 'serve',
+          manifest: {
+            commands: {
+              [customCommandName]: customCommand,
+            },
+          },
+        });
+        const output = fakeBuildOutput();
+        const entrypoints = fakeArray(fakeEntrypoint);
+
+        const actual = await generateMainfest(entrypoints, output, config);
+
+        expect(actual.commands).toMatchObject({
+          [reloadCommandName]: reloadCommand,
+          [customCommandName]: customCommand,
+        });
+      });
+
+      it('should not include the command when building an extension', async () => {
+        const config = fakeInternalConfig({ command: 'build' });
+        const output = fakeBuildOutput();
+        const entrypoints = fakeArray(fakeEntrypoint);
+
+        const actual = await generateMainfest(entrypoints, output, config);
+
+        expect(actual.commands).toBeUndefined();
+      });
+    });
+  });
+});

--- a/src/core/utils/manifest.ts
+++ b/src/core/utils/manifest.ts
@@ -73,6 +73,16 @@ export async function generateMainfest(
     short_name: pkg?.shortName,
     icons: discoverIcons(buildOutput),
   };
+  if (config.command === 'serve') {
+    baseManifest.commands = {
+      'wxt:reload-extension': {
+        description: 'Reload the extension during development',
+        suggested_key: {
+          default: 'Ctrl+E',
+        },
+      },
+    };
+  }
   const userManifest = config.manifest;
 
   const manifest = defu(

--- a/src/core/utils/testing/fake-objects.ts
+++ b/src/core/utils/testing/fake-objects.ts
@@ -17,6 +17,8 @@ import {
   OutputChunk,
   OutputFile,
   OutputAsset,
+  BuildOutput,
+  BuildStepOutput,
 } from '~/types';
 import { mock } from 'vitest-mock-extended';
 
@@ -38,6 +40,16 @@ export function fakeFile(root = process.cwd()): string {
 export function fakeDir(root = process.cwd()): string {
   return resolve(root, faker.string.alphanumeric());
 }
+
+export const fakeEntrypoint = () =>
+  faker.helpers.arrayElement([
+    fakePopupEntrypoint,
+    fakeGenericEntrypoint,
+    fakeOptionsEntrypoint,
+    fakeBackgroundEntrypoint,
+    fakeContentScriptEntrypoint,
+    fakeUnlistedScriptEntrypoint,
+  ])();
 
 export const fakeContentScriptEntrypoint =
   fakeObjectCreator<ContentScriptEntrypoint>(() => ({
@@ -222,3 +234,14 @@ export const fakeInternalConfig = fakeObjectCreator<InternalConfig>(() => {
     builder: mock(),
   };
 });
+
+export const fakeBuildOutput = fakeObjectCreator<BuildOutput>(() => ({
+  manifest: fakeManifest(),
+  publicAssets: fakeArray(fakeOutputAsset),
+  steps: fakeArray(fakeBuildStepOutput),
+}));
+
+export const fakeBuildStepOutput = fakeObjectCreator<BuildStepOutput>(() => ({
+  chunks: fakeArray(fakeOutputChunk),
+  entrypoints: fakeArray(fakeEntrypoint),
+}));

--- a/src/virtual/background-entrypoint.ts
+++ b/src/virtual/background-entrypoint.ts
@@ -26,6 +26,12 @@ if (__COMMAND__ === 'serve') {
   } catch (err) {
     logger.error('Failed to setup web socket connection with dev server', err);
   }
+
+  browser.commands.onCommand.addListener((command) => {
+    if (command === 'wxt:reload-extension') {
+      browser.runtime.reload();
+    }
+  });
 }
 
 try {


### PR DESCRIPTION
With the browser as the focused window, press `ctrl+E` on windows/linux and `cmd+E` on mac to reload the extension without visiting `chrome://extensions`.

This closes #321 