### PR TITLE
feat: Automatically remove top-level MV2-only or MV3-only keys

### DIFF
--- a/docs/guide/manifest.md
+++ b/docs/guide/manifest.md
@@ -130,6 +130,74 @@ See the official localization examples for more details:
 
 <ExampleList tag="i18n" />
 
+## Per-Manifest Version Config
+
+WXT applies several transformations to your manifest to simplify managing both MV2 and MV3 keys in your `wxt.config.ts` file:
+
+1. Top level MV2-only or MV3-only keys are stripped from the final manifest when targeting the other manifest version
+2. Some keys, are automatically converted between versions when possible:
+   - Define `web_accessible_resources` in it's MV3 style and it will be converted to the MV2 style automatically
+
+For example, a `wxt.config.ts` file that looks like this:
+
+```ts
+import { defineConfig } from 'wxt';
+
+export default defineConfig({
+  mainfest: {
+    action: {
+      default_title: 'Some MV3 Title',
+    },
+    browser_action: {
+      default_title: 'Some MV2 Title',
+    },
+    web_accessible_resources: [
+      {
+        matches: ['*://*.google.com/*'],
+        resources: ['icon/*.png'],
+      },
+    ],
+  },
+});
+```
+
+Will be output differently for each manifest version:
+
+:::code-group
+
+```json [MV2]
+{
+  "manifest_version": 2,
+  // ...
+  "browser_action": {
+    "default_title": "Some MV2 Title"
+  },
+  "web_accessible_resources": ["icon/*.png"]
+}
+```
+
+```json [MV3]
+{
+  "manifest_version": 3,
+  // ...
+  "action": {
+    "default_title": "Some MV3 Title"
+  },
+  "web_accessible_resources": [
+    {
+      "matches": ["*://*.google.com/*"],
+      "resources": ["icon/*.png"]
+    }
+  ]
+}
+```
+
+:::
+
+:::tip
+If this isn't enough control for your use-case, remember you can use a function for the `manifest` key and generate it however you'd like, or you can use the `build:manifestGenerated` hook to apply additional transformations.
+:::
+
 ## Per-Browser Configuration
 
 The `manifest` field can be a function. If you are building and extension for multiple browsers, and need to modify the manifest per browser, using a function instead of an object is very useful.

--- a/src/browser.ts
+++ b/src/browser.ts
@@ -51,7 +51,7 @@ export type {
   Identity,
   Idle,
   Management,
-  Manifest,
+  Manifest, // TODO: Export custom manifest types that are valid for both Chrome and Firefox.
   ContextMenus,
   Menus,
   NetworkStatus,

--- a/src/core/utils/__tests__/manifest.test.ts
+++ b/src/core/utils/__tests__/manifest.test.ts
@@ -1306,6 +1306,76 @@ describe('Manifest Utils', () => {
         expect(actual.commands).toBeUndefined();
       });
     });
