### PR TITLE
feat: Restart dev mode when saving config

### DIFF
--- a/src/core/builders/vite/index.ts
+++ b/src/core/builders/vite/index.ts
@@ -230,6 +230,9 @@ export async function createViteBuilder(
         async listen() {
           await viteServer.listen(info.port);
         },
+        async close() {
+          await viteServer.close();
+        },
         transformHtml(...args) {
           return viteServer.transformIndexHtml(...args);
         },

--- a/src/core/create-server.ts
+++ b/src/core/create-server.ts
@@ -184,7 +184,7 @@ function createFileReloader(options: {
         return;
       }
 
-      if (changes.type === 'restart-browser') {
+      if (changes.type === 'browser-restart') {
         config.logger.info('Runner config changed, restarting browser...');
         server.restartBrowser();
         return;

--- a/src/core/runners/web-ext.ts
+++ b/src/core/runners/web-ext.ts
@@ -1,5 +1,6 @@
 import type { WebExtRunInstance } from 'web-ext-run';
 import { ExtensionRunner } from '~/types';
+import { formatDuration } from '../utils/time';
 
 /**
  * Create an `ExtensionRunner` backed by `web-ext`.
@@ -9,7 +10,7 @@ export function createWebExtRunner(): ExtensionRunner {
 
   return {
     async openBrowser(config) {
-      config.logger.info('Opening browser...');
+      const startTime = Date.now();
 
       if (config.browser === 'firefox' && config.manifestVersion === 3) {
         throw Error(
@@ -17,7 +18,7 @@ export function createWebExtRunner(): ExtensionRunner {
         );
       }
 
-      // Use the plugin's logger instead of web-ext's built-in one.
+      // Use WXT's logger instead of web-ext's built-in one.
       const webExtLogger = await import('web-ext-run/util/logger');
       webExtLogger.consoleStream.write = ({ level, msg, name }) => {
         if (level >= ERROR_LOG_LEVEL) config.logger.error(name, msg);
@@ -61,7 +62,8 @@ export function createWebExtRunner(): ExtensionRunner {
       const webExt = await import('web-ext-run');
       runner = await webExt.default.cmd.run(finalConfig, options);
 
-      config.logger.success('Opened!');
+      const duration = Date.now() - startTime;
+      config.logger.success(`Opened browser in ${formatDuration(duration)}`);
     },
 
     async closeBrowser() {

--- a/src/core/utils/__tests__/arrays.test.ts
+++ b/src/core/utils/__tests__/arrays.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { every } from '~/core/utils/arrays';
+import { every, some } from '~/core/utils/arrays';
 
 describe('Array Utils', () => {
   describe('every', () => {
@@ -13,6 +13,22 @@ describe('Array Utils', () => {
 
     it("should return false when a single item predicate's return false", () => {
       expect(every([1, 2, 1], (item) => item === 1)).toBe(false);
+    });
+  });
+
+  describe('some', () => {
+    it('should return true if one value returns true', () => {
+      const array = [1, 2, 3];
+      const predicate = (item: number) => item === 2;
+
+      expect(some(array, predicate)).toBe(true);
+    });
+
+    it('should return false if no values match', () => {
+      const array = [1, 2, 3];
+      const predicate = (item: number) => item === 4;
+
+      expect(some(array, predicate)).toBe(false);
     });
   });
 });

--- a/src/core/utils/arrays.ts
+++ b/src/core/utils/arrays.ts
@@ -9,3 +9,15 @@ export function every<T>(
     if (!predicate(array[i], i)) return false;
   return true;
 }
+
+/**
+ * Returns true when any of the predicates return true;
+ */
+export function some<T>(
+  array: T[],
+  predicate: (item: T, index: number) => boolean,
+): boolean {
+  for (let i = 0; i < array.length; i++)
+    if (predicate(array[i], i)) return true;
+  return false;
+}

--- a/src/core/utils/building/detect-dev-changes.ts
+++ b/src/core/utils/building/detect-dev-changes.ts
@@ -151,7 +151,7 @@ export type DevModeChange =
   | ExtensionReload
   | ContentScriptReload
   | FullRestart
-  | RestartBrowser;
+  | BrowserRestart;
 
 interface NoChange {
   type: 'no-change';
@@ -172,7 +172,7 @@ interface FullRestart {
   type: 'full-restart';
 }
 
-interface RestartBrowser {
+interface BrowserRestart {
   type: 'restart-browser';
 }
 

--- a/src/core/utils/building/detect-dev-changes.ts
+++ b/src/core/utils/building/detect-dev-changes.ts
@@ -6,7 +6,7 @@ import {
   OutputAsset,
   OutputFile,
 } from '~/types';
-import { every } from '~/core/utils/arrays';
+import { every, some } from '~/core/utils/arrays';
 import { normalizePath } from '~/core/utils/paths';
 
 /**
@@ -34,15 +34,17 @@ export function detectDevChanges(
   changedFiles: string[],
   currentOutput: BuildOutput,
 ): DevModeChange {
-  const isConfigChange = changedFiles.some(
+  const isConfigChange = some(
+    changedFiles,
     (file) => file === config.userConfigMetadata.configFile,
   );
   if (isConfigChange) return { type: 'full-restart' };
 
-  const isRunnerChange = changedFiles.some(
+  const isRunnerChange = some(
+    changedFiles,
     (file) => file === config.runnerConfig.configFile,
   );
-  if (isRunnerChange) return { type: 'restart-browser' };
+  if (isRunnerChange) return { type: 'browser-restart' };
 
   const changedSteps = new Set(
     changedFiles.flatMap((changedFile) =>
@@ -79,7 +81,7 @@ export function detectDevChanges(
 
   const isOnlyHtmlChanges =
     changedFiles.length > 0 &&
-    every(changedFiles, ([_, file]) => file.endsWith('.html'));
+    every(changedFiles, (file) => file.endsWith('.html'));
   if (isOnlyHtmlChanges) {
     return {
       type: 'html-reload',
@@ -173,7 +175,7 @@ interface FullRestart {
 }
 
 interface BrowserRestart {
-  type: 'restart-browser';
+  type: 'browser-restart';
 }
 
 interface HtmlReload extends RebuildChange {

--- a/src/core/utils/building/detect-dev-changes.ts
+++ b/src/core/utils/building/detect-dev-changes.ts
@@ -39,6 +39,11 @@ export function detectDevChanges(
   );
   if (isConfigChange) return { type: 'full-restart' };
 
+  const isRunnerChange = changedFiles.some(
+    (file) => file === config.runnerConfig.configFile,
+  );
+  if (isRunnerChange) return { type: 'restart-browser' };
+
   const changedSteps = new Set(
     changedFiles.flatMap((changedFile) =>
       findEffectedSteps(changedFile, currentOutput),
@@ -145,7 +150,8 @@ export type DevModeChange =
   | HtmlReload
   | ExtensionReload
   | ContentScriptReload
-  | FullRestart;
+  | FullRestart
+  | RestartBrowser;
 
 interface NoChange {
   type: 'no-change';
@@ -164,6 +170,10 @@ interface RebuildChange {
 
 interface FullRestart {
   type: 'full-restart';
+}
+
+interface RestartBrowser {
+  type: 'restart-browser';
 }
 
 interface HtmlReload extends RebuildChange {

--- a/src/types/external.ts
+++ b/src/types/external.ts
@@ -308,7 +308,7 @@ export interface BuildStepOutput {
 }
 
 export interface WxtDevServer
-  extends Omit<WxtBuilderServer, 'listen'>,
+  extends Omit<WxtBuilderServer, 'listen' | 'close'>,
     ServerInfo {
   /**
    * Stores the current build output of the server.
@@ -318,6 +318,16 @@ export interface WxtDevServer
    * Start the server.
    */
   start(): Promise<void>;
+  /**
+   * Stop the server.
+   */
+  stop(): Promise<void>;
+  /**
+   * Close the browser, stop the server, rebuild the entire extension, and start the server again.
+   *
+   * The new server is returned.
+   */
+  restart(): Promise<WxtDevServer>;
   /**
    * Transform the HTML for dev mode.
    */
@@ -692,6 +702,10 @@ export interface WxtBuilderServer {
    * Start the server.
    */
   listen(): Promise<void>;
+  /**
+   * Stop the server.
+   */
+  close(): Promise<void>;
   /**
    * Transform the HTML for dev mode.
    */

--- a/src/types/external.ts
+++ b/src/types/external.ts
@@ -313,7 +313,7 @@ export interface WxtDevServer
   /**
    * Stores the current build output of the server.
    */
-  currentOutput: BuildOutput;
+  currentOutput: BuildOutput | undefined;
   /**
    * Start the server.
    */
@@ -324,10 +324,8 @@ export interface WxtDevServer
   stop(): Promise<void>;
   /**
    * Close the browser, stop the server, rebuild the entire extension, and start the server again.
-   *
-   * The new server is returned.
    */
-  restart(): Promise<WxtDevServer>;
+  restart(): Promise<void>;
   /**
    * Transform the HTML for dev mode.
    */
@@ -360,6 +358,10 @@ export interface WxtDevServer
   reloadContentScript: (
     contentScript: Omit<Scripting.RegisteredContentScript, 'id'>,
   ) => void;
+  /**
+   * Grab the latest runner config and restart the browser.
+   */
+  restartBrowser: () => void;
 }
 
 export type TargetBrowser = string;


### PR DESCRIPTION
This closes #16 

- [x] Restart server on config change
   - [x] Refactor server so restart doesn't return a new server object
- [x] Reload browser on runner config file change