### PR TITLE
feat: Add `submit` command

### DIFF
--- a/docs/guide/publishing.md
+++ b/docs/guide/publishing.md
@@ -1,94 +1,66 @@
+---
+outline: deep
+---
+
 # Publishing
 
-WXT offers several utilities that simplify the publishing process.
+WXT will help you ZIP your extensions and submit them to the stores for review.
 
 ## First Time Publishing
 
-If you're publishing an extension to a store for the first time, you must manually navigate the process. Each store has unique steps and requirements that you need to familiarize yourself with.
+If you're publishing an extension to a store for the first time, you must manually navigate the process. WXT doesn't help you create listings, each store has unique steps and requirements that you need to familiarize yourself with.
 
-Each store requires that a ZIP file be uploaded. You can generate these using the `wxt zip` command:
+For specific details about each store, see the stores sections below.
+
+- [Chrome Web Store](#chrome-web-store)
+- [Firefox Addon Store](#firefox-addon-store)
+- [Edge Addons](#edge-addons)
+
+## Automation
+
+WXT provides two commands to help automate the release process:
+
+- `wxt submit`: Submit new versions of your extension for review (and publish them automatically once approved)
+- `wxt submit init`: Help setup all the required secrets and options for the `wxt submit` command
+
+To get started, run `wxt submit init` and follow the prompts. Once finished, you should have a `.env.submit` file! WXT will use this file to submit your updates.
+
+> In CI, make sure you add all the environment variables to the submit step.
+
+To release an update, build all the ZIPs you plan on releasing:
 
 ```sh
 wxt zip
 wxt zip -b firefox
-# etc
 ```
 
-Generated ZIP files are stored in the `.output` directory.
+Then run the `wxt submit` command, passing in all the ZIP files you want to release. In this case, we'll do a release for all 3 major stores: Chrome Web Store, Edge Addons, and Firefox Addons Store.
 
-## Automation
+If it's your first time running the command, you'll want to test your secrets by passing the `--dry-run` flag:
 
-To automate releasing updates, use the [`publish-browser-extension`](https://www.npmjs.com/package/publish-browser-extension) package.
+```sh
+wxt submit --dry-run \
+  --chrome-zip .output/<your-extension>-<version>-chrome.zip \
+  --firefox-zip .output/<your-extension>-<version>-firefox.zip --firefox-sources-zip .output/<your-extension>-<version>-sources.zip \
+  --edge-zip .output/<your-extension>-<version>-chrome.zip
+```
 
-:::info
-🚧 WXT plans to eventually incorporate the `publish-browser-extension` package into its own `wxt submit` command.
+If the dry run passes, remove the flag and do the actual release:
+
+```sh
+wxt submit \
+  --chrome-zip .output/<your-extension>-<version>-chrome.zip \
+  --firefox-zip .output/<your-extension>-<version>-firefox.zip --firefox-sources-zip .output/<your-extension>-<version>-sources.zip \
+  --edge-zip .output/<your-extension>-<version>-chrome.zip
+```
+
+:::tip
+If you only need to release to a single store, only pass that store's ZIP flag.
 :::
 
-1. Install the necessary dependencies:
-
-   ```sh
-   pnpm add -D publish-browser-extension env-cmd
-   ```
-
-2. Add scripts to your `package.json` file:
-
-   ```json
-   {
-     "scripts": {
-       "submit": "env-cmd -f .env.submit -- publish-extension",
-       "submit:dry": "env-cmd -f .env.submit -- publish-extension --dry-run"
-     }
-   }
-   ```
-
-3. Create a `.env.submit` file and include the code below. If you're not publishing to certain stores, simply ignore their respective variables.
-
-   ```txt
-   CHROME_EXTENSION_ID=""
-   CHROME_CLIENT_ID=""
-   CHROME_CLIENT_SECRET=""
-   CHROME_REFRESH_TOKEN=""
-
-   FIREFOX_EXTENSION_ID=""
-   FIREFOX_JWT_ISSUER=""
-   FIREFOX_JWT_SECRET=""
-
-   EDGE_PRODUCT_ID=""
-   EDGE_CLIENT_ID=""
-   EDGE_CLIENT_SECRET=""
-   EDGE_ACCESS_TOKEN_URL=""
-   ```
-
-   > Each value will be filled in during the next step.
-
-4. Run `npx publish-extension --help` for assistance with filling out all the values. Insert the obtained values within the double quotes.
-
-5. ZIP all the targets you plan to publish, in this case Chrome and Firefox.
-
-   ```sh
-   wxt zip
-   wxt zip -b firefox
-   ```
-
-6. Test your credentials by running the `submit:dry` command:
-
-   ```sh
-   pnpm submit:dry \
-     --chrome-zip .output/your-extension-X.Y.Z-chrome.zip \
-     --firefox-zip .output/your-extension-X.Y.Z-firefox.zip \
-     --firefox-sources-zip .output/your-extension-X.Y.Z-sources.zip \
-     --edge-zip .output/your-extension-X.Y.Z-chrome.zip
-   ```
-
-7. Upload and submit your extension for review:
-
-   ```sh
-   pnpm submit \
-     --chrome-zip .output/your-extension-X.Y.Z-chrome.zip \
-     --firefox-zip .output/your-extension-X.Y.Z-firefox.zip \
-     --firefox-sources-zip .output/your-extension-X.Y.Z-sources.zip \
-     --edge-zip .output/your-extension-X.Y.Z-chrome.zip
-   ```
+:::tip
+See the [Firefox Addon Store](#firefox-addon-store) section for more details about the `--firefox-sources-zip` option.
+:::
 
 ## GitHub Action
 
@@ -98,9 +70,11 @@ Here's an example of a GitHub Action to automate submiting new versions of your 
 # TODO
 ```
 
-## Chrome Web Store
+## Stores
 
-✅ Automated &bull; [Developer Dashboard](https://chrome.google.com/webstore/developer/dashboard) &bull; [Publishing Docs](https://developer.chrome.com/docs/webstore/publish/)
+### Chrome Web Store
+
+> ✅ Supported &bull; [Developer Dashboard](https://chrome.google.com/webstore/developer/dashboard) &bull; [Publishing Docs](https://developer.chrome.com/docs/webstore/publish/)
 
 To create a ZIP for Chrome:
 
@@ -108,15 +82,15 @@ To create a ZIP for Chrome:
 wxt zip
 ```
 
-## Firefox Addon Store
+### Firefox Addon Store
 
-✅ Automated &bull; [Developer Dashboard](https://addons.mozilla.org/developers/) &bull; [Publishing Docs](https://extensionworkshop.com/documentation/publish/submitting-an-add-on/)
+> ✅ Supported &bull; [Developer Dashboard](https://addons.mozilla.org/developers/) &bull; [Publishing Docs](https://extensionworkshop.com/documentation/publish/submitting-an-add-on/)
 
 Firefox requires you to upload a ZIP of your source code. This allows them to rebuild your extension and review the code in a readable way. More details can be found in [Firefox's docs](https://extensionworkshop.com/documentation/publish/source-code-submission/).
 
-WXT and `publish-browser-extension` both fully support generating and automatically submitting a source code ZIP.
+WXT fully supports generating and automatically submitting a source code ZIP.
 
-When you run `wxt zip -b firefox`, your sources are zipped into the `.output` directory along with your built extension. WXT is configured to exclude certain files such as config files, hidden files, and tests. However, it's important to manually check the ZIP to ensure it only contains the files necessary to rebuild your extension.
+When you run `wxt zip -b firefox`, your sources are zipped into the `.output` directory alongside the extension. WXT will automatically exclude certain files such as config files, hidden files, and tests. However, it's important to manually check the ZIP to ensure it only contains the files necessary to rebuild your extension.
 
 To customize which files are zipped, add the `zip` option to your config file.
 
@@ -152,22 +126,34 @@ yarn zip:firefox
 
 :::
 
-Ensure that you have a `README.md` or `SOURCE_CODE_REVIEW.md` file with the above commands so that the Firefox team knows how to build your extension.
-
-## Safari
-
-🚧 Not automated at this time
+Make sure the build output is the exact same when running `wxt build -b firefox` in your main project and inside the zipped sources.
 
 :::warning
-🚧 WXT does not currently support automated publishing for Safari. Safari extensions require a native MacOS or iOS app wrapper, which WXT cannot create at this time. For now, if you want to publish to Safari, follow this guide:
+If you use a `.env` files, they can effect the chunk hashes in the output directory. Either delete the .env file before running `wxt zip -b firefox`, or include it in your sources zip with the [`zip.includeSources`](/api/wxt/interfaces/InlineConfig#includesources) option. Be careful to not include any secrets in your `.env` files.
 
-https://developer.apple.com/documentation/safariservices/safari_web_extensions/distributing_your_safari_web_extension
-
+See Issue [#377](https://github.com/wxt-dev/wxt/issues/377) for more details.
 :::
 
-## Edge Addons
+Ensure that you have a `README.md` or `SOURCE_CODE_REVIEW.md` file with the above commands so that the Firefox team knows how to build your extension.
 
-✅ Automated &bull; [Developer Dashboard](https://aka.ms/PartnerCenterLogin) &bull; [Publishing Docs](https://learn.microsoft.com/en-us/microsoft-edge/extensions-chromium/publish/publish-extension)
+### Safari
+
+> 🚧 Not supported yet
+
+WXT does not currently support automated publishing for Safari. Safari extensions require a native MacOS or iOS app wrapper, which WXT does not create yet. For now, if you want to publish to Safari, follow this guide:
+
+- [Converting a web extension for Safari](https://developer.apple.com/documentation/safariservices/safari_web_extensions/converting_a_web_extension_for_safari) - "Convert your existing extension to a Safari web extension using Xcode’s command-line tool."
+
+When running the `safari-web-extension-converter` CLI tool, pass the `.output/safari-mv2` or `.output/safari-mv3` directory, not your source code directory.
+
+```sh
+pnpm wxt build -b safari
+xcrun safari-web-extension-converter .output/safari-mv2
+```
+
+### Edge Addons
+
+> ✅ Supported &bull; [Developer Dashboard](https://aka.ms/PartnerCenterLogin) &bull; [Publishing Docs](https://learn.microsoft.com/en-us/microsoft-edge/extensions-chromium/publish/publish-extension)
 
 No need to create a specific ZIP for Edge. If you're already publishing to the Chrome Web Store, you can reuse your Chrome ZIP.
 

--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     }
   },
   "scripts": {
-    "wxt": "tsx src/cli.ts",
+    "wxt": "tsx src/cli/index.ts",
     "build": "tsx scripts/build.ts",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
@@ -132,6 +132,7 @@
     "ora": "^7.0.1",
     "picocolors": "^1.0.0",
     "prompts": "^2.4.2",
+    "publish-browser-extension": "^2.0.0",
     "rollup-plugin-visualizer": "^5.9.2",
     "unimport": "^3.4.0",
     "vite": "^5.0.12",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -95,6 +95,9 @@ importers:
       prompts:
         specifier: ^2.4.2
         version: 2.4.2
+      publish-browser-extension:
+        specifier: ^2.0.0
+        version: 2.0.0
       rollup-plugin-visualizer:
         specifier: ^5.9.2
         version: 5.9.3
@@ -1165,6 +1168,14 @@ packages:
     resolution: {integrity: sha512-LlmbFLUB7+BDrb9nMuM0wlqtx9LZbBV2x3W98o02cD7Y8i10+sBenTlhG56vr47dzC7WIVXbURii+5jMJsyjLw==}
     dev: false
 
+  /@types/yauzl@2.10.3:
+    resolution: {integrity: sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==}
+    requiresBuild: true
+    dependencies:
+      '@types/node': 20.10.3
+    dev: false
+    optional: true
+
   /@vitejs/plugin-vue@5.0.2(vite@5.0.12)(vue@3.4.3):
     resolution: {integrity: sha512-kEjJHrLb5ePBvjD0SPZwJlw1QTRcjjCA9sB5VyfonoXVBxTS7TMnqL6EkLt1Eu61RDeiuZ/WN9Hf6PxXhPI2uA==}
     engines: {node: ^18.0.0 || >=20.0.0}
@@ -1534,7 +1545,6 @@ packages:
     engines: {node: '>=14.16'}
     dependencies:
       type-fest: 3.13.1
-    dev: true
 
   /ansi-regex@5.0.1:
     resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
@@ -1632,6 +1642,11 @@ packages:
     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
     dev: false
 
+  /big-integer@1.6.52:
+    resolution: {integrity: sha512-QxD8cf2eVqJOOz63z6JIN9BzvVs/dlySa5HGSBH5xtR8dPteIRQnBxxKqkNTiT6jbDTF6jAfrd4oMcND9RGbQg==}
+    engines: {node: '>=0.6'}
+    dev: false
+
   /binary-extensions@2.2.0:
     resolution: {integrity: sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==}
     engines: {node: '>=8'}
@@ -1666,6 +1681,13 @@ packages:
       wrap-ansi: 8.1.0
     dev: false
 
+  /bplist-parser@0.2.0:
+    resolution: {integrity: sha512-z0M+byMThzQmD9NILRniCUXYsYpjwnlO8N5uCFaCqIOpqRsJCrQL9NK3JsD67CN5a08nF5oIL2bD6loTdHOuKw==}
+    engines: {node: '>= 5.10.0'}
+    dependencies:
+      big-integer: 1.6.52
+    dev: false
+
   /brace-expansion@1.1.11:
     resolution: {integrity: sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==}
     dependencies:
@@ -1683,6 +1705,10 @@ packages:
     dependencies:
       fill-range: 7.0.1
 
+  /buffer-crc32@0.2.13:
+    resolution: {integrity: sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==}
+    dev: false
+
   /buffer-from@1.1.2:
     resolution: {integrity: sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==}
     dev: false
@@ -1692,6 +1718,13 @@ packages:
     dependencies:
       base64-js: 1.5.1
       ieee754: 1.2.1
+    dev: false
+
+  /bundle-name@3.0.0:
+    resolution: {integrity: sha512-PKA4BeSvBpQKQ8iPOGCSiell+N8P+Tf1DlwqmYhpe2gAhKPHn8EYOxVT+ShuGmhg8lN8XiSlS80yiExKXrURlw==}
+    engines: {node: '>=12'}
+    dependencies:
+      run-applescript: 5.0.0
     dev: false
 
   /bundle-require@4.0.1(esbuild@0.19.8):
@@ -1787,6 +1820,14 @@ packages:
       escape-string-regexp: 1.0.5
       supports-color: 5.5.0
 
+  /chalk@4.1.2:
+    resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
+    engines: {node: '>=10'}
+    dependencies:
+      ansi-styles: 4.3.0
+      supports-color: 7.2.0
+    dev: false
+
   /chalk@5.3.0:
     resolution: {integrity: sha512-dLitG79d+GV1Nb/VYcCDFivJeK1hiukt9QjRNVOsUtTy1rR1YJsmpGGTZ3qJos+uw7WmWF4wUwBd9jxjocFC2w==}
     engines: {node: ^12.17.0 || ^14.13 || >=16.0.0}
@@ -1844,6 +1885,19 @@ packages:
     dependencies:
       restore-cursor: 4.0.0
 
+  /cli-highlight@2.1.11:
+    resolution: {integrity: sha512-9KDcoEVwyUXrjcJNvHD0NFc/hiwe/WPVYIleQh2O1N2Zro5gWJZ/K+3DGn8w8P/F6FxOgzyC5bxDyHIgCSPhGg==}
+    engines: {node: '>=8.0.0', npm: '>=5.0.0'}
+    hasBin: true
+    dependencies:
+      chalk: 4.1.2
+      highlight.js: 10.7.3
+      mz: 2.7.0
+      parse5: 5.1.1
+      parse5-htmlparser2-tree-adapter: 6.0.1
+      yargs: 16.2.0
+    dev: false
+
   /cli-spinners@2.9.0:
     resolution: {integrity: sha512-4/aL9X3Wh0yiMQlE+eeRhWP6vclO3QRtw1JHKIT0FFUs5FjpFmESqtMvYZ0+lbzBw900b95mS0hohy+qn2VK/g==}
     engines: {node: '>=6'}
@@ -1855,7 +1909,14 @@ packages:
     dependencies:
       slice-ansi: 5.0.0
       string-width: 7.0.0
-    dev: true
+
+  /cliui@7.0.4:
+    resolution: {integrity: sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==}
+    dependencies:
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+      wrap-ansi: 7.0.0
+    dev: false
 
   /cliui@8.0.1:
     resolution: {integrity: sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==}
@@ -1864,6 +1925,11 @@ packages:
       string-width: 4.2.3
       strip-ansi: 6.0.1
       wrap-ansi: 7.0.0
+    dev: false
+
+  /clone@1.0.4:
+    resolution: {integrity: sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg==}
+    engines: {node: '>=0.8'}
     dev: false
 
   /color-convert@1.9.3:
@@ -2054,6 +2120,30 @@ packages:
     engines: {node: '>=4.0.0'}
     dev: false
 
+  /default-browser-id@3.0.0:
+    resolution: {integrity: sha512-OZ1y3y0SqSICtE8DE4S8YOE9UZOJ8wO16fKWVP5J1Qz42kV9jcnMVFrEE/noXb/ss3Q4pZIH79kxofzyNNtUNA==}
+    engines: {node: '>=12'}
+    dependencies:
+      bplist-parser: 0.2.0
+      untildify: 4.0.0
+    dev: false
+
+  /default-browser@4.0.0:
+    resolution: {integrity: sha512-wX5pXO1+BrhMkSbROFsyxUm0i/cJEScyNhA4PPxc41ICuv05ZZB/MX28s8aZx6xjmatvebIapF6hLEKEcpneUA==}
+    engines: {node: '>=14.16'}
+    dependencies:
+      bundle-name: 3.0.0
+      default-browser-id: 3.0.0
+      execa: 7.2.0
+      titleize: 3.0.0
+    dev: false
+
+  /defaults@1.0.4:
+    resolution: {integrity: sha512-eFuaLoy/Rxalv2kr+lqMlUnrDWV+3j4pljOIJgLIhI058IQfWJ7vXhyEIHu+HtC738klGALYxOKDO0bQP3tg8A==}
+    dependencies:
+      clone: 1.0.4
+    dev: false
+
   /defer-to-connect@2.0.1:
     resolution: {integrity: sha512-4tvttepXG1VaYGrRibk5EwJd1t4udunSOVMdLSAL6mId1ix438oPwPZMALY41FCijukO1L0twNcGsdzS7dHgDg==}
     engines: {node: '>=10'}
@@ -2062,6 +2152,11 @@ packages:
   /define-lazy-prop@2.0.0:
     resolution: {integrity: sha512-Ds09qNh8yw3khSjiJjiUInaGX9xlqZDY7JVryGxdxV7NPeuqQfplOpQ66yJFZut3jLa5zOwkXw1g9EI2uKh4Og==}
     engines: {node: '>=8'}
+    dev: false
+
+  /define-lazy-prop@3.0.0:
+    resolution: {integrity: sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg==}
+    engines: {node: '>=12'}
     dev: false
 
   /define-properties@1.2.0:
@@ -2154,7 +2249,6 @@ packages:
 
   /emoji-regex@10.3.0:
     resolution: {integrity: sha512-QpLs9D9v9kArv4lfDEgg1X/gN5XLnf/A6l9cs8SPZLRZR3ZkY9+kwIQTxm+fsSej5UMYGE8fdoaZVIBlqG0XTw==}
-    dev: true
 
   /emoji-regex@8.0.0:
     resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
@@ -2162,6 +2256,12 @@ packages:
 
   /emoji-regex@9.2.2:
     resolution: {integrity: sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==}
+    dev: false
+
+  /end-of-stream@1.4.4:
+    resolution: {integrity: sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==}
+    dependencies:
+      once: 1.4.0
     dev: false
 
   /entities@4.5.0:
@@ -2323,7 +2423,6 @@ packages:
 
   /eventemitter3@5.0.1:
     resolution: {integrity: sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==}
-    dev: true
 
   /execa@5.1.1:
     resolution: {integrity: sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==}
@@ -2338,7 +2437,21 @@ packages:
       onetime: 5.1.2
       signal-exit: 3.0.7
       strip-final-newline: 2.0.0
-    dev: true
+
+  /execa@7.2.0:
+    resolution: {integrity: sha512-UduyVP7TLB5IcAQl+OzLyLcS/l32W/GLg+AhHJ+ow40FOk2U3SAllPwR44v4vmdFwIWqpdwxxpQbF1n5ta9seA==}
+    engines: {node: ^14.18.0 || ^16.14.0 || >=18.0.0}
+    dependencies:
+      cross-spawn: 7.0.3
+      get-stream: 6.0.1
+      human-signals: 4.3.1
+      is-stream: 3.0.0
+      merge-stream: 2.0.0
+      npm-run-path: 5.1.0
+      onetime: 6.0.0
+      signal-exit: 3.0.7
+      strip-final-newline: 3.0.0
+    dev: false
 
   /execa@8.0.1:
     resolution: {integrity: sha512-VyhnebXciFV2DESc+p6B+y0LjSm0krU4OgJN44qFAhBY0TJ+1V61tYD2+wHusZ6F9n5K+vl8k0sTy7PEfV4qpg==}
@@ -2354,6 +2467,20 @@ packages:
       signal-exit: 4.1.0
       strip-final-newline: 3.0.0
 
+  /extract-zip@2.0.1:
+    resolution: {integrity: sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==}
+    engines: {node: '>= 10.17.0'}
+    hasBin: true
+    dependencies:
+      debug: 4.3.4
+      get-stream: 5.2.0
+      yauzl: 2.10.0
+    optionalDependencies:
+      '@types/yauzl': 2.10.3
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
   /fast-glob@3.3.1:
     resolution: {integrity: sha512-kNFPyjhh5cKjrUltxs+wFx+ZkbRaxxmZ+X0ZU31SOsxCEtP9VPgtq2teZw1DebupL5GmDaNQ6yKMMVcM41iqDg==}
     engines: {node: '>=8.6.0'}
@@ -2368,6 +2495,12 @@ packages:
     resolution: {integrity: sha512-wBrocU2LCXXa+lWBt8RoIRD89Fi8OdABODa/kEnyeyjS5aZO5/GNvI5sEINADqP/h8M29UHTHUb53sUu5Ihqdw==}
     dependencies:
       reusify: 1.0.4
+
+  /fd-slicer@1.1.0:
+    resolution: {integrity: sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==}
+    dependencies:
+      pend: 1.2.0
+    dev: false
 
   /filesize@10.1.0:
     resolution: {integrity: sha512-GTLKYyBSDz3nPhlLVPjPWZCnhkd9TrrRArNcy8Z+J2cqScB7h2McAzR6NBX6nYOoWafql0roY8hrocxnZBv9CQ==}
@@ -2411,6 +2544,11 @@ packages:
   /form-data-encoder@2.1.4:
     resolution: {integrity: sha512-yDYSgNMraqvnxiEXO4hi88+YZxaHC6QKzb5N84iRCTDeRO7ZALpir/lVmf/uXUhnwUr2O4HU8s/n6x+yNjQkHw==}
     engines: {node: '>= 14.17'}
+    dev: false
+
+  /formdata-node@6.0.3:
+    resolution: {integrity: sha512-8e1++BCiTzUno9v5IZ2J6bv4RU+3UKDmqWUQD0MIMVCd9AdhWkO1gw57oo1mNEX1dMq2EGI+FbWz4B92pscSQg==}
+    engines: {node: '>= 18'}
     dev: false
 
   /fs-extra@11.1.1:
@@ -2496,7 +2634,6 @@ packages:
   /get-east-asian-width@1.2.0:
     resolution: {integrity: sha512-2nk+7SIVb14QrgXFHcm84tD4bKQz0RxPuMT8Ag5KPOq7J5fEmAg0UbXdTOSHqNuHSU28k55qnceesxXRZGzKWA==}
     engines: {node: '>=18'}
-    dev: true
 
   /get-func-name@2.0.2:
     resolution: {integrity: sha512-8vXOvuE167CtIc3OyItco7N/dpRtBbYOsPsXCz7X/PMnlGjYjSGuZJgM1Y7mmew7BKf9BqvLX2tnOVy1BBUsxQ==}
@@ -2513,6 +2650,13 @@ packages:
   /get-port@7.0.0:
     resolution: {integrity: sha512-mDHFgApoQd+azgMdwylJrv2DX47ywGq1i5VFJE7fZ0dttNq3iQMfsU4IvEgBHojA3KqEudyu7Vq+oN8kNaNkWw==}
     engines: {node: '>=16'}
+    dev: false
+
+  /get-stream@5.2.0:
+    resolution: {integrity: sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==}
+    engines: {node: '>=8'}
+    dependencies:
+      pump: 3.0.0
     dev: false
 
   /get-stream@6.0.1:
@@ -2680,7 +2824,6 @@ packages:
   /has-flag@4.0.0:
     resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
     engines: {node: '>=8'}
-    dev: true
 
   /has-property-descriptors@1.0.0:
     resolution: {integrity: sha512-62DVLZGoiEBDHQyqG4w9xCuZ7eJEwNmJRWw2VY84Oedb7WFcA27fiEVe8oUQx9hAUJ4ekurquucTGwsyO1XGdQ==}
@@ -2716,6 +2859,10 @@ packages:
     dependencies:
       function-bind: 1.1.1
     dev: true
+
+  /highlight.js@10.7.3:
+    resolution: {integrity: sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A==}
+    dev: false
 
   /hosted-git-info@2.8.9:
     resolution: {integrity: sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==}
@@ -2763,7 +2910,11 @@ packages:
   /human-signals@2.1.0:
     resolution: {integrity: sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==}
     engines: {node: '>=10.17.0'}
-    dev: true
+
+  /human-signals@4.3.1:
+    resolution: {integrity: sha512-nZXjEF2nbo7lIw3mgYjItAfgQXog3OjJogSbKa2CQIIvSGWcKgeJnQlNXip6NglNzYH45nSRiEVimMvYL8DDqQ==}
+    engines: {node: '>=14.18.0'}
+    dev: false
 
   /human-signals@5.0.0:
     resolution: {integrity: sha512-AXcZb6vzzrFAUE61HnN4mpLqd/cSIwNQjtNWR0euPm6y0iqx3G4gOXaIDdtdDwZmhwe82LA6+zinmW4UBWVePQ==}
@@ -2926,14 +3077,12 @@ packages:
   /is-fullwidth-code-point@4.0.0:
     resolution: {integrity: sha512-O4L094N2/dZ7xqVdrXhh9r1KODPJpFms8B5sGdJLPy664AgvXsreZUyCQQNItZRDlYug4xStLjNp/sz3HvBowQ==}
     engines: {node: '>=12'}
-    dev: true
 
   /is-fullwidth-code-point@5.0.0:
     resolution: {integrity: sha512-OVa3u9kkBbw7b8Xw5F9P+D/T9X+Z4+JruYVNapTjPYZYUznQ5YfWeFkOj606XYYW8yugTfC8Pj0hYqvi4ryAhA==}
     engines: {node: '>=18'}
     dependencies:
       get-east-asian-width: 1.2.0
-    dev: true
 
   /is-glob@4.0.3:
     resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
@@ -3027,7 +3176,6 @@ packages:
   /is-stream@2.0.1:
     resolution: {integrity: sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==}
     engines: {node: '>=8'}
-    dev: true
 
   /is-stream@3.0.0:
     resolution: {integrity: sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==}
@@ -3282,9 +3430,21 @@ packages:
       colorette: 2.0.20
       eventemitter3: 5.0.1
       log-update: 6.0.0
-      rfdc: 1.3.0
+      rfdc: 1.3.1
       wrap-ansi: 9.0.0
     dev: true
+
+  /listr2@8.0.2:
+    resolution: {integrity: sha512-v5jEMOeEJUpRjSXSB4U3w5A3YPmURYMUO/86f1PA4GGYcdbUQYpkbvKYT7Xaq1iu4Zjn51Rv1UeD1zsBXRijiQ==}
+    engines: {node: '>=18.0.0'}
+    dependencies:
+      cli-truncate: 4.0.0
+      colorette: 2.0.20
+      eventemitter3: 5.0.1
+      log-update: 6.0.0
+      rfdc: 1.3.1
+      wrap-ansi: 9.0.0
+    dev: false
 
   /load-json-file@4.0.0:
     resolution: {integrity: sha512-Kx8hMakjX03tiGTLAIdJ+lL0htKnXjEZN6hk/tozf/WOuYGdZBJrZ+rCJRbVCugsjB3jMLn9746NsQIf5VjBMw==}
@@ -3313,8 +3473,20 @@ packages:
       mlly: 1.4.2
       pkg-types: 1.0.3
 
+  /lodash.camelcase@4.3.0:
+    resolution: {integrity: sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==}
+    dev: false
+
+  /lodash.kebabcase@4.1.1:
+    resolution: {integrity: sha512-N8XRTIMMqqDgSy4VLKPnJ/+hpGZN+PHQiJnSenYqPaVV/NCqEogTnAdZLQiGKhxX+JCs8waWq2t1XHWKOmlY8g==}
+    dev: false
+
   /lodash.merge@4.6.2:
     resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==}
+
+  /lodash.snakecase@4.1.1:
+    resolution: {integrity: sha512-QZ1d4xoBHYUeuouhEq3lk3Uq7ldgyFXGBhg04+oRLnIz8o9T65Eh+8YdroUwn846zchkA9yDsDl5CVVaV2nqYw==}
+    dev: false
 
   /lodash.sortby@4.7.0:
     resolution: {integrity: sha512-HDWXG8isMntAyRF5vZ7xKuEvOhT4AhlRt/3czTSjvGUxjYCBVRQY48ViDHyfYz9VIoBkW4TMGQNapx+l3RUwdA==}
@@ -3337,7 +3509,6 @@ packages:
       slice-ansi: 7.1.0
       strip-ansi: 7.1.0
       wrap-ansi: 9.0.0
-    dev: true
 
   /loose-envify@1.4.0:
     resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
@@ -3673,7 +3844,6 @@ packages:
     engines: {node: '>=8'}
     dependencies:
       path-key: 3.1.1
-    dev: true
 
   /npm-run-path@5.1.0:
     resolution: {integrity: sha512-sJOdmRGrY2sjNTRMbSvluQqg+8X7ZK61yvzBEIDhz4f8z1TZFYABsqjjCBd/0PUNE9M6QDgHJXQkGUEm7Q+l9Q==}
@@ -3710,6 +3880,14 @@ packages:
       object-keys: 1.1.1
     dev: true
 
+  /ofetch@1.3.3:
+    resolution: {integrity: sha512-s1ZCMmQWXy4b5K/TW9i/DtiN8Ku+xCiHcjQ6/J/nDdssirrQNOoB165Zu8EqLMA2lln1JUth9a0aW9Ap2ctrUg==}
+    dependencies:
+      destr: 2.0.2
+      node-fetch-native: 1.4.1
+      ufo: 1.3.1
+    dev: false
+
   /ohash@1.1.3:
     resolution: {integrity: sha512-zuHHiGTYTA1sYJ/wZN+t5HKZaH23i4yI1HMwbuXm24Nid7Dv0KcuRlKoNKS9UNfAVSBlnGLcuQrnOKWOZoEGaw==}
     dev: false
@@ -3738,6 +3916,31 @@ packages:
       define-lazy-prop: 2.0.0
       is-docker: 2.2.1
       is-wsl: 2.2.0
+    dev: false
+
+  /open@9.1.0:
+    resolution: {integrity: sha512-OS+QTnw1/4vrf+9hh1jc1jnYjzSG4ttTBB8UxOwAnInG3Uo4ssetzC1ihqaIHjLJnA5GGlRl6QlZXOTQhRBUvg==}
+    engines: {node: '>=14.16'}
+    dependencies:
+      default-browser: 4.0.0
+      define-lazy-prop: 3.0.0
+      is-inside-container: 1.0.0
+      is-wsl: 2.2.0
+    dev: false
+
+  /ora@6.3.1:
+    resolution: {integrity: sha512-ERAyNnZOfqM+Ao3RAvIXkYh5joP220yf59gVe2X/cI6SiCxIdi4c9HZKZD8R6q/RDXEje1THBju6iExiSsgJaQ==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+    dependencies:
+      chalk: 5.3.0
+      cli-cursor: 4.0.0
+      cli-spinners: 2.9.0
+      is-interactive: 2.0.0
+      is-unicode-supported: 1.3.0
+      log-symbols: 5.1.0
+      stdin-discarder: 0.1.0
+      strip-ansi: 7.1.0
+      wcwidth: 1.0.1
     dev: false
 
   /ora@7.0.1:
@@ -3809,6 +4012,20 @@ packages:
       type-fest: 3.13.1
     dev: false
 
+  /parse5-htmlparser2-tree-adapter@6.0.1:
+    resolution: {integrity: sha512-qPuWvbLgvDGilKc5BoicRovlT4MtYT6JfJyBOMDsKoiT+GiuP5qyrPCnR9HcPECIJJmZh5jRndyNThnhhb/vlA==}
+    dependencies:
+      parse5: 6.0.1
+    dev: false
+
+  /parse5@5.1.1:
+    resolution: {integrity: sha512-ugq4DFI0Ptb+WWjAdOK16+u/nHfiIrcE+sh8kZMaM0WllQKLI9rOUq6c2b7cwPkXdzfQESqvoqK6ug7U/Yyzug==}
+    dev: false
+
+  /parse5@6.0.1:
+    resolution: {integrity: sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw==}
+    dev: false
+
   /path-is-absolute@1.0.1:
     resolution: {integrity: sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==}
     engines: {node: '>=0.10.0'}
@@ -3847,6 +4064,10 @@ packages:
 
   /pathval@1.1.1:
     resolution: {integrity: sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==}
+
+  /pend@1.2.0:
+    resolution: {integrity: sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==}
+    dev: false
 
   /perfect-debounce@1.0.0:
     resolution: {integrity: sha512-xCy9V055GLEqoFaHoC1SoLIaLmWctgCUaBaWxDZ7/Zx4CTyX7cJQLJOok/orfjZAh9kEYpjJa4d0KcJmCbctZA==}
@@ -3962,6 +4183,37 @@ packages:
       picocolors: 1.0.0
       sade: 1.8.1
     dev: true
+
+  /publish-browser-extension@2.0.0:
+    resolution: {integrity: sha512-HzNfnsx2/yN1n288btH6xfmXzYA5e9FpjteJpR68qlevqKMQqbCw9AJOK2WdFKVBy1kuSil8XGuhpQWv3NcrnA==}
+    engines: {node: '18', pnpm: '8'}
+    hasBin: true
+    dependencies:
+      cac: 6.7.14
+      cli-highlight: 2.1.11
+      consola: 3.2.3
+      dotenv: 16.3.1
+      extract-zip: 2.0.1
+      formdata-node: 6.0.3
+      listr2: 8.0.2
+      lodash.camelcase: 4.3.0
+      lodash.kebabcase: 4.1.1
+      lodash.snakecase: 4.1.1
+      ofetch: 1.3.3
+      open: 9.1.0
+      ora: 6.3.1
+      prompts: 2.4.2
+      zod: 3.22.4
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
+  /pump@3.0.0:
+    resolution: {integrity: sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==}
+    dependencies:
+      end-of-stream: 1.4.4
+      once: 1.4.0
+    dev: false
 
   /punycode@2.3.0:
     resolution: {integrity: sha512-rRV+zQD8tVFys26lAGR9WUuS4iUAngJScM+ZRSKtvl5tKeZ2t5bvdNFdNHBW9FWR4guGHlgmsZ1G7BSm2wTbuA==}
@@ -4129,9 +4381,8 @@ packages:
     resolution: {integrity: sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==}
     engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
 
-  /rfdc@1.3.0:
-    resolution: {integrity: sha512-V2hovdzFbOi77/WajaSMXk2OLm+xNIeQdMMuB7icj7bk6zi2F8GGAxigcnDFpJHbNyNcgyJDiP+8nOrY5cZGrA==}
-    dev: true
+  /rfdc@1.3.1:
+    resolution: {integrity: sha512-r5a3l5HzYlIC68TpmYKlxWjmOP6wiPJ1vWv2HeLhNsRZMrCkxeqxiHlQ21oXmQ4F3SiryXBHhAD7JZqvOJjFmg==}
 
   /rimraf@2.4.5:
     resolution: {integrity: sha512-J5xnxTyqaiw06JjMftq7L9ouA448dw/E7dKghkP9WpKNuwmARNNg+Gk8/u5ryb9N/Yo2+z3MCwuqFK/+qPOPfQ==}
@@ -4183,6 +4434,13 @@ packages:
       '@rollup/rollup-win32-ia32-msvc': 4.6.1
       '@rollup/rollup-win32-x64-msvc': 4.6.1
       fsevents: 2.3.3
+
+  /run-applescript@5.0.0:
+    resolution: {integrity: sha512-XcT5rBksx1QdIhlFOCtgZkB99ZEouFZ1E2Kc2LHqNW13U3/74YGdkQRmThTwxy4QIyookibDKYZOPqX//6BlAg==}
+    engines: {node: '>=12'}
+    dependencies:
+      execa: 5.1.1
+    dev: false
 
   /run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
@@ -4369,7 +4627,6 @@ packages:
     dependencies:
       ansi-styles: 6.2.1
       is-fullwidth-code-point: 4.0.0
-    dev: true
 
   /slice-ansi@7.1.0:
     resolution: {integrity: sha512-bSiSngZ/jWeX93BqeIAbImyTbEihizcwNjFoRUIY/T1wWQsfsm2Vw1agPKylXvQTU7iASGdHhyqRlqQzfz+Htg==}
@@ -4377,7 +4634,6 @@ packages:
     dependencies:
       ansi-styles: 6.2.1
       is-fullwidth-code-point: 5.0.0
-    dev: true
 
   /source-map-js@1.0.2:
     resolution: {integrity: sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==}
@@ -4494,7 +4750,6 @@ packages:
       emoji-regex: 10.3.0
       get-east-asian-width: 1.2.0
       strip-ansi: 7.1.0
-    dev: true
 
   /string.prototype.padend@3.1.4:
     resolution: {integrity: sha512-67otBXoksdjsnXXRUq+KMVTdlVRZ2af422Y0aTyTjVaoQkGr3mxl2Bc5emi7dOQ3OGVVQQskmLEWwFXwommpNw==}
@@ -4562,7 +4817,6 @@ packages:
   /strip-final-newline@2.0.0:
     resolution: {integrity: sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==}
     engines: {node: '>=6'}
-    dev: true
 
   /strip-final-newline@3.0.0:
     resolution: {integrity: sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==}
@@ -4608,7 +4862,6 @@ packages:
     engines: {node: '>=8'}
     dependencies:
       has-flag: 4.0.0
-    dev: true
 
   /supports-preserve-symlinks-flag@1.0.0:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
@@ -4665,6 +4918,11 @@ packages:
   /tinyspy@2.2.0:
     resolution: {integrity: sha512-d2eda04AN/cPOR89F7Xv5bK/jrQEhmcLFe6HFldoeO9AJtps+fqEnh486vnT/8y4bw38pSyxDcTCAq+Ks2aJTg==}
     engines: {node: '>=14.0.0'}
+
+  /titleize@3.0.0:
+    resolution: {integrity: sha512-KxVu8EYHDPBdUYdKZdKtU2aj2XfEx9AfjXxE/Aj0vT06w2icA09Vus1rh6eSu1y01akYg6BjIK/hxyLJINoMLQ==}
+    engines: {node: '>=12'}
+    dev: false
 
   /tmp@0.2.1:
     resolution: {integrity: sha512-76SUhtfqR2Ijn+xllcI5P1oyannHNHByD80W1q447gU3mp9G9PSpGdWmjUOHRDPiHYacIk66W7ubDTuPF3BEtQ==}
@@ -4894,6 +5152,11 @@ packages:
       chokidar: 3.5.3
       webpack-sources: 3.2.3
       webpack-virtual-modules: 0.5.0
+    dev: false
+
+  /untildify@4.0.0:
+    resolution: {integrity: sha512-KK8xQ1mkzZeg9inewmFVDNkg3l5LUhoq9kN6iWYB/CC9YMG8HA+c1Q8HwDe6dEX7kErrEVNVBO3fWsVq5iDgtw==}
+    engines: {node: '>=8'}
     dev: false
 
   /update-notifier@6.0.2:
@@ -5184,6 +5447,12 @@ packages:
       graceful-fs: 4.2.11
     dev: false
 
+  /wcwidth@1.0.1:
+    resolution: {integrity: sha512-XHPEwS0q6TaxcvG85+8EYkbiCux2XtWG2mkc47Ng2A77BQu9+DqIOJldST4HgPkuea7dvKSj5VgX3P1d4rW8Tg==}
+    dependencies:
+      defaults: 1.0.4
+    dev: false
+
   /web-ext-run@0.2.0:
     resolution: {integrity: sha512-lAm05ELMr2WDPniyaHmyuPK0rb9tsftC8f/Ui5AQvlU6F3LqoBDfyzOaaUVQrLxtm4F5oax8AHPWswf/XjZzAg==}
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
@@ -5349,7 +5618,6 @@ packages:
       ansi-styles: 6.2.1
       string-width: 7.0.0
       strip-ansi: 7.1.0
-    dev: true
 
   /wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
@@ -5407,9 +5675,27 @@ packages:
     engines: {node: '>= 14'}
     dev: true
 
+  /yargs-parser@20.2.9:
+    resolution: {integrity: sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==}
+    engines: {node: '>=10'}
+    dev: false
+
   /yargs-parser@21.1.1:
     resolution: {integrity: sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==}
     engines: {node: '>=12'}
+    dev: false
+
+  /yargs@16.2.0:
+    resolution: {integrity: sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==}
+    engines: {node: '>=10'}
+    dependencies:
+      cliui: 7.0.4
+      escalade: 3.1.1
+      get-caller-file: 2.0.5
+      require-directory: 2.1.1
+      string-width: 4.2.3
+      y18n: 5.0.8
+      yargs-parser: 20.2.9
     dev: false
 
   /yargs@17.7.2:
@@ -5425,6 +5711,13 @@ packages:
       yargs-parser: 21.1.1
     dev: false
 
+  /yauzl@2.10.0:
+    resolution: {integrity: sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==}
+    dependencies:
+      buffer-crc32: 0.2.13
+      fd-slicer: 1.1.0
+    dev: false
+
   /yocto-queue@1.0.0:
     resolution: {integrity: sha512-9bnSc/HEW2uRy67wc+T8UwauLuPJVn28jb+GtJY16iiKWyvmYJRXVT4UamsAEGQfPohgr2q4Tq0sQbQlxTfi1g==}
     engines: {node: '>=12.20'}
@@ -5434,4 +5727,8 @@ packages:
     dependencies:
       async: 3.2.4
       jszip: 3.10.1
+    dev: false
+
+  /zod@3.22.4:
+    resolution: {integrity: sha512-iC+8Io04lddc+mVqQ9AZ7OQ2MrUKGN+oIQyq1vemgt46jwCwLfhq7/pwnBnNXXXZb8VTVLKwp9EDkx+ryxIWmg==}
     dev: false

--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -94,7 +94,7 @@ const config: tsup.Options[] = [
   {
     ...preset,
     entry: {
-      cli: 'src/cli.ts',
+      cli: 'src/cli/index.ts',
     },
     format: ['esm'],
     banner: {

--- a/src/cli/__tests__/index.test.ts
+++ b/src/cli/__tests__/index.test.ts
@@ -8,22 +8,22 @@ import { initialize } from '~/core/initialize';
 import { mock } from 'vitest-mock-extended';
 import consola from 'consola';
 
-vi.mock('../core/build');
+vi.mock('~/core/build');
 const buildMock = vi.mocked(build);
 
-vi.mock('../core/create-server');
+vi.mock('~/core/create-server');
 const createServerMock = vi.mocked(createServer);
 
-vi.mock('../core/zip');
+vi.mock('~/core/zip');
 const zipMock = vi.mocked(zip);
 
-vi.mock('../core/prepare');
+vi.mock('~/core/prepare');
 const prepareMock = vi.mocked(prepare);
 
-vi.mock('../core/clean');
+vi.mock('~/core/clean');
 const cleanMock = vi.mocked(clean);
 
-vi.mock('../core/initialize');
+vi.mock('~/core/initialize');
 const initializeMock = vi.mocked(initialize);
 
 consola.wrapConsole();

--- a/src/cli/__tests__/index.test.ts
+++ b/src/cli/__tests__/index.test.ts
@@ -1,10 +1,10 @@
 import { describe, it, vi, beforeEach, expect } from 'vitest';
-import { build } from '../../core/build';
-import { createServer } from '../../core/create-server';
-import { zip } from '../../core/zip';
-import { prepare } from '../../core/prepare';
-import { clean } from '../../core/clean';
-import { initialize } from '../../core/initialize';
+import { build } from '~/core/build';
+import { createServer } from '~/core/create-server';
+import { zip } from '~/core/zip';
+import { prepare } from '~/core/prepare';
+import { clean } from '~/core/clean';
+import { initialize } from '~/core/initialize';
 import { mock } from 'vitest-mock-extended';
 import consola from 'consola';
 
@@ -34,6 +34,10 @@ function mockArgv(...args: string[]) {
   process.argv = ['/bin/node', 'bin/wxt.mjs', ...args];
 }
 
+async function importCli() {
+  await import('~/cli');
+}
+
 describe('CLI', () => {
   beforeEach(() => {
     vi.resetModules();
@@ -44,14 +48,14 @@ describe('CLI', () => {
   describe('dev', () => {
     it('should not pass any config when no flags are passed', async () => {
       mockArgv();
-      await import('../commands');
+      await importCli();
 
       expect(createServerMock).toBeCalledWith({});
     });
 
     it('should respect passing a custom root', async () => {
       mockArgv('path/to/root');
-      await import('../commands');
+      await importCli();
 
       expect(createServerMock).toBeCalledWith({
         root: 'path/to/root',
@@ -60,7 +64,7 @@ describe('CLI', () => {
 
     it('should respect a custom config file', async () => {
       mockArgv('-c', './path/to/config.ts');
-      await import('../commands');
+      await importCli();
 
       expect(createServerMock).toBeCalledWith({
         configFile: './path/to/config.ts',
@@ -69,7 +73,7 @@ describe('CLI', () => {
 
     it('should respect passing a custom mode', async () => {
       mockArgv('-m', 'development');
-      await import('../commands');
+      await importCli();
 
       expect(createServerMock).toBeCalledWith({
         mode: 'development',
@@ -78,7 +82,7 @@ describe('CLI', () => {
 
     it('should respect passing a custom browser', async () => {
       mockArgv('-b', 'firefox');
-      await import('../commands');
+      await importCli();
 
       expect(createServerMock).toBeCalledWith({
         browser: 'firefox',
@@ -87,7 +91,7 @@ describe('CLI', () => {
 
     it('should pass correct filtered entrypoints', async () => {
       mockArgv('-e', 'popup', '-e', 'options');
-      await import('../commands');
+      await importCli();
 
       expect(createServerMock).toBeCalledWith({
         filterEntrypoints: ['popup', 'options'],
@@ -96,7 +100,7 @@ describe('CLI', () => {
 
     it('should respect passing --mv2', async () => {
       mockArgv('--mv2');
-      await import('../commands');
+      await importCli();
 
       expect(createServerMock).toBeCalledWith({
         manifestVersion: 2,
@@ -105,7 +109,7 @@ describe('CLI', () => {
 
     it('should respect passing --mv3', async () => {
       mockArgv('--mv3');
-      await import('../commands');
+      await importCli();
 
       expect(createServerMock).toBeCalledWith({
         manifestVersion: 3,
@@ -114,7 +118,7 @@ describe('CLI', () => {
 
     it('should respect passing --debug', async () => {
       mockArgv('--debug');
-      await import('../commands');
+      await importCli();
 
       expect(createServerMock).toBeCalledWith({
         debug: true,
@@ -125,14 +129,14 @@ describe('CLI', () => {
   describe('build', () => {
     it('should not pass any config when no flags are passed', async () => {
       mockArgv('build');
-      await import('../commands');
+      await importCli();
 
       expect(buildMock).toBeCalledWith({});
     });
 
     it('should respect passing a custom root', async () => {
       mockArgv('build', 'path/to/root');
-      await import('../commands');
+      await importCli();
 
       expect(buildMock).toBeCalledWith({
         root: 'path/to/root',
@@ -141,7 +145,7 @@ describe('CLI', () => {
 
     it('should respect a custom config file', async () => {
       mockArgv('build', '-c', './path/to/config.ts');
-      await import('../commands');
+      await importCli();
 
       expect(buildMock).toBeCalledWith({
         configFile: './path/to/config.ts',
@@ -150,7 +154,7 @@ describe('CLI', () => {
 
     it('should respect passing a custom mode', async () => {
       mockArgv('build', '-m', 'development');
-      await import('../commands');
+      await importCli();
 
       expect(buildMock).toBeCalledWith({
         mode: 'development',
@@ -159,7 +163,7 @@ describe('CLI', () => {
 
     it('should respect passing a custom browser', async () => {
       mockArgv('build', '-b', 'firefox');
-      await import('../commands');
+      await importCli();
 
       expect(buildMock).toBeCalledWith({
         browser: 'firefox',
@@ -168,7 +172,7 @@ describe('CLI', () => {
 
     it('should pass correct filtered entrypoints', async () => {
       mockArgv('build', '-e', 'popup', '-e', 'options');
-      await import('../commands');
+      await importCli();
 
       expect(buildMock).toBeCalledWith({
         filterEntrypoints: ['popup', 'options'],
@@ -177,7 +181,7 @@ describe('CLI', () => {
 
     it('should respect passing --mv2', async () => {
       mockArgv('build', '--mv2');
-      await import('../commands');
+      await importCli();
 
       expect(buildMock).toBeCalledWith({
         manifestVersion: 2,
@@ -186,7 +190,7 @@ describe('CLI', () => {
 
     it('should respect passing --mv3', async () => {
       mockArgv('build', '--mv3');
-      await import('../commands');
+      await importCli();
 
       expect(buildMock).toBeCalledWith({
         manifestVersion: 3,
@@ -195,7 +199,7 @@ describe('CLI', () => {
 
     it('should include analysis in the build', async () => {
       mockArgv('build', '--analyze');
-      await import('../commands');
+      await importCli();
 
       expect(buildMock).toBeCalledWith({
         analysis: {
@@ -206,7 +210,7 @@ describe('CLI', () => {
 
     it('should respect passing --debug', async () => {
       mockArgv('build', '--debug');
-      await import('../commands');
+      await importCli();
 
       expect(buildMock).toBeCalledWith({
         debug: true,
@@ -217,14 +221,14 @@ describe('CLI', () => {
   describe('zip', () => {
     it('should not pass any config when no flags are passed', async () => {
       mockArgv('zip');
-      await import('../commands');
+      await importCli();
 
       expect(zipMock).toBeCalledWith({});
     });
 
     it('should respect passing a custom root', async () => {
       mockArgv('zip', 'path/to/root');
-      await import('../commands');
+      await importCli();
 
       expect(zipMock).toBeCalledWith({
         root: 'path/to/root',
@@ -233,7 +237,7 @@ describe('CLI', () => {
 
     it('should respect a custom config file', async () => {
       mockArgv('zip', '-c', './path/to/config.ts');
-      await import('../commands');
+      await importCli();
 
       expect(zipMock).toBeCalledWith({
         configFile: './path/to/config.ts',
@@ -242,7 +246,7 @@ describe('CLI', () => {
 
     it('should respect passing a custom mode', async () => {
       mockArgv('zip', '-m', 'development');
-      await import('../commands');
+      await importCli();
 
       expect(zipMock).toBeCalledWith({
         mode: 'development',
@@ -251,7 +255,7 @@ describe('CLI', () => {
 
     it('should respect passing a custom browser', async () => {
       mockArgv('zip', '-b', 'firefox');
-      await import('../commands');
+      await importCli();
 
       expect(zipMock).toBeCalledWith({
         browser: 'firefox',
@@ -260,7 +264,7 @@ describe('CLI', () => {
 
     it('should respect passing --mv2', async () => {
       mockArgv('zip', '--mv2');
-      await import('../commands');
+      await importCli();
 
       expect(zipMock).toBeCalledWith({
         manifestVersion: 2,
@@ -269,7 +273,7 @@ describe('CLI', () => {
 
     it('should respect passing --mv3', async () => {
       mockArgv('zip', '--mv3');
-      await import('../commands');
+      await importCli();
 
       expect(zipMock).toBeCalledWith({
         manifestVersion: 3,
@@ -278,7 +282,7 @@ describe('CLI', () => {
 
     it('should respect passing --debug', async () => {
       mockArgv('zip', '--debug');
-      await import('../commands');
+      await importCli();
 
       expect(zipMock).toBeCalledWith({
         debug: true,
@@ -289,14 +293,14 @@ describe('CLI', () => {
   describe('prepare', () => {
     it('should not pass any config when no flags are passed', async () => {
       mockArgv('prepare');
-      await import('../commands');
+      await importCli();
 
       expect(prepareMock).toBeCalledWith({});
     });
 
     it('should respect passing a custom root', async () => {
       mockArgv('prepare', 'path/to/root');
-      await import('../commands');
+      await importCli();
 
       expect(prepareMock).toBeCalledWith({
         root: 'path/to/root',
@@ -305,7 +309,7 @@ describe('CLI', () => {
 
     it('should respect a custom config file', async () => {
       mockArgv('prepare', '-c', './path/to/config.ts');
-      await import('../commands');
+      await importCli();
 
       expect(prepareMock).toBeCalledWith({
         configFile: './path/to/config.ts',
@@ -314,7 +318,7 @@ describe('CLI', () => {
 
     it('should respect passing --debug', async () => {
       mockArgv('prepare', '--debug');
-      await import('../commands');
+      await importCli();
 
       expect(prepareMock).toBeCalledWith({
         debug: true,
@@ -325,14 +329,14 @@ describe('CLI', () => {
   describe('clean', () => {
     it('should not pass any config when no flags are passed', async () => {
       mockArgv('clean');
-      await import('../commands');
+      await importCli();
 
       expect(cleanMock).toBeCalledWith(undefined);
     });
 
     it('should respect passing a custom root', async () => {
       mockArgv('clean', 'path/to/root');
-      await import('../commands');
+      await importCli();
 
       expect(cleanMock).toBeCalledWith('path/to/root');
     });
@@ -341,14 +345,14 @@ describe('CLI', () => {
   describe('init', () => {
     it('should not pass any options when no flags are passed', async () => {
       mockArgv('init');
-      await import('../commands');
+      await importCli();
 
       expect(initializeMock).toBeCalledWith({});
     });
 
     it('should respect the provided folder', async () => {
       mockArgv('init', 'path/to/folder');
-      await import('../commands');
+      await importCli();
 
       expect(initializeMock).toBeCalledWith({
         directory: 'path/to/folder',
@@ -357,7 +361,7 @@ describe('CLI', () => {
 
     it('should respect passing --template', async () => {
       mockArgv('init', '-t', 'vue');
-      await import('../commands');
+      await importCli();
 
       expect(initializeMock).toBeCalledWith({
         template: 'vue',
@@ -366,7 +370,7 @@ describe('CLI', () => {
 
     it('should respect passing --pm', async () => {
       mockArgv('init', '--pm', 'pnpm');
-      await import('../commands');
+      await importCli();
 
       expect(initializeMock).toBeCalledWith({
         packageManager: 'pnpm',

--- a/src/cli/__tests__/index.test.ts
+++ b/src/cli/__tests__/index.test.ts
@@ -1,10 +1,10 @@
 import { describe, it, vi, beforeEach, expect } from 'vitest';
-import { build } from '../core/build';
-import { createServer } from '../core/create-server';
-import { zip } from '../core/zip';
-import { prepare } from '../core/prepare';
-import { clean } from '../core/clean';
-import { initialize } from '../core/initialize';
+import { build } from '../../core/build';
+import { createServer } from '../../core/create-server';
+import { zip } from '../../core/zip';
+import { prepare } from '../../core/prepare';
+import { clean } from '../../core/clean';
+import { initialize } from '../../core/initialize';
 import { mock } from 'vitest-mock-extended';
 import consola from 'consola';
 
@@ -44,14 +44,14 @@ describe('CLI', () => {
   describe('dev', () => {
     it('should not pass any config when no flags are passed', async () => {
       mockArgv();
-      await import('../cli');
+      await import('../commands');
 
       expect(createServerMock).toBeCalledWith({});
     });
 
     it('should respect passing a custom root', async () => {
       mockArgv('path/to/root');
-      await import('../cli');
+      await import('../commands');
 
       expect(createServerMock).toBeCalledWith({
         root: 'path/to/root',
@@ -60,7 +60,7 @@ describe('CLI', () => {
 
     it('should respect a custom config file', async () => {
       mockArgv('-c', './path/to/config.ts');
-      await import('../cli');
+      await import('../commands');
 
       expect(createServerMock).toBeCalledWith({
         configFile: './path/to/config.ts',
@@ -69,7 +69,7 @@ describe('CLI', () => {
 
     it('should respect passing a custom mode', async () => {
       mockArgv('-m', 'development');
-      await import('../cli');
+      await import('../commands');
 
       expect(createServerMock).toBeCalledWith({
         mode: 'development',
@@ -78,7 +78,7 @@ describe('CLI', () => {
 
     it('should respect passing a custom browser', async () => {
       mockArgv('-b', 'firefox');
-      await import('../cli');
+      await import('../commands');
 
       expect(createServerMock).toBeCalledWith({
         browser: 'firefox',
@@ -87,7 +87,7 @@ describe('CLI', () => {
 
     it('should pass correct filtered entrypoints', async () => {
       mockArgv('-e', 'popup', '-e', 'options');
-      await import('../cli');
+      await import('../commands');
 
       expect(createServerMock).toBeCalledWith({
         filterEntrypoints: ['popup', 'options'],
@@ -96,7 +96,7 @@ describe('CLI', () => {
 
     it('should respect passing --mv2', async () => {
       mockArgv('--mv2');
-      await import('../cli');
+      await import('../commands');
 
       expect(createServerMock).toBeCalledWith({
         manifestVersion: 2,
@@ -105,7 +105,7 @@ describe('CLI', () => {
 
     it('should respect passing --mv3', async () => {
       mockArgv('--mv3');
-      await import('../cli');
+      await import('../commands');
 
       expect(createServerMock).toBeCalledWith({
         manifestVersion: 3,
@@ -114,7 +114,7 @@ describe('CLI', () => {
 
     it('should respect passing --debug', async () => {
       mockArgv('--debug');
-      await import('../cli');
+      await import('../commands');
 
       expect(createServerMock).toBeCalledWith({
         debug: true,
@@ -125,14 +125,14 @@ describe('CLI', () => {
   describe('build', () => {
     it('should not pass any config when no flags are passed', async () => {
       mockArgv('build');
-      await import('../cli');
+      await import('../commands');
 
       expect(buildMock).toBeCalledWith({});
     });
 
     it('should respect passing a custom root', async () => {
       mockArgv('build', 'path/to/root');
-      await import('../cli');
+      await import('../commands');
 
       expect(buildMock).toBeCalledWith({
         root: 'path/to/root',
@@ -141,7 +141,7 @@ describe('CLI', () => {
 
     it('should respect a custom config file', async () => {
       mockArgv('build', '-c', './path/to/config.ts');
-      await import('../cli');
+      await import('../commands');
 
       expect(buildMock).toBeCalledWith({
         configFile: './path/to/config.ts',
@@ -150,7 +150,7 @@ describe('CLI', () => {
 
     it('should respect passing a custom mode', async () => {
       mockArgv('build', '-m', 'development');
-      await import('../cli');
+      await import('../commands');
 
       expect(buildMock).toBeCalledWith({
         mode: 'development',
@@ -159,7 +159,7 @@ describe('CLI', () => {
 
     it('should respect passing a custom browser', async () => {
       mockArgv('build', '-b', 'firefox');
-      await import('../cli');
+      await import('../commands');
 
       expect(buildMock).toBeCalledWith({
         browser: 'firefox',
@@ -168,7 +168,7 @@ describe('CLI', () => {
 
     it('should pass correct filtered entrypoints', async () => {
       mockArgv('build', '-e', 'popup', '-e', 'options');
-      await import('../cli');
+      await import('../commands');
 
       expect(buildMock).toBeCalledWith({
         filterEntrypoints: ['popup', 'options'],
@@ -177,7 +177,7 @@ describe('CLI', () => {
 
     it('should respect passing --mv2', async () => {
       mockArgv('build', '--mv2');
-      await import('../cli');
+      await import('../commands');
 
       expect(buildMock).toBeCalledWith({
         manifestVersion: 2,
@@ -186,7 +186,7 @@ describe('CLI', () => {
 
     it('should respect passing --mv3', async () => {
       mockArgv('build', '--mv3');
-      await import('../cli');
+      await import('../commands');
 
       expect(buildMock).toBeCalledWith({
         manifestVersion: 3,
@@ -195,7 +195,7 @@ describe('CLI', () => {
 
     it('should include analysis in the build', async () => {
       mockArgv('build', '--analyze');
-      await import('../cli');
+      await import('../commands');
 
       expect(buildMock).toBeCalledWith({
         analysis: {
@@ -206,7 +206,7 @@ describe('CLI', () => {
 
     it('should respect passing --debug', async () => {
       mockArgv('build', '--debug');
-      await import('../cli');
+      await import('../commands');
 
       expect(buildMock).toBeCalledWith({
         debug: true,
@@ -217,14 +217,14 @@ describe('CLI', () => {
   describe('zip', () => {
     it('should not pass any config when no flags are passed', async () => {
       mockArgv('zip');
-      await import('../cli');
+      await import('../commands');
 
       expect(zipMock).toBeCalledWith({});
     });
 
     it('should respect passing a custom root', async () => {
       mockArgv('zip', 'path/to/root');
-      await import('../cli');
+      await import('../commands');
 
       expect(zipMock).toBeCalledWith({
         root: 'path/to/root',
@@ -233,7 +233,7 @@ describe('CLI', () => {
 
     it('should respect a custom config file', async () => {
       mockArgv('zip', '-c', './path/to/config.ts');
-      await import('../cli');
+      await import('../commands');
 
       expect(zipMock).toBeCalledWith({
         configFile: './path/to/config.ts',
@@ -242,7 +242,7 @@ describe('CLI', () => {
 
     it('should respect passing a custom mode', async () => {
       mockArgv('zip', '-m', 'development');
-      await import('../cli');
+      await import('../commands');
 
       expect(zipMock).toBeCalledWith({
         mode: 'development',
@@ -251,7 +251,7 @@ describe('CLI', () => {
 
     it('should respect passing a custom browser', async () => {
       mockArgv('zip', '-b', 'firefox');
-      await import('../cli');
+      await import('../commands');
 
       expect(zipMock).toBeCalledWith({
         browser: 'firefox',
@@ -260,7 +260,7 @@ describe('CLI', () => {
 
     it('should respect passing --mv2', async () => {
       mockArgv('zip', '--mv2');
-      await import('../cli');
+      await import('../commands');
 
       expect(zipMock).toBeCalledWith({
         manifestVersion: 2,
@@ -269,7 +269,7 @@ describe('CLI', () => {
 
     it('should respect passing --mv3', async () => {
       mockArgv('zip', '--mv3');
-      await import('../cli');
+      await import('../commands');
 
       expect(zipMock).toBeCalledWith({
         manifestVersion: 3,
@@ -278,7 +278,7 @@ describe('CLI', () => {
 
     it('should respect passing --debug', async () => {
       mockArgv('zip', '--debug');
-      await import('../cli');
+      await import('../commands');
 
       expect(zipMock).toBeCalledWith({
         debug: true,
@@ -289,14 +289,14 @@ describe('CLI', () => {
   describe('prepare', () => {
     it('should not pass any config when no flags are passed', async () => {
       mockArgv('prepare');
-      await import('../cli');
+      await import('../commands');
 
       expect(prepareMock).toBeCalledWith({});
     });
 
     it('should respect passing a custom root', async () => {
       mockArgv('prepare', 'path/to/root');
-      await import('../cli');
+      await import('../commands');
 
       expect(prepareMock).toBeCalledWith({
         root: 'path/to/root',
@@ -305,7 +305,7 @@ describe('CLI', () => {
 
     it('should respect a custom config file', async () => {
       mockArgv('prepare', '-c', './path/to/config.ts');
-      await import('../cli');
+      await import('../commands');
 
       expect(prepareMock).toBeCalledWith({
         configFile: './path/to/config.ts',
@@ -314,7 +314,7 @@ describe('CLI', () => {
 
     it('should respect passing --debug', async () => {
       mockArgv('prepare', '--debug');
-      await import('../cli');
+      await import('../commands');
 
       expect(prepareMock).toBeCalledWith({
         debug: true,
@@ -325,14 +325,14 @@ describe('CLI', () => {
   describe('clean', () => {
     it('should not pass any config when no flags are passed', async () => {
       mockArgv('clean');
-      await import('../cli');
+      await import('../commands');
 
       expect(cleanMock).toBeCalledWith(undefined);
     });
 
     it('should respect passing a custom root', async () => {
       mockArgv('clean', 'path/to/root');
-      await import('../cli');
+      await import('../commands');
 
       expect(cleanMock).toBeCalledWith('path/to/root');
     });
@@ -341,14 +341,14 @@ describe('CLI', () => {
   describe('init', () => {
     it('should not pass any options when no flags are passed', async () => {
       mockArgv('init');
-      await import('../cli');
+      await import('../commands');
 
       expect(initializeMock).toBeCalledWith({});
     });
 
     it('should respect the provided folder', async () => {
       mockArgv('init', 'path/to/folder');
-      await import('../cli');
+      await import('../commands');
 
       expect(initializeMock).toBeCalledWith({
         directory: 'path/to/folder',
@@ -357,7 +357,7 @@ describe('CLI', () => {
 
     it('should respect passing --template', async () => {
       mockArgv('init', '-t', 'vue');
-      await import('../cli');
+      await import('../commands');
 
       expect(initializeMock).toBeCalledWith({
         template: 'vue',
@@ -366,7 +366,7 @@ describe('CLI', () => {
 
     it('should respect passing --pm', async () => {
       mockArgv('init', '--pm', 'pnpm');
-      await import('../cli');
+      await import('../commands');
 
       expect(initializeMock).toBeCalledWith({
         packageManager: 'pnpm',

--- a/src/cli/cli-utils.ts
+++ b/src/cli/cli-utils.ts
@@ -1,0 +1,93 @@
+import { CAC, Command } from 'cac';
+import consola, { LogLevels } from 'consola';
+import { getInternalConfig } from '~/core/utils/building';
+import { exec } from '~/core/utils/exec';
+import { printHeader } from '~/core/utils/log';
+import { formatDuration } from '~/core/utils/time';
+import { ValidationError } from '~/core/utils/validation';
+
+/**
+ * Wrap an action handler to add a timer, error handling, and maybe enable debug mode.
+ */
+export function wrapAction(
+  cb: (
+    ...args: any[]
+  ) => void | { isOngoing?: boolean } | Promise<void | { isOngoing?: boolean }>,
+  options?: {
+    disableFinishedLog?: boolean;
+  },
+) {
+  return async (...args: any[]) => {
+    // Enable consola's debug mode globally at the start of all commands when the `--debug` flag is
+    // passed
+    const isDebug = !!args.find((arg) => arg?.debug);
+    if (isDebug) {
+      consola.level = LogLevels.debug;
+    }
+
+    const startTime = Date.now();
+    try {
+      printHeader();
+
+      const status = await cb(...args);
+
+      if (!status?.isOngoing && !options?.disableFinishedLog)
+        consola.success(
+          `Finished in ${formatDuration(Date.now() - startTime)}`,
+        );
+    } catch (err) {
+      consola.fail(
+        `Command failed after ${formatDuration(Date.now() - startTime)}`,
+      );
+      if (err instanceof ValidationError) {
+        // Don't log these errors, they've already been logged
+      } else {
+        consola.error(err);
+      }
+      process.exit(1);
+    }
+  };
+}
+
+/**
+ * Array flags, when not passed, are either `undefined` or `[undefined]`. This function filters out
+ * the
+ */
+export function getArrayFromFlags<T>(
+  flags: any,
+  name: string,
+): T[] | undefined {
+  const array = [flags[name]].flat() as Array<T | undefined>;
+  const result = array.filter((item) => item != null) as T[];
+  return result.length ? result : undefined;
+}
+
+const aliasCommandNames = new Set<string>();
+export function createAliasedCommand(
+  base: CAC,
+  name: string,
+  alias: string,
+  docsUrl: string,
+) {
+  const aliasedCommand = base
+    .command(name, `Alias for ${alias} (${docsUrl})`)
+    .allowUnknownOptions()
+    .action(async () => {
+      try {
+        const config = await getInternalConfig({}, 'build');
+        const args = process.argv.slice(
+          process.argv.indexOf(aliasedCommand.name) + 1,
+        );
+        await exec(config, alias, args, {
+          stdio: 'inherit',
+        });
+      } catch {
+        // Let the other aliased CLI log errors, just exit
+        process.exit(1);
+      }
+    });
+  aliasCommandNames.add(aliasedCommand.name);
+}
+export function isAliasedCommand(command: Command | undefined): boolean {
+  return !!command && aliasCommandNames.has(command.name);
+}

--- a/src/cli/commands.ts
+++ b/src/cli/commands.ts
@@ -1,17 +1,12 @@
 import cac from 'cac';
-import { version } from '~/version';
 import { build, clean, createServer, initialize, prepare, zip } from '~/core';
-import consola, { LogLevels } from 'consola';
-import { printHeader } from '~/core/utils/log';
-import { formatDuration } from '~/core/utils/time';
-import { ValidationError } from './core/utils/validation';
-
-// TODO: Remove. See https://github.com/wxt-dev/wxt/issues/277
-process.env.VITE_CJS_IGNORE_WARNING = 'true';
+import {
+  createAliasedCommand,
+  getArrayFromFlags,
+  wrapAction,
+} from './cli-utils';
 
 const cli = cac('wxt');
-cli.help();
-cli.version(version);
 
 cli.option('--debug', 'enable debug mode');
 
@@ -140,57 +135,12 @@ cli
     ),
   );
 
-cli.parse(process.argv);
+// SUBMIT
+createAliasedCommand(
+  cli,
+  'submit',
+  'publish-extension',
+  'https://www.npmjs.com/publish-browser-extension',
+);
 
-/**
- * Wrap an action handler to add a timer, error handling, and maybe enable debug mode.
- */
-function wrapAction(
-  cb: (
-    ...args: any[]
-  ) => void | { isOngoing?: boolean } | Promise<void | { isOngoing?: boolean }>,
-  options?: {
-    disableFinishedLog?: boolean;
-  },
-) {
-  return async (...args: any[]) => {
-    // Enable consola's debug mode globally at the start of all commands when the `--debug` flag is
-    // passed
-    const isDebug = !!args.find((arg) => arg?.debug);
-    if (isDebug) {
-      consola.level = LogLevels.debug;
-    }
-
-    const startTime = Date.now();
-    try {
-      printHeader();
-
-      const status = await cb(...args);
-
-      if (!status?.isOngoing && !options?.disableFinishedLog)
-        consola.success(
-          `Finished in ${formatDuration(Date.now() - startTime)}`,
-        );
-    } catch (err) {
-      consola.fail(
-        `Command failed after ${formatDuration(Date.now() - startTime)}`,
-      );
-      if (err instanceof ValidationError) {
-        // Don't log these errors, they've already been logged
-      } else {
-        consola.error(err);
-      }
-      process.exit(1);
-    }
-  };
-}
-
-/**
- * Array flags, when not passed, are either `undefined` or `[undefined]`. This function filters out
- * the
- */
-function getArrayFromFlags<T>(flags: any, name: string): T[] | undefined {
-  const array = [flags[name]].flat() as Array<T | undefined>;
-  const result = array.filter((item) => item != null) as T[];
-  return result.length ? result : undefined;
-}
+export default cli;

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -1,0 +1,19 @@
+import cli from './commands';
+import { version } from '~/version';
+import { isAliasedCommand } from './cli-utils';
+
+// TODO: Remove. See https://github.com/wxt-dev/wxt/issues/277
+process.env.VITE_CJS_IGNORE_WARNING = 'true';
+
+// Grab the command that we're trying to run
+cli.parse(process.argv, { run: false });
+
+// If it's not an alias, add the help and version options, then parse again
+if (!isAliasedCommand(cli.matchedCommand)) {
+  cli.help();
+  cli.version(version);
+  cli.parse(process.argv, { run: false });
+}
+
+// Run the alias or command
+await cli.runMatchedCommand();

--- a/src/core/utils/exec.ts
+++ b/src/core/utils/exec.ts
@@ -1,0 +1,24 @@
+import { execa, Options } from 'execa';
+import managePath from 'manage-path';
+import { resolve } from 'node:path';
+import { InternalConfig } from '~/types';
+
+const managedPath = managePath(process.env);
+
+/**
+ * Wrapper around `execa` with a modified `PATH` variable containing CLI tools from WXT's dependencies.
+ */
+export const exec = (
+  config: InternalConfig,
+  file: string,
+  args?: readonly string[],
+  options?: Options,
+) => {
+  // Reset so the same path isn't added multiple times
+  managedPath.restore();
+
+  // Add subdependency path for PNPM shamefully-hoist=false
+  managedPath.push(resolve(config.root, 'node_modules/wxt/node_modules/.bin'));
+
+  return execa(file, args, options);
+};

--- a/src/core/utils/exec.ts
+++ b/src/core/utils/exec.ts
@@ -1,4 +1,4 @@
-import { execa, Options } from 'execa';
+import type { Options } from 'execa';
 import managePath from 'manage-path';
 import { resolve } from 'node:path';
 import { InternalConfig } from '~/types';
@@ -8,7 +8,7 @@ const managedPath = managePath(process.env);
 /**
  * Wrapper around `execa` with a modified `PATH` variable containing CLI tools from WXT's dependencies.
  */
-export const exec = (
+export const exec = async (
   config: InternalConfig,
   file: string,
   args?: readonly string[],
@@ -20,5 +20,6 @@ export const exec = (
   // Add subdependency path for PNPM shamefully-hoist=false
   managedPath.push(resolve(config.root, 'node_modules/wxt/node_modules/.bin'));
 
-  return execa(file, args, options);
+  const { execa } = await import('execa');
+  return await execa(file, args, options);
 };

--- a/src/types/modules.d.ts
+++ b/src/types/modules.d.ts
@@ -51,7 +51,15 @@ declare module 'web-ext-run/util/logger' {
 }
 
 declare module 'manage-path' {
-  export default function managePath(env: object): string[];
+  export interface ManagedPath {
+    push(...paths: string[]);
+    push(paths: string[]);
+    shift(...paths: string[]);
+    shift(paths: string[]);
+    get(): string;
+    restore(): void;
+  }
+  export default function managePath(env: object): ManagedPath;
 }
 
 declare module 'wxt/browser' {


### PR DESCRIPTION
This closes #57!

Adds the `wxt submit` and `wxt submit init` commands. Not using the word "publish" since `npm publish` is a built-in command. Naming it submit will hopefully guide people to calling their package.json scripts "submit" as well.