+
+    describe('Stripping keys', () => {
+      const mv2Manifest = {
+        page_action: {},
+        browser_action: {},
+        automation: {},
+        content_capabilities: {},
+        converted_from_user_script: {},
+        current_locale: {},
+        differential_fingerprint: {},
+        event_rules: {},
+        file_browser_handlers: {},
+        file_system_provider_capabilities: {},
+        input_components: {},
+        nacl_modules: {},
+        natively_connectable: {},
+        offline_enabled: {},
+        platforms: {},
+        replacement_web_app: {},
+        system_indicator: {},
+        user_scripts: {},
+      };
+      const mv3Manifest = {
+        action: {},
+        export: {},
+        optional_host_permissions: {},
+        side_panel: {},
+      };
+      const hostPermissionsManifest = {
+        host_permissions: {},
+      };
+      const manifest: any = {
+        ...mv2Manifest,
+        ...mv3Manifest,
+        ...hostPermissionsManifest,
+      };
+
+      it.each([
+        ['firefox', 2, mv2Manifest],
+        ['chrome', 2, { ...mv2Manifest, ...hostPermissionsManifest }],
+        ['safari', 2, { ...mv2Manifest, ...hostPermissionsManifest }],
+        ['edge', 2, { ...mv2Manifest, ...hostPermissionsManifest }],
+        ['firefox', 3, { ...mv3Manifest, ...hostPermissionsManifest }],
+        ['chrome', 3, { ...mv3Manifest, ...hostPermissionsManifest }],
+        ['safari', 3, { ...mv3Manifest, ...hostPermissionsManifest }],
+        ['edge', 3, { ...mv3Manifest, ...hostPermissionsManifest }],
+      ] as const)(
+        "%s MV%s should only include that version's keys",
+        async (browser, manifestVersion, expected) => {
+          setFakeWxt({
+            config: {
+              browser,
+              manifest,
+              manifestVersion,
+              command: 'build',
+            },
+          });
+          const output = fakeBuildOutput();
+
+          const { manifest: actual } = await generateManifest([], output);
+
+          expect(actual).toEqual({
+            name: expect.any(String),
+            version: expect.any(String),
+            manifest_version: manifestVersion,
+            ...expected,
+          });
+        },
+      );
+    });
   });
 
   describe('stripPathFromMatchPattern', () => {

--- a/src/core/utils/__tests__/manifest.test.ts
+++ b/src/core/utils/__tests__/manifest.test.ts
@@ -111,6 +111,7 @@ describe('Manifest Utils', () => {
         setFakeWxt({
           config: {
             outDir,
+            manifestVersion: 3,
             manifest: {
               action: {
                 default_icon: 'icon-16.png',

--- a/src/core/utils/manifest.ts
+++ b/src/core/utils/manifest.ts
@@ -110,6 +110,8 @@ export async function generateManifest(
   if (wxt.config.command === 'serve') addDevModeCsp(manifest);
   if (wxt.config.command === 'serve') addDevModePermissions(manifest);
 
+  stripKeys(manifest);
+
   // TODO: Remove in v1
   wxt.config.transformManifest(manifest);
   await wxt.hooks.callHook('build:manifestGenerated', wxt, manifest);
@@ -632,3 +634,50 @@ export function validateMv3WebAccessbileResources(
     );
   }
 }
+
+/**
+ * Remove keys from the manifest based on the build target.
+ */
+function stripKeys(manifest: Manifest.WebExtensionManifest): void {
+  let keysToRemove: string[] = [];
+  if (wxt.config.manifestVersion === 2) {
+    keysToRemove.push(...mv3OnlyKeys);
+    if (wxt.config.browser === 'firefox')
+      keysToRemove.push(...firefoxMv3OnlyKeys);
+  } else {
+    keysToRemove.push(...mv2OnlyKeys);
+  }
+
+  keysToRemove.forEach((key) => {
+    delete manifest[key as keyof Manifest.WebExtensionManifest];
+  });
+}
+
+const mv2OnlyKeys = [
+  'page_action',
+  'browser_action',
+  'automation',
+  'content_capabilities',
+  'converted_from_user_script',
+  'current_locale',
+  'differential_fingerprint',
+  'event_rules',
+  'file_browser_handlers',
+  'file_system_provider_capabilities',
+  'input_components',
+  'nacl_modules',
+  'natively_connectable',
+  'offline_enabled',
+  'platforms',
+  'replacement_web_app',
+  'system_indicator',
+  'user_scripts',
+];
+
+const mv3OnlyKeys = [
+  'action',
+  'export',
+  'optional_host_permissions',
+  'side_panel',
+];
+const firefoxMv3OnlyKeys = ['host_permissions'];

--- a/src/core/utils/testing/fake-objects.ts
+++ b/src/core/utils/testing/fake-objects.ts
@@ -314,6 +314,7 @@ export const fakeWxt = fakeObjectCreator<Wxt>(() => ({
 export function setFakeWxt(overrides?: DeepPartial<Wxt>) {
   const wxt = fakeWxt(overrides);
   setWxtForTesting(wxt);
+  return wxt;
 }
 
 export const fakeBuildOutput = fakeObjectCreator<BuildOutput>(() => ({


### PR DESCRIPTION
This closes #517.

Instead of having to use a function to change the keys between manifest versions, you can just include both the MV2 and MV3 keys in a single object. When targetting MV2, all MV3 keys will be removed. When targetting MV3, all MV2 keys will be removed.

###### Before

```ts
export default defineConfig({
  manifest: ({ manifestVersion }) => {
    const manifest = {
      // ...
    };
    if (manifestVersion === 2) manifest.browser_action = {};
    else manifest.action = {};
    return manifest;
  };
});
```

###### After

```ts
export default defineConfig({
  manifest: {
    // ...,
    action: {},
    browser_action: {},
  },
});
```