### PR TITLE
fix: Enable inline sourcemaps by default during development

### DIFF
--- a/src/core/builders/vite/index.ts
+++ b/src/core/builders/vite/index.ts
@@ -44,6 +44,10 @@ export async function createViteBuilder(
     if (config.build.minify == null && wxtConfig.command === 'serve') {
       config.build.minify = false;
     }
+    // Enable inline sourcemaps for the dev command (so content scripts have sourcemaps)
+    if (config.build.sourcemap == null && wxtConfig.command === 'serve') {
+      config.build.sourcemap = 'inline';
+    }
 
     config.plugins ??= [];
     config.plugins.push(


### PR DESCRIPTION
This closes #236.

Still facing the problem where chrome ignores loading sourcemaps by default, but the workaround is to use a custom profile with the setting disabled, as mentioned in https://github.com/wxt-dev/wxt/issues/236#issuecomment-1915049984