### PR TITLE
chore(e2e): Use `wxt prepare` instead of `wxt build` when possible to speed up E2E tests

### DIFF
--- a/e2e/tests/auto-imports.test.ts
+++ b/e2e/tests/auto-imports.test.ts
@@ -7,7 +7,7 @@ describe('Auto Imports', () => {
       const project = new TestProject();
       project.addFile('entrypoints/popup.html', `<html></html>`);
 
-      await project.build();
+      await project.prepare();
 
       expect(await project.serializeFile('.wxt/types/imports.d.ts'))
         .toMatchInlineSnapshot(`
@@ -38,7 +38,7 @@ describe('Auto Imports', () => {
       const project = new TestProject();
       project.addFile('entrypoints/popup.html', `<html></html>`);
 
-      await project.build();
+      await project.prepare();
 
       expect(await project.serializeFile('.wxt/wxt.d.ts'))
         .toMatchInlineSnapshot(`
@@ -63,7 +63,7 @@ describe('Auto Imports', () => {
       });
       project.addFile('entrypoints/popup.html', `<html></html>`);
 
-      await project.build();
+      await project.prepare();
 
       expect(await project.fileExists('.wxt/types/imports.d.ts')).toBe(false);
     });
@@ -75,7 +75,7 @@ describe('Auto Imports', () => {
       });
       project.addFile('entrypoints/popup.html', `<html></html>`);
 
-      await project.build();
+      await project.prepare();
 
       expect(
         await project.serializeFile('.wxt/wxt.d.ts'),

--- a/e2e/tests/typescript-project.test.ts
+++ b/e2e/tests/typescript-project.test.ts
@@ -6,7 +6,7 @@ describe('TypeScript Project', () => {
     const project = new TestProject();
     project.addFile('entrypoints/unlisted.html');
 
-    await project.build();
+    await project.prepare();
 
     const output = await project.serializeFile('.wxt/types/globals.d.ts');
     expect(output).toMatchInlineSnapshot(`
@@ -38,7 +38,7 @@ describe('TypeScript Project', () => {
     project.addFile('entrypoints/options.html');
     project.addFile('entrypoints/sandbox.html');
 
-    await project.build();
+    await project.prepare();
 
     const output = await project.serializeFile('.wxt/types/paths.d.ts');
     expect(output).toMatchInlineSnapshot(`
@@ -103,7 +103,7 @@ describe('TypeScript Project', () => {
       },
     });
 
-    await project.build();
+    await project.prepare();
 
     const output = await project.serializeFile('.wxt/types/i18n.d.ts');
     expect(output).toMatchInlineSnapshot(`
@@ -225,7 +225,7 @@ describe('TypeScript Project', () => {
     const project = new TestProject();
     project.addFile('entrypoints/unlisted.html');
 
-    await project.build();
+    await project.prepare();
 
     const output = await project.serializeFile('.wxt/wxt.d.ts');
     expect(output).toMatchInlineSnapshot(`
@@ -245,7 +245,7 @@ describe('TypeScript Project', () => {
     const project = new TestProject();
     project.addFile('entrypoints/unlisted.html');
 
-    await project.build();
+    await project.prepare();
 
     const output = await project.serializeFile('.wxt/tsconfig.json');
     expect(output).toMatchInlineSnapshot(`
@@ -289,7 +289,7 @@ describe('TypeScript Project', () => {
       srcDir: 'src',
     });
 
-    await project.build();
+    await project.prepare();
 
     const output = await project.serializeFile('.wxt/tsconfig.json');
     expect(output).toMatchInlineSnapshot(`
@@ -337,7 +337,7 @@ describe('TypeScript Project', () => {
       },
     });
 
-    await project.build();
+    await project.prepare();
 
     const output = await project.serializeFile('.wxt/tsconfig.json');
     expect(output).toMatchInlineSnapshot(`


### PR DESCRIPTION
| Case | Before | After |
| --- | --- | --- |
| `pnpm test run` on Windows CI | 44s | 45s |
| `pnpm test:coverage` on Linux CI | 37s | 37s |

So no actual change to test performance