### PR TITLE
feat: Customize when content scripts are registered, in the manifest or at runtime

### DIFF
--- a/docs/entrypoints/content-scripts.md
+++ b/docs/entrypoints/content-scripts.md
@@ -37,6 +37,9 @@ export default defineContentScript({
   // Configure how CSS is injected onto the page
   cssInjectionMode: undefined | "manifest" | "manual" | "ui",
 
+  // Configure how/when content script will be registered
+  registration: undefined | "manifest" | "runtime",
+
   main(ctx) {
     // Executed when content script is loaded
   },

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -507,6 +507,18 @@ export interface BaseContentScriptEntrypointOptions
    * @default "manifest"
    */
   cssInjectionMode?: PerBrowserOption<'manifest' | 'manual' | 'ui'>;
+  /**
+   * Specify how the content script is registered.
+   *
+   * - `"manifest"`: The content script will be added to the `content_scripts` entry in the
+   *   manifest. This is the normal and most well known way of registering a content script.
+   * - `"runtime"`: The content script's `matches` is added to `host_permissions` and you are
+   *   responsible for using the scripting API to register the content script dynamically at
+   *   runtime.
+   *
+   * @default "manifest"
+   */
+  registration?: PerBrowserOption<'manifest' | 'runtime'>;
 }
 
 export interface MainWorldContentScriptEntrypointOptions


### PR DESCRIPTION
This closes #469 