### PR TITLE
fix: Strip path from `web_accessible_resources[0].matches`

### DIFF
--- a/src/core/utils/__tests__/manifest.test.ts
+++ b/src/core/utils/__tests__/manifest.test.ts
@@ -646,6 +646,47 @@ describe('Manifest Utils', () => {
             'content-scripts/one.css',
           ]);
         });
+
+        it('should strip the path off the match pattern so the pattern is valid for `web_accessible_resources`', async () => {
+          const cs: ContentScriptEntrypoint = {
+            type: 'content-script',
+            name: 'one',
+            inputPath: 'entrypoints/one.content.ts',
+            outputDir: contentScriptOutDir,
+            options: {
+              matches: ['*://play.google.com/books/*'],
+              cssInjectionMode: 'ui',
+            },
+          };
+          const styles: OutputAsset = {
+            type: 'asset',
+            fileName: 'content-scripts/one.css',
+          };
+
+          const entrypoints = [cs];
+          const buildOutput: Omit<BuildOutput, 'manifest'> = {
+            publicAssets: [],
+            steps: [{ entrypoints: cs, chunks: [styles] }],
+          };
+          const config = fakeInternalConfig({
+            outDir,
+            command: 'build',
+            manifestVersion: 3,
+          });
+
+          const actual = await generateManifest(
+            entrypoints,
+            buildOutput,
+            config,
+          );
+
+          expect(actual.web_accessible_resources).toEqual([
+            {
+              matches: ['*://play.google.com/*'],
+              resources: ['content-scripts/one.css'],
+            },
+          ]);
+        });
       });
     });
 

--- a/src/core/utils/__tests__/manifest.test.ts
+++ b/src/core/utils/__tests__/manifest.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { generateManifest } from '../manifest';
+import { generateManifest, stripPathFromMatchPattern } from '../manifest';
 import {
   fakeArray,
   fakeBackgroundEntrypoint,
@@ -948,6 +948,18 @@ describe('Manifest Utils', () => {
 
         expect(actual.commands).toBeUndefined();
       });
+    });
+  });
+
+  describe('stripPathFromMatchPattern', () => {
+    it.each([
+      ['<all_urls>', '<all_urls>'],
+      ['*://play.google.com/books/*', '*://play.google.com/*'],
+      ['*://*/*', '*://*/*'],
+      ['https://github.com/wxt-dev/*', 'https://github.com/*'],
+    ])('should convert "%s" to "%s"', (input, expected) => {
+      const actual = stripPathFromMatchPattern(input);
+      expect(actual).toEqual(expected);
     });
   });
 });

--- a/src/core/utils/manifest.ts
+++ b/src/core/utils/manifest.ts
@@ -503,7 +503,10 @@ export function getContentScriptCssWebAccessibleResources(
     } else {
       resources.push({
         resources: [cssFile],
-        matches: script.options.matches,
+        matches: resolvePerBrowserOption(
+          script.options.matches,
+          config.browser,
+        ).map((matchPattern) => stripPathFromMatchPattern(matchPattern)),
       });
     }
   });
@@ -546,4 +549,16 @@ function addHostPermission(
   manifest.host_permissions ??= [];
   if (manifest.host_permissions.includes(hostPermission)) return;
   manifest.host_permissions.push(hostPermission);
+}
+
+/**
+ * - "<all_urls>" &rarr; "<all_urls>"
+ * - "*://play.google.com/books/*" &rarr; "*://play.google.com/*"
+ */
+export function stripPathFromMatchPattern(pattern: string) {
+  const protocolSepIndex = pattern.indexOf('://');
+  if (protocolSepIndex === -1) return pattern;
+
+  const startOfPath = pattern.indexOf('/', protocolSepIndex + 3);
+  return pattern.substring(0, startOfPath) + '/*';
 }


### PR DESCRIPTION
This closes #329.

For MV3, match patterns in the `web_accessible_resources` are not the same as content scripts. They must have a path of `/*`, nothing else.

> An array of strings, each containing a [match pattern](https://developer.chrome.com/docs/extensions/mv3/match_patterns) that specifies which sites can access this set of resources. Only the origin is used to match URLs. Origins include subdomain matching. Google Chrome emits an "Invalid match pattern" error if the pattern has a path other than '/*'.
> &ndash; https://developer.chrome.com/docs/extensions/reference/manifest/web-accessible-resources#manifest_declaration

So if the content script matches `*://play.google.com/books/*`, the `web_accessible_resources` match pattern should be `*://play.google.com/*`.
