### PR TITLE
fix: Improve error message and document use of imported variables outside an entrypoint's `main` function

### DIFF
--- a/docs/guide/entrypoints.md
+++ b/docs/guide/entrypoints.md
@@ -86,3 +86,56 @@ export default defineContentScript({
 :::info
 For a full list of entrypoints and each of their options, see the [`/entrypoints` folder](/entrypoints/background) documentation.
 :::
+
+### Side Effects
+
+You cannot use imported variables outside the `main` function is JS entrypoints. This includes options, as shown below:
+
+```ts
+// entrypoints/content.ts
+import { GOOGLE_MATCHES } from '~/utils/match-patterns';
+
+export default defineContentScript({
+  matches: GOOGLE_MATCHES,
+  main() {
+    // ...
+  },
+});
+```
+
+```
+$ wxt build
+wxt build
+
+WXT 0.14.1
+ℹ Building chrome-mv3 for production with Vite 5.0.5
+✖ Command failed after 360 ms
+
+[8:55:54 AM]  ERROR  entrypoints/content.ts: Cannot use imported variable "GOOGLE_MATCHES" before main function. See https://wxt.dev/guide/entrypoints.html#side-effects
+```
+
+This throws an error because WXT needs to import each entrypoint during the build process to extract its definition (containing the `match`, `run_at`, `include`/`exclude`, etc.) to render the `manifest.json` correctly. Before loading an entrypoint, a transformation is applied to remove all imports. This prevents imported modules (local or NPM) with side-effects from running during the build process, potentially throwing an error.
+
+:::details Why?
+
+When importing your entrypoint to get its definition, the file is imported in a **_node environement_**, and doesn't have access to the `window`, `chrome`, or `browser` globals a web extension ususally has access to. If WXT doesn't remove all the imports from the file, the imported modules could try and access one of these variables, throwing an error.
+
+:::
+
+:::warning
+See [`wxt-dev/wxt#336`](https://github.com/wxt-dev/wxt/issues/336) to track the status of this bug.
+:::
+
+Usually, this error occurs when you try to extract options into a shared file or try to run code outside the `main` function. To fix the example from above, use litteral values when defining an entrypoint instead of importing them:
+
+```ts
+import { GOOGLE_MATCHES } from '~/utils/match-patterns'; // [!code --]
+
+export default defineContentScript({
+  matches: GOOGLE_MATCHES, // [!code --]
+  matches: ['*//*.google.com/*'], // [!code ++]
+  main() {
+    // ...
+  },
+});
+```

--- a/src/core/utils/__tests__/test-entrypoints/imported-option.ts
+++ b/src/core/utils/__tests__/test-entrypoints/imported-option.ts
@@ -1,0 +1,7 @@
+import { defineContentScript } from '~/sandbox';
+import { faker } from '@faker-js/faker';
+
+export default defineContentScript({
+  matches: [faker.string.nanoid()],
+  main() {},
+});

--- a/src/core/utils/building/__tests__/import-entrypoint.test.ts
+++ b/src/core/utils/building/__tests__/import-entrypoint.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 import { importEntrypointFile } from '~/core/utils/building';
 import { fakeInternalConfig } from '~/core/utils/testing/fake-objects';
 import { resolve } from 'node:path';
+import { unnormalizePath } from '../../paths';
 
 const entrypointPath = (filename: string) =>
   resolve('src/core/utils/__tests__/test-entrypoints', filename);
@@ -40,10 +41,13 @@ describe('importEntrypointFile', () => {
   });
 
   it('should throw a custom error message when an imported variable is used before main', async () => {
+    const filePath = unnormalizePath(
+      '../src/core/utils/__tests__/test-entrypoints/imported-option.ts',
+    );
     await expect(() =>
       importEntrypointFile(entrypointPath('imported-option.ts'), config),
     ).rejects.toThrowErrorMatchingInlineSnapshot(
-      `[Error: ../src/core/utils/__tests__/test-entrypoints/imported-option.ts: Cannot use imported variable "faker" outside the main function. See https://wxt.dev/guide/entrypoints.html#side-effects]`,
+      `[Error: ${filePath}: Cannot use imported variable "faker" outside the main function. See https://wxt.dev/guide/entrypoints.html#side-effects]`,
     );
   });
 });

--- a/src/core/utils/building/__tests__/import-entrypoint.test.ts
+++ b/src/core/utils/building/__tests__/import-entrypoint.test.ts
@@ -38,4 +38,12 @@ describe('importEntrypointFile', () => {
 
     expect(actual).toBeUndefined();
   });
+
+  it('should throw a custom error message when an imported variable is used before main', async () => {
+    await expect(() =>
+      importEntrypointFile(entrypointPath('imported-option.ts'), config),
+    ).rejects.toThrowErrorMatchingInlineSnapshot(
+      `[Error: ../src/core/utils/__tests__/test-entrypoints/imported-option.ts: Cannot use imported variable "faker" outside the main function. See https://wxt.dev/guide/entrypoints.html#side-effects]`,
+    );
+  });
 });


