### PR TITLE
feat: Add `filterEntrypoints` option to speed up development

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -20,6 +20,9 @@ cli
   .option('-c, --config <file>', 'use specified config file')
   .option('-m, --mode <mode>', 'set env mode')
   .option('-b, --browser <browser>', 'specify a browser')
+  .option('-e, --allow-entrypoint <entrypoint>', 'specify allow entrypoints', {
+    type: [],
+  })
   .option('--mv3', 'target manifest v3')
   .option('--mv2', 'target manifest v2')
   .action(
@@ -31,6 +34,7 @@ cli
         manifestVersion: flags.mv3 ? 3 : flags.mv2 ? 2 : undefined,
         configFile: flags.config,
         debug: flags.debug,
+        allowEntrypoints: flags.allowEntrypoints,
       });
       await server.start();
       return { isOngoing: true };
@@ -43,6 +47,9 @@ cli
   .option('-c, --config <file>', 'use specified config file')
   .option('-m, --mode <mode>', 'set env mode')
   .option('-b, --browser <browser>', 'specify a browser')
+  .option('-e, --allow-entrypoint <entrypoint>', 'specify allow entrypoints', {
+    type: [],
+  })
   .option('--mv3', 'target manifest v3')
   .option('--mv2', 'target manifest v2')
   .option('--analyze', 'visualize extension bundle')
@@ -58,6 +65,7 @@ cli
         analysis: {
           enabled: flags.analyze,
         },
+        allowEntrypoints: flags.allowEntrypoints,
       });
     }),
   );

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -38,7 +38,7 @@ cli
         manifestVersion: flags.mv3 ? 3 : flags.mv2 ? 2 : undefined,
         configFile: flags.config,
         debug: flags.debug,
-        filterEntrypoints: flags.filterEntrypoints,
+        filterEntrypoints: flags.filterEntrypoint,
       });
       await server.start();
       return { isOngoing: true };
@@ -73,7 +73,7 @@ cli
         analysis: {
           enabled: flags.analyze,
         },
-        filterEntrypoints: flags.filterEntrypoints,
+        filterEntrypoints: flags.filterEntrypoint,
       });
     }),
   );

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -38,7 +38,7 @@ cli
         manifestVersion: flags.mv3 ? 3 : flags.mv2 ? 2 : undefined,
         configFile: flags.config,
         debug: flags.debug,
-        filterEntrypoints: flags.filterEntrypoint,
+        filterEntrypoints: getArrayFromFlags(flags, 'filterEntrypoint'),
       });
       await server.start();
       return { isOngoing: true };
@@ -73,7 +73,7 @@ cli
         analysis: {
           enabled: flags.analyze,
         },
-        filterEntrypoints: flags.filterEntrypoint,
+        filterEntrypoints: getArrayFromFlags(flags, 'filterEntrypoint'),
       });
     }),
   );
@@ -180,4 +180,13 @@ function wrapAction(
       process.exit(1);
     }
   };
+}
+
+/**
+ * Array flags, when not passed, are either `undefined` or `[undefined]`. This function filters out
+ * the
+ */
+function getArrayFromFlags<T>(flags: any, name: string): T[] | undefined {
+  const array = [flags[name]].flat() as Array<T | undefined>;
+  return array.filter((item) => item != null) as T[];
 }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -20,9 +20,13 @@ cli
   .option('-c, --config <file>', 'use specified config file')
   .option('-m, --mode <mode>', 'set env mode')
   .option('-b, --browser <browser>', 'specify a browser')
-  .option('-e, --allow-entrypoint <entrypoint>', 'specify allow entrypoints', {
-    type: [],
-  })
+  .option(
+    '-e, --filter-entrypoint <entrypoint>',
+    'custom allowed entrypoints',
+    {
+      type: [],
+    },
+  )
   .option('--mv3', 'target manifest v3')
   .option('--mv2', 'target manifest v2')
   .action(
@@ -34,7 +38,7 @@ cli
         manifestVersion: flags.mv3 ? 3 : flags.mv2 ? 2 : undefined,
         configFile: flags.config,
         debug: flags.debug,
-        allowEntrypoints: flags.allowEntrypoints,
+        filterEntrypoints: flags.filterEntrypoints,
       });
       await server.start();
       return { isOngoing: true };
@@ -47,9 +51,13 @@ cli
   .option('-c, --config <file>', 'use specified config file')
   .option('-m, --mode <mode>', 'set env mode')
   .option('-b, --browser <browser>', 'specify a browser')
-  .option('-e, --allow-entrypoint <entrypoint>', 'specify allow entrypoints', {
-    type: [],
-  })
+  .option(
+    '-e, --filter-entrypoint <entrypoint>',
+    'custom allowed entrypoints',
+    {
+      type: [],
+    },
+  )
   .option('--mv3', 'target manifest v3')
   .option('--mv2', 'target manifest v2')
   .option('--analyze', 'visualize extension bundle')
@@ -65,7 +73,7 @@ cli
         analysis: {
           enabled: flags.analyze,
         },
