### PR TITLE
fix: Output main JS file for HTML entrypoints to chunks directory

### DIFF
--- a/src/core/create-server.ts
+++ b/src/core/create-server.ts
@@ -5,7 +5,10 @@ import {
   ServerInfo,
   WxtDevServer,
 } from '~/types';
-import { getEntrypointBundlePath } from '~/core/utils/entrypoints';
+import {
+  getEntrypointBundlePath,
+  isHtmlEntrypoint,
+} from '~/core/utils/entrypoints';
 import {
   getContentScriptCssFiles,
   getContentScriptsCssMap,
@@ -248,9 +251,7 @@ function reloadHtmlPages(
   server: WxtDevServer,
 ): { reloadedNames: string[] } {
   // groups might contain other files like background/content scripts, and we only care about the HTMl pages
-  const htmlEntries = groups
-    .flat()
-    .filter((entry) => entry.inputPath.endsWith('.html'));
+  const htmlEntries = groups.flat().filter(isHtmlEntrypoint);
 
   htmlEntries.forEach((entry) => {
     const path = getEntrypointBundlePath(entry, wxt.config.outDir, '.html');

--- a/src/core/utils/building/generate-wxt-dir.ts
+++ b/src/core/utils/building/generate-wxt-dir.ts
@@ -6,7 +6,10 @@ import {
 } from '~/types';
 import fs from 'fs-extra';
 import { relative, resolve } from 'path';
-import { getEntrypointBundlePath } from '~/core/utils/entrypoints';
+import {
+  getEntrypointBundlePath,
+  isHtmlEntrypoint,
+} from '~/core/utils/entrypoints';
 import { getEntrypointGlobals, getGlobals } from '~/core/utils/globals';
 import { normalizePath } from '~/core/utils/paths';
 import path from 'node:path';
@@ -82,7 +85,7 @@ async function writePathsDeclarationFile(
       getEntrypointBundlePath(
         entry,
         wxt.config.outDir,
-        entry.inputPath.endsWith('.html') ? '.html' : '.js',
+        isHtmlEntrypoint(entry) ? '.html' : '.js',
       ),
     )
     .concat(await getPublicFiles())

--- a/src/core/utils/entrypoints.ts
+++ b/src/core/utils/entrypoints.ts
@@ -70,3 +70,12 @@ export function resolvePerBrowserOptions<
     ]),
   );
 }
+
+/**
+ * Returns true when the entrypoint is an HTML entrypoint.
+ *
+ * Naively just checking the file extension of the input path.
+ */
+export function isHtmlEntrypoint(entrypoint: Entrypoint): boolean {
+  return entrypoint.inputPath.endsWith('.html');
+}


### PR DESCRIPTION
This closes #421 

It seems like vite logs this error when a script outside the chunks directory is mentioned in the HTML file? Not really sure why, but that was the only difference I found.