### PR TITLE
chore: Add dependabot for github actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,7 @@ updates:
     directory: '/' # Location of package manifests
     schedule:
       interval: 'monthly'
+  - package-ecosystem: 'github-actions'
+    directory: '/'
+    schedule:
+      interval: 'monthly'


### PR DESCRIPTION
Dependabot should also watch GitHub Actions for updates.


Ideally I would like to migrate it to [renovate](https://github.com/renovatebot/renovate) as I do find renovate a lot more extensible / useful as you can have one config for all your packages / projects in one repository and it has way more dependency checks it can do like actions, npm modules, your package.json's `packageManager` field and many more. Plus it can automerge if checks pass like tests (if enabled)