### PR TITLE
fix: Allow `browser.runtime.getURL` to include hashes and query params for HTML paths

### DIFF
--- a/demo/src/entrypoints/background.ts
+++ b/demo/src/entrypoints/background.ts
@@ -15,6 +15,10 @@ export default defineBackground(() => {
   browser.runtime.getURL('/');
   browser.runtime.getURL('/background.js');
   browser.runtime.getURL('/icon/128.png');
+  browser.runtime.getURL('/example.html#hash');
+  browser.runtime.getURL('/example.html?query=param');
+  // @ts-expect-error: should only allow hashes/query params on HTML files
+  browser.runtime.getURL('/icon-128.png?query=param');
 
   // @ts-expect-error: should only accept known message names
   browser.i18n.getMessage('test');

--- a/e2e/tests/typescript-project.test.ts
+++ b/e2e/tests/typescript-project.test.ts
@@ -49,8 +49,10 @@ describe('TypeScript Project', () => {
           | "/options.html"
           | "/popup.html"
           | "/sandbox.html"
+        type HtmlPublicPath = Extract<PublicPath, \`\${string}.html\`>
         export interface WxtRuntime extends Runtime.Static {
           getURL(path: PublicPath): string;
+          getURL(path: \`\${HtmlPublicPath}\${string}\`): string;
         }
       }
       "

--- a/src/core/utils/building/generate-wxt-dir.ts
+++ b/src/core/utils/building/generate-wxt-dir.ts
@@ -79,8 +79,10 @@ import "wxt/browser";
 declare module "wxt/browser" {
   export type PublicPath =
 {{ union }}
+  type HtmlPublicPath = Extract<PublicPath, \`\${string}.html\`>
   export interface WxtRuntime extends Runtime.Static {
     getURL(path: PublicPath): string;
+    getURL(path: \`\${HtmlPublicPath}\${string}\`): string;
   }
 }
 `;


### PR DESCRIPTION
This closes #349 