### PR TITLE
feat(manifest): Automatically add `sidePanel` permission

### DIFF
--- a/src/core/utils/manifest.ts
+++ b/src/core/utils/manifest.ts
@@ -338,6 +338,7 @@ function addEntrypoints(
         open_at_install: defaultSidepanel.options.openAtInstall,
       };
     } else if (wxt.config.manifestVersion === 3) {
+      addPermission(manifest, 'sidePanel');
       // @ts-expect-error: Untyped
       manifest.side_panel = {
         default_path: page,


### PR DESCRIPTION
 Automatically add sidePanel permission when a sidepanel entrypoint exists