### PR TITLE
perf: Only call `findEntrypoint` once per build

### DIFF
--- a/src/core/create-server.ts
+++ b/src/core/create-server.ts
@@ -20,6 +20,7 @@ import {
   getInternalConfig,
   detectDevChanges,
   rebuild,
+  findEntrypoints,
 } from '~/core/utils/building';
 import { createExtensionRunner } from '~/core/runners';
 import { consola } from 'consola';
@@ -140,6 +141,7 @@ function createFileReloader(options: {
       const fileChanges = changeQueue.splice(0, changeQueue.length);
       if (fileChanges.length === 0) return;
 
+      const allEntrypoints = await findEntrypoints(config);
       const changes = detectDevChanges(fileChanges, server.currentOutput);
       if (changes.type === 'no-change') return;
 
@@ -161,6 +163,7 @@ function createFileReloader(options: {
       // Rebuild entrypoints on change
       const { output: newOutput } = await rebuild(
         config,
+        allEntrypoints,
         // TODO: this excludes new entrypoints, so they're not built until the dev command is restarted
         changes.rebuildGroups,
         changes.cachedOutput,

--- a/src/core/create-server.ts
+++ b/src/core/create-server.ts
@@ -141,7 +141,6 @@ function createFileReloader(options: {
       const fileChanges = changeQueue.splice(0, changeQueue.length);
       if (fileChanges.length === 0) return;
 
-      const allEntrypoints = await findEntrypoints(config);
       const changes = detectDevChanges(fileChanges, server.currentOutput);
       if (changes.type === 'no-change') return;
 
@@ -161,6 +160,7 @@ function createFileReloader(options: {
         .join(pc.dim(', '));
 
       // Rebuild entrypoints on change
+      const allEntrypoints = await findEntrypoints(config);
       const { output: newOutput } = await rebuild(
         config,
         allEntrypoints,

--- a/src/core/utils/building/internal-build.ts
+++ b/src/core/utils/building/internal-build.ts
@@ -38,7 +38,7 @@ export async function internalBuild(
   const entrypoints = await findEntrypoints(config);
   config.logger.debug('Detected entrypoints:', entrypoints);
   const groups = groupEntrypoints(entrypoints);
-  const { output } = await rebuild(config, groups, undefined);
+  const { output } = await rebuild(config, entrypoints, groups, undefined);
 
   // Post-build
   await printBuildSummary(

--- a/src/core/utils/building/rebuild.ts
+++ b/src/core/utils/building/rebuild.ts
@@ -1,6 +1,10 @@
 import type { Manifest } from '~/browser';
-import { BuildOutput, EntrypointGroup, InternalConfig } from '~/types';
-import { findEntrypoints } from './find-entrypoints';
+import {
+  BuildOutput,
+  Entrypoint,
+  EntrypointGroup,
+  InternalConfig,
+} from '~/types';
 import { generateTypesDir } from './generate-wxt-dir';
 import { buildEntrypoints } from './build-entrypoints';
 import { generateManifest, writeManifest } from '~/core/utils/manifest';
@@ -17,6 +21,7 @@ import { generateManifest, writeManifest } from '~/core/utils/manifest';
  */
 export async function rebuild(
   config: InternalConfig,
+  allEntrypoints: Entrypoint[],
   entrypointGroups: EntrypointGroup[],
   existingOutput: Omit<BuildOutput, 'manifest'> = {
     steps: [],
@@ -27,7 +32,6 @@ export async function rebuild(
   const spinner = ora(`Preparing...`).start();
 
   // Update types directory with new files and types
-  const allEntrypoints = await findEntrypoints(config);
   await generateTypesDir(allEntrypoints, config).catch((err) => {
     config.logger.warn('Failed to update .wxt directory:', err);
     // Throw the error if doing a regular build, don't for dev mode.

--- a/src/core/utils/building/rebuild.ts
+++ b/src/core/utils/building/rebuild.ts
@@ -18,6 +18,12 @@ import { generateManifest, writeManifest } from '~/core/utils/manifest';
  * 2. Build the `entrypointGroups` (and copies public files)
  * 3. Generate the latest manifest for all entrypoints
  * 4. Write the new manifest to the file system
+ *
+ * @param config Internal config containing all the project information.
+ * @param allEntrypoints List of entrypoints used to generate the types inside .wxt directory.
+ * @param entrypointGroups The list of entrypoint groups to build.
+ * @param existingOutput The previous output to combine the rebuild results into. An emptry array if
+ *                       this is the first build.
  */
 export async function rebuild(
   config: InternalConfig,


### PR DESCRIPTION
Previously, we were calling it twice.