### PR TITLE
fix: Don't assume react when importing JSX entrypoints during build

### DIFF
--- a/src/core/utils/building/import-entrypoint.ts
+++ b/src/core/utils/building/import-entrypoint.ts
@@ -105,6 +105,13 @@ function getEsbuildOptions(opts: JitiTransformOptions): TransformOptions {
   return {
     format: 'cjs',
     loader: isJsx ? 'tsx' : 'ts',
-    jsx: isJsx ? 'automatic' : undefined,
+    ...(isJsx
+      ? {
+          // `h` and `Fragment` are undefined, but that's OK because JSX is never evaluated while
+          // grabbing the entrypoint's options.
+          jsxFactory: 'h',
+          jsxFragment: 'Fragment',
+        }
+      : undefined),
   };
 }


### PR DESCRIPTION
This closes #463