### PR TITLE
fix(zip): List all private packages correctly in a PNPM workspace

### DIFF
--- a/src/core/package-managers/pnpm.ts
+++ b/src/core/package-managers/pnpm.ts
@@ -7,7 +7,7 @@ export const pnpm: WxtPackageManagerImpl = {
     return npm.downloadDependency(...args);
   },
   async listDependencies(options) {
-    const args = ['ls', '--json'];
+    const args = ['ls', '-r', '--json'];
     if (options?.all) {
       args.push('--depth', 'Infinity');
     }


### PR DESCRIPTION
If a private package is in the root `package.json`, it was not discovered. Now it is, using `pnpm ls -r` instead of just `pnpm ls`. This is valid for non-workspace repos as well.