### PR TITLE
feat: Add `dev.reloadCommand` config

### DIFF
--- a/demo/wxt.config.ts
+++ b/demo/wxt.config.ts
@@ -15,4 +15,7 @@ export default defineConfig({
   alias: {
     public: 'src/public',
   },
+  dev: {
+    reloadCommand: 'Ctrl+E',
+  },
 });

--- a/demo/wxt.config.ts
+++ b/demo/wxt.config.ts
@@ -15,7 +15,4 @@ export default defineConfig({
   alias: {
     public: 'src/public',
   },
-  dev: {
-    reloadCommand: 'Ctrl+E',
-  },
 });

--- a/src/core/utils/__tests__/manifest.test.ts
+++ b/src/core/utils/__tests__/manifest.test.ts
@@ -965,6 +965,7 @@ describe('Manifest Utils', () => {
     describe('commands', () => {
       const reloadCommandName = 'wxt:reload-extension';
       const reloadCommand = {
+        description: expect.any(String),
         suggested_key: {
           default: 'Alt+R',
         },
@@ -981,9 +982,54 @@ describe('Manifest Utils', () => {
           config,
         );
 
-        expect(actual.commands).toMatchObject({
+        expect(actual.commands).toEqual({
           [reloadCommandName]: reloadCommand,
         });
+      });
+
+      it('should customize the reload commands key binding if passing a custom command', async () => {
+        const config = fakeInternalConfig({
+          command: 'serve',
+          dev: {
+            reloadCommand: 'Ctrl+E',
+          },
+        });
+        const output = fakeBuildOutput();
+        const entrypoints = fakeArray(fakeEntrypoint);
+
+        const { manifest: actual } = await generateManifest(
+          entrypoints,
+          output,
+          config,
+        );
+
+        expect(actual.commands).toEqual({
+          [reloadCommandName]: {
+            ...reloadCommand,
+            suggested_key: {
+              default: 'Ctrl+E',
+            },
+          },
+        });
+      });
+
+      it("should not include the reload command when it's been disabled", async () => {
+        const config = fakeInternalConfig({
+          command: 'serve',
+          dev: {
+            reloadCommand: false,
+          },
+        });
+        const output = fakeBuildOutput();
+        const entrypoints = fakeArray(fakeEntrypoint);
+
+        const { manifest: actual } = await generateManifest(
+          entrypoints,
+          output,
+          config,
+        );
+
+        expect(actual.commands).toBeUndefined();
       });
 
       it('should not override any existing commands when adding the one to reload the extension', async () => {
@@ -1006,7 +1052,7 @@ describe('Manifest Utils', () => {
           config,
         );
 
-        expect(actual.commands).toMatchObject({
+        expect(actual.commands).toEqual({
           [reloadCommandName]: reloadCommand,
           [customCommandName]: customCommand,
         });

--- a/src/core/utils/building/get-internal-config.ts
+++ b/src/core/utils/building/get-internal-config.ts
@@ -79,6 +79,7 @@ export async function getInternalConfig(
   const typesDir = path.resolve(wxtDir, 'types');
   const outBaseDir = path.resolve(root, mergedConfig.outDir ?? '.output');
   const outDir = path.resolve(outBaseDir, `${browser}-mv${manifestVersion}`);
+  const reloadCommand = mergedConfig.dev?.reloadCommand ?? 'Alt+R';
 
   const runnerConfig = await loadConfig<ExtensionRunnerConfig>({
     name: 'web-ext',
@@ -136,6 +137,9 @@ export async function getInternalConfig(
         mergedConfig.experimental?.includeBrowserPolyfill ?? true,
     },
     server,
+    dev: {
+      reloadCommand,
+    },
   };
 
   const builder = await createViteBuilder(
@@ -221,6 +225,10 @@ function mergeInlineConfig(
     },
     vite: undefined,
     transformManifest: undefined,
+    dev: {
+      ...userConfig.dev,
+      ...inlineConfig.dev,
+    },
   };
 }
 

--- a/src/core/utils/manifest.ts
+++ b/src/core/utils/manifest.ts
@@ -84,7 +84,7 @@ export async function generateManifest(
   ) as Manifest.WebExtensionManifest;
 
   // Add reload command in dev mode
-  if (config.command === 'serve') {
+  if (config.command === 'serve' && config.dev.reloadCommand) {
     if (manifest.commands && Object.keys(manifest.commands).length >= 4) {
       warnings.push([
         "Extension already has 4 registered commands, WXT's reload command is disabled",
@@ -94,7 +94,7 @@ export async function generateManifest(
       manifest.commands['wxt:reload-extension'] = {
         description: 'Reload the extension during development',
         suggested_key: {
-          default: 'Alt+R',
+          default: config.dev.reloadCommand,
         },
       };
     }

--- a/src/core/utils/testing/fake-objects.ts
+++ b/src/core/utils/testing/fake-objects.ts
@@ -244,6 +244,9 @@ export const fakeInternalConfig = fakeObjectCreator<InternalConfig>(() => {
       includeBrowserPolyfill: true,
     },
     builder: mock(),
+    dev: {
+      reloadCommand: 'Alt+R',
+    },
   };
 });
 

--- a/src/types/external.ts
+++ b/src/types/external.ts
@@ -229,6 +229,24 @@ export interface InlineConfig {
      */
     includeBrowserPolyfill?: boolean;
   };
+  /**
+   * Config effecting dev mode only.
+   */
+  dev?: {
+    /**
+     * Controls whether a custom keyboard shortcut command, `Alt+R`, is added during dev mode to
+     * quickly reload the extension.
+     *
+     * If false, the shortcut is not added during development.
+     *
+     * If set to a custom string, you can override the key combo used. See
+     * [Chrome's command docs](https://developer.chrome.com/docs/extensions/reference/api/commands)
+     * for available options.
+     *
+     * @default "Alt+R"
+     */
+    reloadCommand?: string | false;
+  };
 }
 
 // TODO: Extract to @wxt/vite-builder and use module augmentation to include the vite field

--- a/src/types/internal.ts
+++ b/src/types/internal.ts
@@ -57,6 +57,9 @@ export interface InternalConfig {
     includeBrowserPolyfill: boolean;
   };
   builder: WxtBuilder;
+  dev: {
+    reloadCommand: string | false;
+  };
 }
 
 export interface FsCache {


### PR DESCRIPTION
You can disable the reload command by setting the value to `false`, or customize the key binding by setting it to a custom string.

This closes #358 