### PR DESCRIPTION
This closes #345. Doesn't fix the underlying issue, but improves the error message and updates the documentation to talk about the bug.

###### Before

```
WXT 0.14.1                                                                                                             9:27:53 AM
ℹ Building chrome-mv3 for production with Vite 5.0.5                                                                  9:27:54 AM
✖ Command failed after 559 ms                                                                                         9:27:54 AM

[9:27:54 AM]  ERROR  logId is not defined

  at importEntrypointFile (/Users/aklinker1/Development/github.com/wxt-dev/wxt/dist/cli.js:1792:13)
  at async getContentScriptEntrypoint (/Users/aklinker1/Development/github.com/wxt-dev/wxt/dist/cli.js:451:35)
  at async /Users/aklinker1/Development/github.com/wxt-dev/wxt/dist/cli.js:230:18
  at async Promise.all (index 5)
  at async findEntrypoints (/Users/aklinker1/Development/github.com/wxt-dev/wxt/dist/cli.js:218:23)
  at async internalBuild (/Users/aklinker1/Development/github.com/wxt-dev/wxt/dist/cli.js:2510:23)
  at async build (/Users/aklinker1/Development/github.com/wxt-dev/wxt/dist/cli.js:2545:10)
  at async /Users/aklinker1/Development/github.com/wxt-dev/wxt/dist/cli.js:3077:5
  at async CAC.<anonymous> (/Users/aklinker1/Development/github.com/wxt-dev/wxt/dist/cli.js:3138:22)
```

###### After

```
WXT 0.14.1                                                                                                             9:27:53 AM
ℹ Building chrome-mv3 for production with Vite 5.0.5                                                                  9:27:54 AM
✖ Command failed after 559 ms                                                                                         9:27:54 AM

[9:27:54 AM]  ERROR  src/entrypoints/iframe.content.ts: Cannot use imported variable "logId" outside the main function. See https://wxt.dev/guide/entrypoints.html#side-effects

  at importEntrypointFile (/Users/aklinker1/Development/github.com/wxt-dev/wxt/dist/cli.js:1792:13)
  at async getContentScriptEntrypoint (/Users/aklinker1/Development/github.com/wxt-dev/wxt/dist/cli.js:451:35)
  at async /Users/aklinker1/Development/github.com/wxt-dev/wxt/dist/cli.js:230:18
  at async Promise.all (index 5)
  at async findEntrypoints (/Users/aklinker1/Development/github.com/wxt-dev/wxt/dist/cli.js:218:23)
  at async internalBuild (/Users/aklinker1/Development/github.com/wxt-dev/wxt/dist/cli.js:2510:23)
  at async build (/Users/aklinker1/Development/github.com/wxt-dev/wxt/dist/cli.js:2545:10)
  at async /Users/aklinker1/Development/github.com/wxt-dev/wxt/dist/cli.js:3077:5
  at async CAC.<anonymous> (/Users/aklinker1/Development/github.com/wxt-dev/wxt/dist/cli.js:3138:22)
```

