### PR TITLE
fix: Resolve the path to `node_modules/wxt` correctly

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "wxt",
   "type": "module",
-  "version": "0.17.3",
+  "version": "0.17.4-alpha1",
   "description": "Next gen framework for developing web extensions",
   "engines": {
     "node": ">=18",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "wxt",
   "type": "module",
-  "version": "0.17.4-alpha1",
+  "version": "0.17.3",
   "description": "Next gen framework for developing web extensions",
   "engines": {
     "node": ">=18",

--- a/src/core/utils/building/resolve-config.ts
+++ b/src/core/utils/building/resolve-config.ts
@@ -330,7 +330,7 @@ async function getUnimportOptions(
  */
 async function resolveWxtModuleDir() {
   // require.resolve returns the wxt/dist/index file
-  let requireResolve =
+  const requireResolve =
     require?.resolve ??
     (await import('node:module')).default.createRequire(import.meta.url)
       .resolve;

--- a/src/core/utils/building/resolve-config.ts
+++ b/src/core/utils/building/resolve-config.ts
@@ -71,7 +71,7 @@ export async function resolveConfig(
     inlineConfig.root ?? userConfig.root ?? process.cwd(),
   );
   const wxtDir = path.resolve(root, '.wxt');
-  const wxtModuleDir = resolveWxtModuleDir();
+  const wxtModuleDir = await resolveWxtModuleDir();
   const srcDir = path.resolve(root, mergedConfig.srcDir ?? root);
   const entrypointsDir = path.resolve(
     srcDir,
@@ -328,7 +328,11 @@ async function getUnimportOptions(
 /**
  * Returns the path to `node_modules/wxt`.
  */
-export function resolveWxtModuleDir() {
+async function resolveWxtModuleDir() {
   // require.resolve returns the wxt/dist/index file
-  return path.resolve(require.resolve('wxt'), '../..');
+  let requireResolve =
+    require?.resolve ??
+    (await import('node:module')).default.createRequire(import.meta.url)
+      .resolve;
+  return path.resolve(requireResolve('wxt'), '../..');
 }

--- a/src/core/utils/building/resolve-config.ts
+++ b/src/core/utils/building/resolve-config.ts
@@ -329,10 +329,10 @@ async function getUnimportOptions(
  * Returns the path to `node_modules/wxt`.
  */
 async function resolveWxtModuleDir() {
-  // require.resolve returns the wxt/dist/index file
   const requireResolve =
     require?.resolve ??
     (await import('node:module')).default.createRequire(import.meta.url)
       .resolve;
+  // require.resolve returns the wxt/dist/index file, not the package's root directory, which we want to return
   return path.resolve(requireResolve('wxt'), '../..');
 }

--- a/src/core/utils/building/resolve-config.ts
+++ b/src/core/utils/building/resolve-config.ts
@@ -71,7 +71,7 @@ export async function resolveConfig(
     inlineConfig.root ?? userConfig.root ?? process.cwd(),
   );
   const wxtDir = path.resolve(root, '.wxt');
-  const wxtModuleDir = path.resolve(root, 'node_modules/wxt');
+  const wxtModuleDir = resolveWxtModuleDir();
   const srcDir = path.resolve(root, mergedConfig.srcDir ?? root);
   const entrypointsDir = path.resolve(
     srcDir,
@@ -323,4 +323,12 @@ async function getUnimportOptions(
     config.imports ?? {},
     defaultOptions,
   );
+}
+
+/**
+ * Returns the path to `node_modules/wxt`.
+ */
+export function resolveWxtModuleDir() {
+  // require.resolve returns the wxt/dist/index file
+  return path.resolve(require.resolve('wxt'), '../..');
 }


### PR DESCRIPTION
This closes #457

- [x] Works in an ESM project
- [x] Works in a CJS project
- [x] Works in PNPM monorepo
- [x] Works in Yarn monorepo
- [x] Works in NPM monorepo