### PR TITLE
fix: Exclude analysis files from the build summary

### DIFF
--- a/src/core/builders/vite/index.ts
+++ b/src/core/builders/vite/index.ts
@@ -66,7 +66,7 @@ export async function createViteBuilder(
       wxtPlugins.defineImportMeta(),
     );
     if (wxtConfig.analysis.enabled) {
-      config.plugins.push(wxtPlugins.bundleAnalysis());
+      config.plugins.push(wxtPlugins.bundleAnalysis(wxtConfig));
     }
 
     return config;

--- a/src/core/builders/vite/plugins/bundleAnalysis.ts
+++ b/src/core/builders/vite/plugins/bundleAnalysis.ts
@@ -1,12 +1,15 @@
 import type * as vite from 'vite';
 import { visualizer } from 'rollup-plugin-visualizer';
+import { ResolvedConfig } from '~/types';
+import path from 'node:path';
 
 let increment = 0;
 
-export function bundleAnalysis(): vite.Plugin {
+export function bundleAnalysis(
+  config: Omit<ResolvedConfig, 'builder'>,
+): vite.Plugin {
   return visualizer({
-    emitFile: true,
     template: 'raw-data',
-    filename: `stats-${increment++}.json`,
+    filename: path.resolve(config.outDir, `.stats-${increment++}.json`),
   }) as vite.Plugin;
 }

--- a/src/core/builders/vite/plugins/bundleAnalysis.ts
+++ b/src/core/builders/vite/plugins/bundleAnalysis.ts
@@ -10,6 +10,6 @@ export function bundleAnalysis(
 ): vite.Plugin {
   return visualizer({
     template: 'raw-data',
-    filename: path.resolve(config.outDir, `.stats-${increment++}.json`),
+    filename: path.resolve(config.outDir, `stats-${increment++}.json`),
   }) as vite.Plugin;
 }

--- a/src/core/utils/building/build-entrypoints.ts
+++ b/src/core/utils/building/build-entrypoints.ts
@@ -20,6 +20,7 @@ export async function buildEntrypoints(
     try {
       steps.push(await wxt.config.builder.build(group));
     } catch (err) {
+      wxt.logger.error(err);
       throw Error(`Failed to build ${groupNames.join(', ')}`, { cause: err });
     }
   }

--- a/src/core/utils/building/internal-build.ts
+++ b/src/core/utils/building/internal-build.ts
@@ -97,6 +97,7 @@ async function combineAnalysisStats(): Promise<void> {
     [...absolutePaths, '--template', wxt.config.analysis.template],
     { cwd: wxt.config.root, stdio: 'inherit' },
   );
+  await Promise.all(absolutePaths.map((statsFile) => fs.remove(statsFile)));
 }
 
 function printValidationResults({


### PR DESCRIPTION
This closes #422. Removing `emitFile: true` removed the stats files from the vite output since they're now written to the output directory by the `fs` module instead of being added to vite's bundle (which is used to generate the build summary)

I also removed the files after the `stats.html` file is generated.

