### PR TITLE
feat: Add option to customize the analysis output filename

### DIFF
--- a/src/core/utils/building/internal-build.ts
+++ b/src/core/utils/building/internal-build.ts
@@ -77,8 +77,9 @@ export async function internalBuild(): Promise<BuildOutput> {
 
   if (wxt.config.analysis.enabled) {
     await combineAnalysisStats();
+    const statsPath = relative(wxt.config.root, wxt.config.analysis.outputFile);
     wxt.logger.info(
-      `Analysis complete:\n  ${pc.gray('└─')} ${pc.yellow('stats.html')}`,
+      `Analysis complete:\n  ${pc.gray('└─')} ${pc.yellow(statsPath)}`,
     );
   }
 
@@ -94,7 +95,13 @@ async function combineAnalysisStats(): Promise<void> {
 
   await exec(
     'rollup-plugin-visualizer',
-    [...absolutePaths, '--template', wxt.config.analysis.template],
+    [
+      ...absolutePaths,
+      '--template',
+      wxt.config.analysis.template,
+      '--filename',
+      wxt.config.analysis.outputFile,
+    ],
     { cwd: wxt.config.root, stdio: 'inherit' },
   );
 }

--- a/src/core/utils/building/resolve-config.ts
+++ b/src/core/utils/building/resolve-config.ts
@@ -129,6 +129,10 @@ export async function resolveConfig(
     analysis: {
       enabled: mergedConfig.analysis?.enabled ?? false,
       template: mergedConfig.analysis?.template ?? 'treemap',
+      outputFile: path.resolve(
+        root,
+        mergedConfig.analysis?.outputFile ?? 'stats.html',
+      ),
     },
     userConfigMetadata: userConfigMetadata ?? {},
     alias,
@@ -216,9 +220,8 @@ function mergeInlineConfig(
     outDir: inlineConfig.outDir ?? userConfig.outDir,
     zip,
     analysis: {
-      enabled: inlineConfig.analysis?.enabled ?? userConfig.analysis?.enabled,
-      template:
-        inlineConfig.analysis?.template ?? userConfig.analysis?.template,
+      ...userConfig.analysis,
+      ...inlineConfig.analysis,
     },
     alias: {
       ...userConfig.alias,

--- a/src/core/utils/testing/fake-objects.ts
+++ b/src/core/utils/testing/fake-objects.ts
@@ -236,6 +236,7 @@ export const fakeResolvedConfig = fakeObjectCreator<ResolvedConfig>(() => {
     analysis: {
       enabled: false,
       template: 'treemap',
+      outputFile: 'stats.html',
     },
     zip: {
       artifactTemplate: '{{name}}-{{version}}.zip',

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -209,6 +209,12 @@ export interface InlineConfig {
      * @default "treemap"
      */
     template?: PluginVisualizerOptions['template'];
+    /**
+     * Name of the output HTML file. Relative to the project's root directory.
+     *
+     * @default "stats.html"
+     */
+    outputFile?: string;
   };
   /**
    * Add additional paths to the `.wxt/tsconfig.json`. Use this instead of overwriting the `paths`
@@ -895,6 +901,8 @@ export interface ResolvedConfig {
   analysis: {
     enabled: boolean;
     template: NonNullable<PluginVisualizerOptions['template']>;
+    /** Absolute file path */
+    outputFile: string;
   };
   userConfigMetadata: Omit<C12ResolvedConfig<UserConfig>, 'config'>;
   /**


### PR DESCRIPTION
See #422. To add a timestamp:

```ts
export default defineConfig({
  analysis: {
    outputFile: `stats-${Date.now()}.html`
  },
});
```
