### PR TITLE
docs: Replace `pnpx` with `pnpm dlx`

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ https://github.com/wxt-dev/wxt/assets/10101283/07359e53-f491-43b6-8e8f-fae94aec8
 Bootstrap a new project:
 
 ```sh
-pnpx wxt@latest init <project-name>
+pnpm dlx wxt@latest init <project-name>
 ```
 
 Or see the [installation guide](https://wxt.dev/guide/installation.html) to get started with WXT.

--- a/docs/guide/installation.md
+++ b/docs/guide/installation.md
@@ -7,7 +7,7 @@ Bootstrap a new project, start from scratch, or [migrate an existing project](/g
 :::code-group
 
 ```sh [pnpm]
-pnpx wxt@latest init <project-name>
+pnpm dlx wxt@latest init <project-name>
 ```
 
 ```sh [npm]
@@ -102,7 +102,7 @@ Finally, add scripts to your `package.json`:
 
 ## Migrate an Existing Project
 
-Before starting the migration, it is recommended to run `pnpx wxt@latest init` to see what a basic project looks like. Once you have an understanding of how WXT projects are structured, you're ready to convert the project, using the initialized project as a reference.
+Before starting the migration, it is recommended to run `pnpm dlx wxt@latest init` to see what a basic project looks like. Once you have an understanding of how WXT projects are structured, you're ready to convert the project, using the initialized project as a reference.
 
 Migrating a project to WXT comes down to a few steps:
 

--- a/docs/guide/migrate-to-wxt.md
+++ b/docs/guide/migrate-to-wxt.md
@@ -12,7 +12,7 @@ Always start by generating a new vanilla project and merging it into your projec
 
 ```sh
 cd path/to/your/project
-pnpx wxt@latest init example-wxt --template vanilla
+pnpm dlx wxt@latest init example-wxt --template vanilla
 ```
 
 In general, you'll need to:


### PR DESCRIPTION
Faced with the error below when trying to use `pnpx` on my Windows machine.

`pnpx : The term 'pnpx' is not recognized as the name of a cmdlet, function, script file, or operable program.`

[ `pnpm dlx`](https://pnpm.io/cli/dlx) works fine. pnpm maker Zoltan says [`pnpx` is being deprecated in favor of `pnpm dlx`](https://stackoverflow.com/a/70266473).