### PR TITLE
fix: Generate missing sourcemap in `wxt:unimport` plugin

### DIFF
--- a/src/core/builders/vite/plugins/unimport.ts
+++ b/src/core/builders/vite/plugins/unimport.ts
@@ -36,7 +36,12 @@ export function unimport(
       // Don't transform non-js files
       if (!ENABLED_EXTENSIONS.has(extname(id))) return;
 
-      return unimport.injectImports(code, id);
+      const injected = await unimport.injectImports(code, id);
+      return {
+        code: injected.code,
+        map: injected.s.generateMap({ hires: 'boundary', source: id }),
+      };
+      // return
     },
   };
 }


### PR DESCRIPTION
Apart of #236, addresses issue with `wxt:unimport` plugin transforming code, but not providing sourcemaps for the transformed code. 