### PR TITLE
fix(dev): Reload `<name>/index.html` entrypoints properly on save

### DIFF
--- a/src/core/utils/building/__tests__/detect-dev-changes.test.ts
+++ b/src/core/utils/building/__tests__/detect-dev-changes.test.ts
@@ -184,16 +184,16 @@ describe('Detect Dev Changes', () => {
       const step1: BuildStepOutput = {
         entrypoints: [htmlPage1, htmlPage2],
         chunks: [
-          fakeOutputChunk({
-            moduleIds: [fakeFile(), changedPath],
+          fakeOutputAsset({
+            fileName: 'page1.html',
           }),
         ],
       };
       const step2: BuildStepOutput = {
         entrypoints: [htmlPage3],
         chunks: [
-          fakeOutputChunk({
-            moduleIds: [fakeFile(), fakeFile(), fakeFile()],
+          fakeOutputAsset({
+            fileName: 'page2.html',
           }),
         ],
       };

--- a/src/core/utils/building/__tests__/detect-dev-changes.test.ts
+++ b/src/core/utils/building/__tests__/detect-dev-changes.test.ts
@@ -167,9 +167,9 @@ describe('Detect Dev Changes', () => {
   });
 
   describe('HTML Pages', () => {
-    it('should rebuild then reload only the effected pages', async () => {
+    it('should detect changes to entrypoints/<name>.html files', async () => {
       const config = fakeInternalConfig();
-      const changedPath = '/root/page1/index.html';
+      const changedPath = '/root/page1.html';
       const htmlPage1 = fakePopupEntrypoint({
         inputPath: changedPath,
       });
@@ -179,6 +179,56 @@ describe('Detect Dev Changes', () => {
       const htmlPage3 = fakeGenericEntrypoint({
         type: 'sandbox',
         inputPath: '/root/page3.html',
+      });
+
+      const step1: BuildStepOutput = {
+        entrypoints: [htmlPage1, htmlPage2],
+        chunks: [
+          fakeOutputAsset({
+            fileName: 'page1.html',
+          }),
+        ],
+      };
+      const step2: BuildStepOutput = {
+        entrypoints: [htmlPage3],
+        chunks: [
+          fakeOutputAsset({
+            fileName: 'page2.html',
+          }),
+        ],
+      };
+
+      const currentOutput: BuildOutput = {
+        manifest: fakeManifest(),
+        publicAssets: [],
+        steps: [step1, step2],
+      };
+      const expected: DevModeChange = {
+        type: 'html-reload',
+        cachedOutput: {
+          ...currentOutput,
+          steps: [step2],
+        },
+        rebuildGroups: [[htmlPage1, htmlPage2]],
+      };
+
+      const actual = detectDevChanges(config, [changedPath], currentOutput);
+
+      expect(actual).toEqual(expected);
+    });
+
+    it('should detect changes to entrypoints/<name>/index.html files', async () => {
+      const config = fakeInternalConfig();
+      const changedPath = '/root/page1/index.html';
+      const htmlPage1 = fakePopupEntrypoint({
+        inputPath: changedPath,
+      });
+      const htmlPage2 = fakeOptionsEntrypoint({
+        inputPath: '/root/page2/index.html',
+      });
+      const htmlPage3 = fakeGenericEntrypoint({
+        type: 'sandbox',
+        inputPath: '/root/page3/index.html',
       });
 
       const step1: BuildStepOutput = {

--- a/src/core/utils/building/detect-dev-changes.ts
+++ b/src/core/utils/building/detect-dev-changes.ts
@@ -123,11 +123,12 @@ function findEffectedSteps(
   const changedPath = normalizePath(changedFile);
 
   const isChunkEffected = (chunk: OutputFile): boolean =>
-    // If it's an HTML file with the same path, is is effected because HTML files need to be pre-rendered
-    // fileName is normalized, relative bundle path
-    (chunk.type === 'asset' && changedPath.endsWith(chunk.fileName)) ||
+    // If it's an HTML file with the same path, is is effected because HTML files need to be re-rendered
+    // - fileName is normalized, relative bundle path, "<entrypoint-name>.html"
+    (chunk.type === 'asset' &&
+      changedPath.replace('/index.html', '.html').endsWith(chunk.fileName)) ||
     // If it's a chunk that depends on the changed file, it is effected
-    // moduleIds are absolute, normalized paths
+    // - moduleIds are absolute, normalized paths
     (chunk.type === 'chunk' && chunk.moduleIds.includes(changedPath));
 
   for (const step of currentOutput.steps) {


### PR DESCRIPTION
This closes #388. See https://github.com/wxt-dev/wxt/issues/388#issuecomment-1919216744 for a description of the problem.