### PR TITLE
fix: Use `insertBefore` on mounting content script UI

### DIFF
--- a/src/client/content-scripts/ui/__tests__/index.test.ts
+++ b/src/client/content-scripts/ui/__tests__/index.test.ts
@@ -367,7 +367,7 @@ describe('Content Script UIs', () => {
       });
     });
 
-    describe.todo('after', () => {
+    describe('after', () => {
       it('should append the UI after the anchor', () => {
         const ui = createIntegratedUi(ctx, {
           position: 'inline',

--- a/src/client/content-scripts/ui/index.ts
+++ b/src/client/content-scripts/ui/index.ts
@@ -217,10 +217,10 @@ function mountUi(
       anchor.replaceWith(root);
       break;
     case 'after':
-      anchor.replaceWith(anchor, root);
+      anchor.parentElement?.insertBefore(root, anchor.nextElementSibling);
       break;
     case 'before':
-      anchor.replaceWith(root, anchor);
+      anchor.parentElement?.insertBefore(root, anchor);
       break;
     default:
       options.append(anchor, root);

--- a/src/client/content-scripts/ui/index.ts
+++ b/src/client/content-scripts/ui/index.ts
@@ -211,11 +211,7 @@ function mountUi(
       anchor.append(root);
       break;
     case 'first':
-      if (anchor.firstChild) {
-        anchor.insertBefore(root, anchor.firstChild);
-      } else {
-        anchor.append(root);
-      }
+      anchor.prepend(root);
       break;
     case 'replace':
       anchor.replaceWith(root);


### PR DESCRIPTION
`insertBefore` recreates the anchor element.
When using dynamic injection triggered by adding the anchor element, the browser will run into infinite loop.
and mini refactor included.