-        allowEntrypoints: flags.allowEntrypoints,
+        filterEntrypoints: flags.filterEntrypoints,
       });
     }),
   );

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -22,7 +22,7 @@ cli
   .option('-b, --browser <browser>', 'specify a browser')
   .option(
     '-e, --filter-entrypoint <entrypoint>',
-    'custom allowed entrypoints',
+    'only build specific entrypoints',
     {
       type: [],
     },
@@ -53,7 +53,7 @@ cli
   .option('-b, --browser <browser>', 'specify a browser')
   .option(
     '-e, --filter-entrypoint <entrypoint>',
-    'custom allowed entrypoints',
+    'only build specific entrypoints',
     {
       type: [],
     },

--- a/src/core/utils/__tests__/entrypoints.test.ts
+++ b/src/core/utils/__tests__/entrypoints.test.ts
@@ -47,6 +47,7 @@ describe('Entrypoint Utils', () => {
         name,
         outputDir,
         options: {},
+        skipped: false,
       };
 
       const actual = getEntrypointOutputFile(entrypoint, ext);

--- a/src/core/utils/__tests__/manifest.test.ts
+++ b/src/core/utils/__tests__/manifest.test.ts
@@ -339,6 +339,7 @@ describe('Manifest Utils', () => {
           options: {
             matches: ['*://google.com/*'],
           },
+          skipped: false,
         };
         const cs1Styles: OutputAsset = {
           type: 'asset',
@@ -353,6 +354,7 @@ describe('Manifest Utils', () => {
             matches: ['*://google.com/*'],
             runAt: 'document_end',
           },
+          skipped: false,
         };
         const cs2Styles: OutputAsset = {
           type: 'asset',
@@ -367,6 +369,7 @@ describe('Manifest Utils', () => {
             matches: ['*://google.com/*'],
             runAt: 'document_end',
           },
+          skipped: false,
         };
         const cs3Styles: OutputAsset = {
           type: 'asset',
@@ -381,6 +384,7 @@ describe('Manifest Utils', () => {
             matches: ['*://duckduckgo.com/*'],
             runAt: 'document_end',
           },
+          skipped: false,
         };
         const cs4Styles: OutputAsset = {
           type: 'asset',
@@ -395,6 +399,7 @@ describe('Manifest Utils', () => {
             matches: ['*://google.com/*'],
             world: 'MAIN',
           },
+          skipped: false,
         };
         const cs5Styles: OutputAsset = {
           type: 'asset',
@@ -454,6 +459,7 @@ describe('Manifest Utils', () => {
           options: {
             matches: ['*://google.com/*'],
           },
+          skipped: false,
         };
         const generatedContentScript = {
           matches: ['*://google.com/*'],
@@ -493,6 +499,7 @@ describe('Manifest Utils', () => {
                 matches: ['*://google.com/*'],
                 cssInjectionMode,
               },
+              skipped: false,
             };
             const styles: OutputAsset = {
               type: 'asset',
@@ -537,6 +544,7 @@ describe('Manifest Utils', () => {
                 matches: ['*://google.com/*'],
                 cssInjectionMode,
               },
+              skipped: false,
             };
             const styles: OutputAsset = {
               type: 'asset',
@@ -578,6 +586,7 @@ describe('Manifest Utils', () => {
               matches: ['*://google.com/*'],
               cssInjectionMode: 'ui',
             },
+            skipped: false,
           };
           const styles: OutputAsset = {
             type: 'asset',
@@ -619,6 +628,7 @@ describe('Manifest Utils', () => {
               matches: ['*://google.com/*'],
               cssInjectionMode: 'ui',
             },
+            skipped: false,
           };
           const styles: OutputAsset = {
             type: 'asset',
@@ -657,6 +667,7 @@ describe('Manifest Utils', () => {
               matches: ['*://play.google.com/books/*'],
               cssInjectionMode: 'ui',
             },
+            skipped: false,
           };
           const styles: OutputAsset = {
             type: 'asset',
@@ -701,6 +712,7 @@ describe('Manifest Utils', () => {
             matches: ['*://google.com/*'],
             cssInjectionMode: 'ui',
           },
+          skipped: false,
         };
         const styles: OutputAsset = {
           type: 'asset',
@@ -744,6 +756,7 @@ describe('Manifest Utils', () => {
             matches: ['*://google.com/*'],
             cssInjectionMode: 'ui',
           },
+          skipped: false,
         };
         const styles: OutputAsset = {
           type: 'asset',

--- a/src/core/utils/building/__tests__/find-entrypoints.test.ts
+++ b/src/core/utils/building/__tests__/find-entrypoints.test.ts
@@ -737,4 +737,29 @@ describe('findEntrypoints', () => {
       expect(entrypoints).toEqual([]);
     });
   });
+
+  describe('allowEntrypoints option', () => {
+    it('should control entrypoints accessible', async () => {
+      globMock.mockResolvedValue([
+        'options/index.html',
+        'popup/index.html',
+        'ui.content/index.ts',
+        'injected.content/index.ts',
+      ]);
+      importEntrypointFileMock.mockResolvedValue({});
+      const allowEntrypoints = ['popup', 'ui'];
+      const config = fakeInternalConfig({
+        root: '/',
+        entrypointsDir: resolve('/src/entrypoints'),
+        outDir: resolve('.output'),
+        command: 'build',
+        allowEntrypoints,
+      });
+
+      const entrypoints = await findEntrypoints(config);
+      const names = entrypoints.map((item) => item.name);
+      expect(names).toHaveLength(2);
+      expect(names).toEqual(allowEntrypoints);
+    });
+  });
 });

--- a/src/core/utils/building/__tests__/find-entrypoints.test.ts
+++ b/src/core/utils/building/__tests__/find-entrypoints.test.ts
@@ -53,6 +53,7 @@ describe('findEntrypoints', () => {
           defaultIcon: { '16': '/icon/16.png' },
           defaultTitle: 'Default Title',
         },
+        skipped: false,
       },
     ],
     [
@@ -72,6 +73,7 @@ describe('findEntrypoints', () => {
         options: {
           defaultTitle: 'Title',
         },
+        skipped: false,
       },
     ],
   ])(
@@ -103,6 +105,7 @@ describe('findEntrypoints', () => {
         inputPath: resolve(config.entrypointsDir, 'options.html'),
         outputDir: config.outDir,
         options: {},
+        skipped: false,
       },
     ],
     [
@@ -123,6 +126,7 @@ describe('findEntrypoints', () => {
         options: {
           openInTab: true,
         },
+        skipped: false,
       },
     ],
   ])(
@@ -146,6 +150,7 @@ describe('findEntrypoints', () => {
         name: 'content',
         inputPath: resolve(config.entrypointsDir, 'content.ts'),
         outputDir: resolve(config.outDir, 'content-scripts'),
+        skipped: false,
       },
     ],
     [
@@ -155,6 +160,7 @@ describe('findEntrypoints', () => {
         name: 'overlay',
         inputPath: resolve(config.entrypointsDir, 'overlay.content.ts'),
         outputDir: resolve(config.outDir, 'content-scripts'),
+        skipped: false,
       },
     ],
     [
@@ -164,6 +170,7 @@ describe('findEntrypoints', () => {
         name: 'content',
         inputPath: resolve(config.entrypointsDir, 'content/index.ts'),
         outputDir: resolve(config.outDir, 'content-scripts'),
+        skipped: false,
       },
     ],
     [
@@ -173,6 +180,7 @@ describe('findEntrypoints', () => {
         name: 'overlay',
         inputPath: resolve(config.entrypointsDir, 'overlay.content/index.ts'),
         outputDir: resolve(config.outDir, 'content-scripts'),
+        skipped: false,
       },
     ],
     [
@@ -182,6 +190,7 @@ describe('findEntrypoints', () => {
         name: 'overlay',
         inputPath: resolve(config.entrypointsDir, 'overlay.content.tsx'),
         outputDir: resolve(config.outDir, 'content-scripts'),
+        skipped: false,
       },
     ],
   ])(
@@ -212,6 +221,7 @@ describe('findEntrypoints', () => {
         name: 'background',
         inputPath: resolve(config.entrypointsDir, 'background.ts'),
         outputDir: config.outDir,
+        skipped: false,
       },
     ],
     [
@@ -221,6 +231,7 @@ describe('findEntrypoints', () => {
         name: 'background',
         inputPath: resolve(config.entrypointsDir, 'background/index.ts'),
         outputDir: config.outDir,
+        skipped: false,
       },
     ],
   ])(
@@ -258,6 +269,7 @@ describe('findEntrypoints', () => {
       name: 'background',
       options: {},
       outputDir: config.outDir,
+      skipped: false,
     });
   });
 
@@ -278,6 +290,7 @@ describe('findEntrypoints', () => {
         name: 'injected',
         inputPath: resolve(config.entrypointsDir, path),
         outputDir: config.outDir,
+        skipped: false,
       };
       const options: GenericEntrypoint['options'] = {};
       globMock.mockResolvedValueOnce([path]);
@@ -304,6 +317,7 @@ describe('findEntrypoints', () => {
         inputPath: resolve(config.entrypointsDir, 'sandbox.html'),
         outputDir: config.outDir,
         options: {},
+        skipped: false,
       },
     ],
     [
@@ -314,6 +328,7 @@ describe('findEntrypoints', () => {
         inputPath: resolve(config.entrypointsDir, 'sandbox/index.html'),
         outputDir: config.outDir,
         options: {},
+        skipped: false,
       },
     ],
     [
@@ -324,6 +339,7 @@ describe('findEntrypoints', () => {
         inputPath: resolve(config.entrypointsDir, 'named.sandbox.html'),
         outputDir: config.outDir,
         options: {},
+        skipped: false,
       },
     ],
     [
@@ -334,6 +350,7 @@ describe('findEntrypoints', () => {
         inputPath: resolve(config.entrypointsDir, 'named.sandbox/index.html'),
         outputDir: config.outDir,
         options: {},
+        skipped: false,
       },
     ],
 
@@ -346,6 +363,7 @@ describe('findEntrypoints', () => {
         inputPath: resolve(config.entrypointsDir, 'bookmarks.html'),
         outputDir: config.outDir,
         options: {},
+        skipped: false,
       },
     ],
     [
@@ -356,6 +374,7 @@ describe('findEntrypoints', () => {
         inputPath: resolve(config.entrypointsDir, 'bookmarks/index.html'),
         outputDir: config.outDir,
         options: {},
+        skipped: false,
       },
     ],
 
@@ -368,6 +387,7 @@ describe('findEntrypoints', () => {
         inputPath: resolve(config.entrypointsDir, 'history.html'),
         outputDir: config.outDir,
         options: {},
+        skipped: false,
       },
     ],
     [
@@ -378,6 +398,7 @@ describe('findEntrypoints', () => {
         inputPath: resolve(config.entrypointsDir, 'history/index.html'),
         outputDir: config.outDir,
         options: {},
+        skipped: false,
       },
     ],
 
@@ -390,6 +411,7 @@ describe('findEntrypoints', () => {
         inputPath: resolve(config.entrypointsDir, 'newtab.html'),
         outputDir: config.outDir,
         options: {},
+        skipped: false,
       },
     ],
     [
@@ -400,6 +422,7 @@ describe('findEntrypoints', () => {
         inputPath: resolve(config.entrypointsDir, 'newtab/index.html'),
         outputDir: config.outDir,
         options: {},
+        skipped: false,
       },
     ],
 
@@ -412,6 +435,7 @@ describe('findEntrypoints', () => {
         inputPath: resolve(config.entrypointsDir, 'sidepanel.html'),
         outputDir: config.outDir,
         options: {},
+        skipped: false,
       },
     ],
     [
@@ -422,6 +446,7 @@ describe('findEntrypoints', () => {
         inputPath: resolve(config.entrypointsDir, 'sidepanel/index.html'),
         outputDir: config.outDir,
         options: {},
+        skipped: false,
       },
     ],
     [
@@ -432,6 +457,7 @@ describe('findEntrypoints', () => {
         inputPath: resolve(config.entrypointsDir, 'named.sidepanel.html'),
         outputDir: config.outDir,
         options: {},
+        skipped: false,
       },
     ],
     [
@@ -442,6 +468,7 @@ describe('findEntrypoints', () => {
         inputPath: resolve(config.entrypointsDir, 'named.sidepanel/index.html'),
         outputDir: config.outDir,
         options: {},
+        skipped: false,
       },
     ],
 
@@ -454,6 +481,7 @@ describe('findEntrypoints', () => {
         inputPath: resolve(config.entrypointsDir, 'devtools.html'),
         outputDir: config.outDir,
         options: {},
+        skipped: false,
       },
     ],
     [
@@ -464,6 +492,7 @@ describe('findEntrypoints', () => {
         inputPath: resolve(config.entrypointsDir, 'devtools/index.html'),
         outputDir: config.outDir,
         options: {},
+        skipped: false,
       },
     ],
 
@@ -476,6 +505,7 @@ describe('findEntrypoints', () => {
         inputPath: resolve(config.entrypointsDir, 'onboarding.html'),
         outputDir: config.outDir,
         options: {},
+        skipped: false,
       },
     ],
     [
@@ -486,6 +516,7 @@ describe('findEntrypoints', () => {
         inputPath: resolve(config.entrypointsDir, 'onboarding/index.html'),
         outputDir: config.outDir,
         options: {},
+        skipped: false,
       },
     ],
 
@@ -498,6 +529,7 @@ describe('findEntrypoints', () => {
         inputPath: resolve(config.entrypointsDir, 'iframe.scss'),
         outputDir: config.outDir,
         options: {},
+        skipped: false,
       },
     ],
     [
@@ -508,6 +540,7 @@ describe('findEntrypoints', () => {
         inputPath: resolve(config.entrypointsDir, 'iframe.css'),
         outputDir: config.outDir,
         options: {},
+        skipped: false,
       },
     ],
 
@@ -520,6 +553,7 @@ describe('findEntrypoints', () => {
         inputPath: resolve(config.entrypointsDir, 'content.css'),
         outputDir: resolve(config.outDir, 'content-scripts'),
         options: {},
+        skipped: false,
       },
     ],
     [
@@ -530,6 +564,7 @@ describe('findEntrypoints', () => {
         inputPath: resolve(config.entrypointsDir, 'overlay.content.css'),
         outputDir: resolve(config.outDir, 'content-scripts'),
         options: {},
+        skipped: false,
       },
     ],
     [
@@ -540,6 +575,7 @@ describe('findEntrypoints', () => {
         inputPath: resolve(config.entrypointsDir, 'content/index.css'),
         outputDir: resolve(config.outDir, 'content-scripts'),
         options: {},
+        skipped: false,
       },
     ],
     [
@@ -550,6 +586,7 @@ describe('findEntrypoints', () => {
         inputPath: resolve(config.entrypointsDir, 'overlay.content/index.css'),
         outputDir: resolve(config.outDir, 'content-scripts'),
         options: {},
+        skipped: false,
       },
     ],
   ])('should find entrypoint for %s', async (path, expected) => {

--- a/src/core/utils/building/__tests__/find-entrypoints.test.ts
+++ b/src/core/utils/building/__tests__/find-entrypoints.test.ts
@@ -738,7 +738,7 @@ describe('findEntrypoints', () => {
     });
   });
 
-  describe('allowEntrypoints option', () => {
+  describe('filterEntrypoints option', () => {
     it('should control entrypoints accessible', async () => {
       globMock.mockResolvedValue([
         'options/index.html',
@@ -747,19 +747,19 @@ describe('findEntrypoints', () => {
         'injected.content/index.ts',
       ]);
       importEntrypointFileMock.mockResolvedValue({});
-      const allowEntrypoints = ['popup', 'ui'];
+      const filterEntrypoints = ['popup', 'ui'];
       const config = fakeInternalConfig({
         root: '/',
         entrypointsDir: resolve('/src/entrypoints'),
         outDir: resolve('.output'),
         command: 'build',
-        allowEntrypoints,
+        filterEntrypoints,
       });
 
       const entrypoints = await findEntrypoints(config);
       const names = entrypoints.map((item) => item.name);
       expect(names).toHaveLength(2);
-      expect(names).toEqual(allowEntrypoints);
+      expect(names).toEqual(filterEntrypoints);
     });
   });
 });

--- a/src/core/utils/building/__tests__/find-entrypoints.test.ts
+++ b/src/core/utils/building/__tests__/find-entrypoints.test.ts
@@ -790,7 +790,7 @@ describe('findEntrypoints', () => {
         entrypointsDir: resolve('/src/entrypoints'),
         outDir: resolve('.output'),
         command: 'build',
-        filterEntrypoints,
+        filterEntrypoints: new Set(filterEntrypoints),
       });
 
       const entrypoints = await findEntrypoints(config);

--- a/src/core/utils/building/__tests__/group-entrypoints.test.ts
+++ b/src/core/utils/building/__tests__/group-entrypoints.test.ts
@@ -8,6 +8,7 @@ const background: Entrypoint = {
   inputPath: '/background.ts',
   outputDir: '/.output/background',
   options: {},
+  skipped: false,
 };
 const contentScript: Entrypoint = {
   type: 'content-script',
@@ -17,6 +18,7 @@ const contentScript: Entrypoint = {
   options: {
     matches: ['<all_urls>'],
   },
+  skipped: false,
 };
 const unlistedScript: Entrypoint = {
   type: 'unlisted-script',
@@ -24,6 +26,7 @@ const unlistedScript: Entrypoint = {
   inputPath: '/injected.ts',
   outputDir: '/.output/injected',
   options: {},
+  skipped: false,
 };
 const popup: Entrypoint = {
   type: 'popup',
@@ -31,6 +34,7 @@ const popup: Entrypoint = {
   inputPath: '/popup.html',
   outputDir: '/.output/popup',
   options: {},
+  skipped: false,
 };
 const unlistedPage: Entrypoint = {
   type: 'unlisted-page',
@@ -38,6 +42,7 @@ const unlistedPage: Entrypoint = {
   inputPath: '/onboarding.html',
   outputDir: '/.output/onboarding',
   options: {},
+  skipped: false,
 };
 const options: Entrypoint = {
   type: 'options',
@@ -45,6 +50,7 @@ const options: Entrypoint = {
   inputPath: '/options.html',
   outputDir: '/.output/options',
   options: {},
+  skipped: false,
 };
 const sandbox1: Entrypoint = {
   type: 'sandbox',
@@ -52,6 +58,7 @@ const sandbox1: Entrypoint = {
   inputPath: '/sandbox1.html',
   outputDir: '/.output/sandbox1',
   options: {},
+  skipped: false,
 };
 const sandbox2: Entrypoint = {
   type: 'sandbox',
@@ -59,6 +66,7 @@ const sandbox2: Entrypoint = {
   inputPath: '/sandbox2.html',
   outputDir: '/.output/sandbox2',
   options: {},
+  skipped: false,
 };
 const unlistedStyle: Entrypoint = {
   type: 'unlisted-style',
@@ -66,6 +74,7 @@ const unlistedStyle: Entrypoint = {
   inputPath: '/injected.scss',
   outputDir: '/.output',
   options: {},
+  skipped: false,
 };
 const contentScriptStyle: Entrypoint = {
   type: 'content-script-style',
@@ -73,6 +82,7 @@ const contentScriptStyle: Entrypoint = {
   inputPath: '/overlay.content.scss',
   outputDir: '/.output/content-scripts',
   options: {},
+  skipped: false,
 };
 
 describe('groupEntrypoints', () => {

--- a/src/core/utils/building/find-entrypoints.ts
+++ b/src/core/utils/building/find-entrypoints.ts
@@ -53,8 +53,8 @@ export async function findEntrypoints(
         inputPath,
         type,
         skipped:
-          Array.isArray(config.filterEntrypoints) &&
-          !config.filterEntrypoints.includes(name),
+          config.filterEntrypoints != null &&
+          !config.filterEntrypoints.has(name),
       });
     }
     return results;

--- a/src/core/utils/building/find-entrypoints.ts
+++ b/src/core/utils/building/find-entrypoints.ts
@@ -52,9 +52,9 @@ export async function findEntrypoints(
         name,
         inputPath,
         type,
-        disallowed:
-          Array.isArray(config.allowEntrypoints) &&
-          !config.allowEntrypoints.includes(name),
+        skipped:
+          Array.isArray(config.filterEntrypoints) &&
+          !config.filterEntrypoints.includes(name),
       });
     }
     return results;
@@ -118,12 +118,12 @@ export async function findEntrypoints(
   }
 
   config.logger.debug('All entrypoints:', entrypoints);
-  const disallowedEntrypointNames = entrypointInfos
-    .filter((item) => item.disallowed)
+  const skippedEntrypointNames = entrypointInfos
+    .filter((item) => item.skipped)
     .map((item) => item.name);
-  if (disallowedEntrypointNames.length) {
+  if (skippedEntrypointNames.length) {
     config.logger.warn(
-      `The follow entrypoints is ignored by not allowed:\n${disallowedEntrypointNames
+      `The follow entrypoints is ignored after filtered:\n${skippedEntrypointNames
         .map((item) => {
           return `- ${item}`;
         })
@@ -144,7 +144,7 @@ export async function findEntrypoints(
     if (include?.length && !exclude?.length) {
       return include.includes(config.browser);
     }
-    if (disallowedEntrypointNames.includes(entry.name)) {
+    if (skippedEntrypointNames.includes(entry.name)) {
       return false;
     }
 
@@ -161,7 +161,7 @@ interface EntrypointInfo {
   /**
    * @default false
    */
-  disallowed?: boolean;
+  skipped?: boolean;
 }
 
 function preventDuplicateEntrypointNames(

--- a/src/core/utils/building/find-entrypoints.ts
+++ b/src/core/utils/building/find-entrypoints.ts
@@ -113,6 +113,7 @@ export async function findEntrypoints(
         inputPath: VIRTUAL_NOOP_BACKGROUND_MODULE_ID,
         name: 'background',
         type: 'background',
+        skipped: false,
       }),
     );
   }
@@ -161,7 +162,7 @@ interface EntrypointInfo {
   /**
    * @default false
    */
-  skipped?: boolean;
+  skipped: boolean;
 }
 
 function preventDuplicateEntrypointNames(
@@ -228,7 +229,7 @@ function getHtmlBaseOptions(document: Document): BaseEntrypointOptions {
  */
 async function getPopupEntrypoint(
   config: InternalConfig,
-  { inputPath, name }: EntrypointInfo,
+  { inputPath, name, skipped }: EntrypointInfo,
 ): Promise<PopupEntrypoint> {
   const content = await fs.readFile(inputPath, 'utf-8');
   const { document } = parseHTML(content);
@@ -273,6 +274,7 @@ async function getPopupEntrypoint(
     options,
     inputPath,
     outputDir: config.outDir,
+    skipped,
   };
 }
 
@@ -282,7 +284,7 @@ async function getPopupEntrypoint(
  */
 async function getOptionsEntrypoint(
   config: InternalConfig,
-  { inputPath, name }: EntrypointInfo,
+  { inputPath, name, skipped }: EntrypointInfo,
 ): Promise<OptionsEntrypoint> {
   const content = await fs.readFile(inputPath, 'utf-8');
   const { document } = parseHTML(content);
@@ -316,6 +318,7 @@ async function getOptionsEntrypoint(
     options,
     inputPath,
     outputDir: config.outDir,
+    skipped,
   };
 }
 
@@ -325,7 +328,7 @@ async function getOptionsEntrypoint(
  */
 async function getUnlistedPageEntrypoint(
   config: InternalConfig,
-  { inputPath, name }: EntrypointInfo,
+  { inputPath, name, skipped }: EntrypointInfo,
 ): Promise<GenericEntrypoint> {
   const content = await fs.readFile(inputPath, 'utf-8');
   const { document } = parseHTML(content);
@@ -336,6 +339,7 @@ async function getUnlistedPageEntrypoint(
     inputPath,
     outputDir: config.outDir,
     options: getHtmlBaseOptions(document),
+    skipped,
   };
 }
 
@@ -345,7 +349,7 @@ async function getUnlistedPageEntrypoint(
  */
 async function getUnlistedScriptEntrypoint(
   config: InternalConfig,
-  { inputPath, name }: EntrypointInfo,
+  { inputPath, name, skipped }: EntrypointInfo,
 ): Promise<GenericEntrypoint> {
   const defaultExport = await importEntrypointFile<UnlistedScriptDefinition>(
     inputPath,
@@ -364,6 +368,7 @@ async function getUnlistedScriptEntrypoint(
     inputPath,
     outputDir: config.outDir,
     options,
+    skipped,
   };
 }
 
@@ -372,7 +377,7 @@ async function getUnlistedScriptEntrypoint(
  */
 async function getBackgroundEntrypoint(
   config: InternalConfig,
-  { inputPath, name }: EntrypointInfo,
+  { inputPath, name, skipped }: EntrypointInfo,
 ): Promise<BackgroundEntrypoint> {
   let options: Omit<BackgroundDefinition, 'main'> = {};
   if (inputPath !== VIRTUAL_NOOP_BACKGROUND_MODULE_ID) {
@@ -398,6 +403,7 @@ async function getBackgroundEntrypoint(
       type: resolvePerBrowserOption(options.type, config.browser),
       persistent: resolvePerBrowserOption(options.persistent, config.browser),
     },
+    skipped,
   };
 }
 
@@ -406,7 +412,7 @@ async function getBackgroundEntrypoint(
  */
 async function getContentScriptEntrypoint(
   config: InternalConfig,
-  { inputPath, name }: EntrypointInfo,
+  { inputPath, name, skipped }: EntrypointInfo,
 ): Promise<ContentScriptEntrypoint> {
   const { main: _, ...options } =
     await importEntrypointFile<ContentScriptDefinition>(inputPath, config);
@@ -421,6 +427,7 @@ async function getContentScriptEntrypoint(
     inputPath,
     outputDir: resolve(config.outDir, CONTENT_SCRIPT_OUT_DIR),
     options,
+    skipped,
   };
 }
 

--- a/src/core/utils/building/find-entrypoints.ts
+++ b/src/core/utils/building/find-entrypoints.ts
@@ -24,6 +24,7 @@ import {
 } from '~/core/utils/entrypoints';
 import { VIRTUAL_NOOP_BACKGROUND_MODULE_ID } from '~/core/utils/constants';
 import { CSS_EXTENSIONS_PATTERN } from '~/core/utils/paths';
+import pc from 'picocolors';
 
 /**
  * Return entrypoints and their configuration by looking through the project's files.
@@ -124,10 +125,8 @@ export async function findEntrypoints(
     .map((item) => item.name);
   if (skippedEntrypointNames.length) {
     config.logger.warn(
-      `The follow entrypoints is ignored after filtered:\n${skippedEntrypointNames
-        .map((item) => {
-          return `- ${item}`;
-        })
+      `Filter excluded the following entrypoints:\n${skippedEntrypointNames
+        .map((item) => `${pc.dim('-')} ${pc.cyan(item)}`)
         .join('\n')}`,
     );
   }

--- a/src/core/utils/building/get-internal-config.ts
+++ b/src/core/utils/building/get-internal-config.ts
@@ -72,7 +72,9 @@ export async function getInternalConfig(
     srcDir,
     mergedConfig.entrypointsDir ?? 'entrypoints',
   );
-  const filterEntrypoints = mergedConfig.filterEntrypoints;
+  const filterEntrypoints = !!mergedConfig.filterEntrypoints?.length
+    ? new Set(mergedConfig.filterEntrypoints)
+    : undefined;
   const publicDir = path.resolve(srcDir, mergedConfig.publicDir ?? 'public');
   const typesDir = path.resolve(wxtDir, 'types');
   const outBaseDir = path.resolve(root, mergedConfig.outDir ?? '.output');

--- a/src/core/utils/building/get-internal-config.ts
+++ b/src/core/utils/building/get-internal-config.ts
@@ -72,7 +72,7 @@ export async function getInternalConfig(
     srcDir,
     mergedConfig.entrypointsDir ?? 'entrypoints',
   );
-  const allowEntrypoints = mergedConfig.allowEntrypoints ?? true;
+  const filterEntrypoints = mergedConfig.filterEntrypoints;
   const publicDir = path.resolve(srcDir, mergedConfig.publicDir ?? 'public');
   const typesDir = path.resolve(wxtDir, 'types');
   const outBaseDir = path.resolve(root, mergedConfig.outDir ?? '.output');
@@ -102,7 +102,7 @@ export async function getInternalConfig(
     command,
     debug,
     entrypointsDir,
-    allowEntrypoints,
+    filterEntrypoints,
     env,
     fsCache: createFsCache(wxtDir),
     imports: mergedConfig.imports ?? {},
@@ -193,8 +193,8 @@ function mergeInlineConfig(
     configFile: inlineConfig.configFile,
     debug: inlineConfig.debug ?? userConfig.debug,
     entrypointsDir: inlineConfig.entrypointsDir ?? userConfig.entrypointsDir,
-    allowEntrypoints:
-      inlineConfig.allowEntrypoints ?? userConfig.allowEntrypoints,
+    filterEntrypoints:
+      inlineConfig.filterEntrypoints ?? userConfig.filterEntrypoints,
     imports,
     logger: inlineConfig.logger ?? userConfig.logger,
     manifest,

--- a/src/core/utils/building/get-internal-config.ts
+++ b/src/core/utils/building/get-internal-config.ts
@@ -72,6 +72,7 @@ export async function getInternalConfig(
     srcDir,
     mergedConfig.entrypointsDir ?? 'entrypoints',
   );
+  const allowEntrypoints = mergedConfig.allowEntrypoints ?? true;
   const publicDir = path.resolve(srcDir, mergedConfig.publicDir ?? 'public');
   const typesDir = path.resolve(wxtDir, 'types');
   const outBaseDir = path.resolve(root, mergedConfig.outDir ?? '.output');
@@ -101,6 +102,7 @@ export async function getInternalConfig(
     command,
     debug,
     entrypointsDir,
+    allowEntrypoints,
     env,
     fsCache: createFsCache(wxtDir),
     imports: mergedConfig.imports ?? {},
@@ -191,6 +193,8 @@ function mergeInlineConfig(
     configFile: inlineConfig.configFile,
     debug: inlineConfig.debug ?? userConfig.debug,
     entrypointsDir: inlineConfig.entrypointsDir ?? userConfig.entrypointsDir,
+    allowEntrypoints:
+      inlineConfig.allowEntrypoints ?? userConfig.allowEntrypoints,
     imports,
     logger: inlineConfig.logger ?? userConfig.logger,
     manifest,

--- a/src/core/utils/testing/fake-objects.ts
+++ b/src/core/utils/testing/fake-objects.ts
@@ -201,6 +201,7 @@ export const fakeInternalConfig = fakeObjectCreator<InternalConfig>(() => {
     browser,
     command,
     entrypointsDir: fakeDir(),
+    allowEntrypoints: true,
     env: { browser, command, manifestVersion, mode },
     fsCache: mock<FsCache>(),
     imports: {},

--- a/src/core/utils/testing/fake-objects.ts
+++ b/src/core/utils/testing/fake-objects.ts
@@ -73,6 +73,7 @@ export const fakeContentScriptEntrypoint =
       ]),
     },
     outputDir: fakeDir('.output'),
+    skipped: false,
   }));
 
 export const fakeBackgroundEntrypoint = fakeObjectCreator<BackgroundEntrypoint>(
@@ -85,6 +86,7 @@ export const fakeBackgroundEntrypoint = fakeObjectCreator<BackgroundEntrypoint>(
       type: faker.helpers.maybe(() => 'module'),
     },
     outputDir: fakeDir('.output'),
+    skipped: false,
   }),
 );
 
@@ -95,6 +97,7 @@ export const fakeUnlistedScriptEntrypoint =
     name: faker.string.alpha(),
     outputDir: fakeDir('.output'),
     options: {},
+    skipped: false,
   }));
 
 export const fakeOptionsEntrypoint = fakeObjectCreator<OptionsEntrypoint>(
@@ -108,6 +111,7 @@ export const fakeOptionsEntrypoint = fakeObjectCreator<OptionsEntrypoint>(
       chromeStyle: faker.helpers.arrayElement([true, false, undefined]),
       openInTab: faker.helpers.arrayElement([true, false, undefined]),
     },
+    skipped: false,
   }),
 );
 
@@ -134,6 +138,7 @@ export const fakePopupEntrypoint = fakeObjectCreator<PopupEntrypoint>(() => ({
       undefined,
     ]),
   },
+  skipped: false,
 }));
 
 export const fakeGenericEntrypoint = fakeObjectCreator<GenericEntrypoint>(
@@ -152,6 +157,7 @@ export const fakeGenericEntrypoint = fakeObjectCreator<GenericEntrypoint>(
     name: faker.string.alpha(),
     outputDir: fakeDir('.output'),
     options: {},
+    skipped: false,
   }),
 );
 

--- a/src/core/utils/testing/fake-objects.ts
+++ b/src/core/utils/testing/fake-objects.ts
@@ -59,7 +59,7 @@ export const fakeContentScriptEntrypoint =
     name: faker.string.alpha(),
     options: {
       matches: [],
-      matchAboutBlank: faker.helpers.arrayElement([true, false, undefined]),
+      matchAboutBlank: faker.datatype.boolean(),
       matchOriginAsFallback: faker.helpers.arrayElement([
         true,
         false,
@@ -73,7 +73,7 @@ export const fakeContentScriptEntrypoint =
       ]),
     },
     outputDir: fakeDir('.output'),
-    skipped: false,
+    skipped: faker.datatype.boolean(),
   }));
 
 export const fakeBackgroundEntrypoint = fakeObjectCreator<BackgroundEntrypoint>(
@@ -82,11 +82,11 @@ export const fakeBackgroundEntrypoint = fakeObjectCreator<BackgroundEntrypoint>(
     inputPath: 'entrypoints/background.ts',
     name: 'background',
     options: {
-      persistent: faker.helpers.arrayElement([true, false, undefined]),
+      persistent: faker.datatype.boolean(),
       type: faker.helpers.maybe(() => 'module'),
     },
     outputDir: fakeDir('.output'),
-    skipped: false,
+    skipped: faker.datatype.boolean(),
   }),
 );
 
@@ -97,7 +97,7 @@ export const fakeUnlistedScriptEntrypoint =
     name: faker.string.alpha(),
     outputDir: fakeDir('.output'),
     options: {},
-    skipped: false,
+    skipped: faker.datatype.boolean(),
   }));
 
 export const fakeOptionsEntrypoint = fakeObjectCreator<OptionsEntrypoint>(
@@ -107,11 +107,11 @@ export const fakeOptionsEntrypoint = fakeObjectCreator<OptionsEntrypoint>(
     name: 'options',
     outputDir: fakeDir('.output'),
     options: {
-      browserStyle: faker.helpers.arrayElement([true, false, undefined]),
-      chromeStyle: faker.helpers.arrayElement([true, false, undefined]),
-      openInTab: faker.helpers.arrayElement([true, false, undefined]),
+      browserStyle: faker.datatype.boolean(),
+      chromeStyle: faker.datatype.boolean(),
+      openInTab: faker.datatype.boolean(),
     },
-    skipped: false,
+    skipped: faker.datatype.boolean(),
   }),
 );
 
@@ -138,7 +138,7 @@ export const fakePopupEntrypoint = fakeObjectCreator<PopupEntrypoint>(() => ({
       undefined,
     ]),
   },
-  skipped: false,
+  skipped: faker.datatype.boolean(),
 }));
 
 export const fakeGenericEntrypoint = fakeObjectCreator<GenericEntrypoint>(
@@ -157,7 +157,7 @@ export const fakeGenericEntrypoint = fakeObjectCreator<GenericEntrypoint>(
     name: faker.string.alpha(),
     outputDir: fakeDir('.output'),
     options: {},
-    skipped: false,
+    skipped: faker.datatype.boolean(),
   }),
 );
 

--- a/src/core/utils/testing/fake-objects.ts
+++ b/src/core/utils/testing/fake-objects.ts
@@ -201,7 +201,6 @@ export const fakeInternalConfig = fakeObjectCreator<InternalConfig>(() => {
     browser,
     command,
     entrypointsDir: fakeDir(),
-    filterEntrypoints: true,
     env: { browser, command, manifestVersion, mode },
     fsCache: mock<FsCache>(),
     imports: {},

--- a/src/core/utils/testing/fake-objects.ts
+++ b/src/core/utils/testing/fake-objects.ts
@@ -201,7 +201,7 @@ export const fakeInternalConfig = fakeObjectCreator<InternalConfig>(() => {
     browser,
     command,
     entrypointsDir: fakeDir(),
-    allowEntrypoints: true,
+    filterEntrypoints: true,
     env: { browser, command, manifestVersion, mode },
     fsCache: mock<FsCache>(),
     imports: {},

--- a/src/types/external.ts
+++ b/src/types/external.ts
@@ -381,6 +381,7 @@ export interface BaseEntrypoint {
    */
   outputDir: string;
   options: BaseEntrypointOptions;
+  skipped: boolean;
 }
 
 export interface GenericEntrypoint extends BaseEntrypoint {

--- a/src/types/external.ts
+++ b/src/types/external.ts
@@ -32,6 +32,12 @@ export interface InlineConfig {
    */
   entrypointsDir?: string;
   /**
+   * Specify allow entrypoints, default allow all entrypoints
+   *
+   * @default true
+   */
+  allowEntrypoints?: true | string[];
+  /**
    * Output directory that stored build folders and ZIPs.
    *
    * @default ".output"

--- a/src/types/external.ts
+++ b/src/types/external.ts
@@ -32,11 +32,9 @@ export interface InlineConfig {
    */
   entrypointsDir?: string;
   /**
-   * Specify allow entrypoints, default allow all entrypoints
-   *
-   * @default true
+   * Custom allowed entrypoints, default allow all entrypoints
    */
-  allowEntrypoints?: true | string[];
+  filterEntrypoints?: string[];
   /**
    * Output directory that stored build folders and ZIPs.
    *

--- a/src/types/external.ts
+++ b/src/types/external.ts
@@ -32,7 +32,9 @@ export interface InlineConfig {
    */
   entrypointsDir?: string;
   /**
-   * Custom allowed entrypoints, default allow all entrypoints
+   * A list of entrypoint names (`"popup"`, `"options"`, etc.) to build. Will speed up the build if
+   * your extension has lots of entrypoints, and you don't need to build all of them to develop a
+   * feature.
    */
   filterEntrypoints?: string[];
   /**

--- a/src/types/internal.ts
+++ b/src/types/internal.ts
@@ -21,7 +21,7 @@ export interface InternalConfig {
   wxtDir: string;
   typesDir: string;
   entrypointsDir: string;
-  allowEntrypoints: true | string[];
+  filterEntrypoints?: string[];
   outBaseDir: string;
   outDir: string;
   debug: boolean;

--- a/src/types/internal.ts
+++ b/src/types/internal.ts
@@ -21,6 +21,7 @@ export interface InternalConfig {
   wxtDir: string;
   typesDir: string;
   entrypointsDir: string;
+  allowEntrypoints: true | string[];
   outBaseDir: string;
   outDir: string;
   debug: boolean;

--- a/src/types/internal.ts
+++ b/src/types/internal.ts
@@ -21,7 +21,7 @@ export interface InternalConfig {
   wxtDir: string;
   typesDir: string;
   entrypointsDir: string;
-  filterEntrypoints?: string[];
+  filterEntrypoints?: Set<string>;
   outBaseDir: string;
   outDir: string;
   debug: boolean;


### PR DESCRIPTION
ref: https://github.com/wxt-dev/wxt/issues/330

Add a simple test case and passed, but I found that test cases of `src/core/utils/building/__tests__/find-entrypoints.test.ts` seems outdated, not only caused by my changes:

![image](https://github.com/wxt-dev/wxt/assets/18096089/00c9c936-dcce-4a43-9950-2ba786281e15)
