### PR TITLE
docs: Add examples for GitHub Actions

### DIFF
--- a/docs/guide/publishing.md
+++ b/docs/guide/publishing.md
@@ -114,12 +114,14 @@ jobs:
 ```
 
 :::tip Advanced Automation
+
 The action above lays the foundation for basic automation processes, including `zip` and `submit` actions. To further enhance your GitHub Action capabilities and delve into more complex scenarios, consider exploring the following examples. They introduce advanced features such as version management and GitHub releases, tailored for different needs:
 
 - [Manual submission](https://github.com/aklinker1/github-better-line-counts/blob/main/.github/workflows/submit.yml): For scenarios requiring control and manual intervention.
 - [Automatic submission](https://github.com/GuiEpi/plex-skipper/blob/main/.github/workflows/deploy.yml): For fully automated update and deployment cycles.
-  > These examples are designed to provide clear insights and are a good starting point for customizing your own workflows. Feel free to explore and adapt them to your project needs.
-  > :::
+
+> These examples are designed to provide clear insights and are a good starting point for customizing your own workflows. Feel free to explore and adapt them to your project needs.
+> :::
 
 ## Stores
 

--- a/docs/guide/publishing.md
+++ b/docs/guide/publishing.md
@@ -66,13 +66,7 @@ See the [Firefox Addon Store](#firefox-addon-store) section for more details abo
 
 Here's an example of a GitHub Action to automate submitting new versions of your extension for review. Ensure that you've added all required secrets used in the workflow to the repo's settings.
 
-:::code-group
-
-```yml [pnpm]
-env:
-  DIRECTORY: .output
-  PROJECT_NAME: myextension
-
+```yml
 name: Release
 
 on:
@@ -82,61 +76,33 @@ on:
     branches: ['main']
 
 jobs:
-  Version:
-    runs-on: ubuntu-latest
-    outputs:
-      version: ${{ steps.get_version.outputs.version }}
-      version_changed: ${{ steps.check_version.outputs.version_changed }}
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-      - name: Check for version change
-        id: check_version
-        run: |
-          if git diff --name-only HEAD~1..HEAD | grep -q '^package\.json$'; then
-            VERSION_CHANGED=1
-          else
-            VERSION_CHANGED=0
-          fi
-          echo "version_changed=$VERSION_CHANGED" >> "$GITHUB_OUTPUT"
-      - name: Get version
-        if: ${{ steps.check_version.outputs.version_changed == '1' }}
-        id: get_version
-        run: |
-          VERSION=$(jq -r .version package.json)
-          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
-
   Submit:
-    needs: Version
-    if: ${{ needs.Version.outputs.version_changed == '1' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+
       - uses: pnpm/action-setup@v3
         with:
           version: 'latest'
-      - name: Use Node.js
-        uses: actions/setup-node@v4
+
+      - uses: actions/setup-node@v4
         with:
           node-version: 20
           cache: 'pnpm'
+
       - name: Install dependencies
         run: pnpm install
-      - name: Build extensions
-        run: |
-          pnpm run build && 
-          pnpm run build:firefox
+
       - name: Zip extensions
         run: |
           pnpm run zip && 
           pnpm run zip:firefox
+
       - name: Submit to stores
         run: |
           pnpm wxt submit \
-            --chrome-zip ${{ env.DIRECTORY }}/${{env.PROJECT_NAME}}-${{ needs.Version.outputs.version }}-chrome.zip \
-            --firefox-zip ${{ env.DIRECTORY }}/${{env.PROJECT_NAME}}-${{ needs.Version.outputs.version }}-firefox.zip \
-            --firefox-sources-zip ${{ env.DIRECTORY }}/${{env.PROJECT_NAME}}-${{ needs.Version.outputs.version }}-sources.zip
+            --chrome-zip .output/*-chrome.zip \
+            --firefox-zip .output/*-firefox.zip --firefox-sources-zip .output/*-sources.zip
         env:
           CHROME_EXTENSION_ID: ${{ secrets.CHROME_EXTENSION_ID }}
           CHROME_CLIENT_ID: ${{ secrets.CHROME_CLIENT_ID }}
@@ -147,83 +113,13 @@ jobs:
           FIREFOX_JWT_SECRET: ${{ secrets.FIREFOX_JWT_SECRET }}
 ```
 
-```yml [npm]
-env:
-  DIRECTORY: .output
-  PROJECT_NAME: myextension
+:::tip Advanced Automation
+The action above lays the foundation for basic automation processes, including `zip` and `submit` actions. To further enhance your GitHub Action capabilities and delve into more complex scenarios, consider exploring the following examples. They introduce advanced features such as version management and GitHub releases, tailored for different needs:
 
-name: Release
-
-on:
-  push:
-    branches: ['main']
-  pull_request:
-    branches: ['main']
-
-jobs:
-  Version:
-    runs-on: ubuntu-latest
-    outputs:
-      version: ${{ steps.get_version.outputs.version }}
-      version_changed: ${{ steps.check_version.outputs.version_changed }}
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-      - name: Check for version change
-        id: check_version
-        run: |
-          if git diff --name-only HEAD~1..HEAD | grep -q '^package\.json$'; then
-            VERSION_CHANGED=1
-          else
-            VERSION_CHANGED=0
-          fi
-          echo "version_changed=$VERSION_CHANGED" >> "$GITHUB_OUTPUT"
-      - name: Get version
-        if: ${{ steps.check_version.outputs.version_changed == '1' }}
-        id: get_version
-        run: |
-          VERSION=$(jq -r .version package.json)
-          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
-
-  Submit:
-    needs: Version
-    if: ${{ needs.Version.outputs.version_changed == '1' }}
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - name: Use Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: 20
-          cache: npm
-      - name: Install dependencies
-        run: npm install
-      - name: Build extensions
-        run: |
-          npm run build && 
-          npm run build:firefox
-      - name: Zip extensions
-        run: |
-          npm run zip && 
-          npm run zip:firefox
-      - name: Submit to stores
-        run: |
-          npm wxt submit \
-            --chrome-zip ${{ env.DIRECTORY }}/${{env.PROJECT_NAME}}-${{ needs.Version.outputs.version }}-chrome.zip \
-            --firefox-zip ${{ env.DIRECTORY }}/${{env.PROJECT_NAME}}-${{ needs.Version.outputs.version }}-firefox.zip \
-            --firefox-sources-zip ${{ env.DIRECTORY }}/${{env.PROJECT_NAME}}-${{ needs.Version.outputs.version }}-sources.zip
-        env:
-          CHROME_EXTENSION_ID: ${{ secrets.CHROME_EXTENSION_ID }}
-          CHROME_CLIENT_ID: ${{ secrets.CHROME_CLIENT_ID }}
-          CHROME_CLIENT_SECRET: ${{ secrets.CHROME_CLIENT_SECRET }}
-          CHROME_REFRESH_TOKEN: ${{ secrets.CHROME_REFRESH_TOKEN }}
-          FIREFOX_EXTENSION_ID: ${{ secrets.FIREFOX_EXTENSION_ID }}
-          FIREFOX_JWT_ISSUER: ${{ secrets.FIREFOX_JWT_ISSUER }}
-          FIREFOX_JWT_SECRET: ${{ secrets.FIREFOX_JWT_SECRET }}
-```
-
-:::
+- [Manual submission](https://github.com/aklinker1/github-better-line-counts/blob/main/.github/workflows/submit.yml): For scenarios requiring control and manual intervention.
+- [Automatic submission](https://github.com/GuiEpi/plex-skipper/blob/main/.github/workflows/deploy.yml): For fully automated update and deployment cycles.
+  > These examples are designed to provide clear insights and are a good starting point for customizing your own workflows. Feel free to explore and adapt them to your project needs.
+  > :::
 
 ## Stores
 

--- a/docs/guide/publishing.md
+++ b/docs/guide/publishing.md
@@ -66,9 +66,164 @@ See the [Firefox Addon Store](#firefox-addon-store) section for more details abo
 
 Here's an example of a GitHub Action to automate submitting new versions of your extension for review. Ensure that you've added all required secrets used in the workflow to the repo's settings.
 
-```yml
-# TODO
+:::code-group
+
+```yml [pnpm]
+env:
+  DIRECTORY: .output
+  PROJECT_NAME: myextension
+
+name: Release
+
+on:
+  push:
+    branches: ['main']
+  pull_request:
+    branches: ['main']
+
+jobs:
+  Version:
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.get_version.outputs.version }}
+      version_changed: ${{ steps.check_version.outputs.version_changed }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Check for version change
+        id: check_version
+        run: |
+          if git diff --name-only HEAD~1..HEAD | grep -q '^package\.json$'; then
+            VERSION_CHANGED=1
+          else
+            VERSION_CHANGED=0
+          fi
+          echo "version_changed=$VERSION_CHANGED" >> "$GITHUB_OUTPUT"
+      - name: Get version
+        if: ${{ steps.check_version.outputs.version_changed == '1' }}
+        id: get_version
+        run: |
+          VERSION=$(jq -r .version package.json)
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
+  Submit:
+    needs: Version
+    if: ${{ needs.Version.outputs.version_changed == '1' }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v3
+        with:
+          version: 'latest'
+      - name: Use Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'pnpm'
+      - name: Install dependencies
+        run: pnpm install
+      - name: Build extensions
+        run: |
+          pnpm run build && 
+          pnpm run build:firefox
+      - name: Zip extensions
+        run: |
+          pnpm run zip && 
+          pnpm run zip:firefox
+      - name: Submit to stores
+        run: |
+          pnpm wxt submit \
+            --chrome-zip ${{ env.DIRECTORY }}/${{env.PROJECT_NAME}}-${{ needs.Version.outputs.version }}-chrome.zip \
+            --firefox-zip ${{ env.DIRECTORY }}/${{env.PROJECT_NAME}}-${{ needs.Version.outputs.version }}-firefox.zip \
+            --firefox-sources-zip ${{ env.DIRECTORY }}/${{env.PROJECT_NAME}}-${{ needs.Version.outputs.version }}-sources.zip
+        env:
+          CHROME_EXTENSION_ID: ${{ secrets.CHROME_EXTENSION_ID }}
+          CHROME_CLIENT_ID: ${{ secrets.CHROME_CLIENT_ID }}
+          CHROME_CLIENT_SECRET: ${{ secrets.CHROME_CLIENT_SECRET }}
+          CHROME_REFRESH_TOKEN: ${{ secrets.CHROME_REFRESH_TOKEN }}
+          FIREFOX_EXTENSION_ID: ${{ secrets.FIREFOX_EXTENSION_ID }}
+          FIREFOX_JWT_ISSUER: ${{ secrets.FIREFOX_JWT_ISSUER }}
+          FIREFOX_JWT_SECRET: ${{ secrets.FIREFOX_JWT_SECRET }}
 ```
+
+```yml [npm]
+env:
+  DIRECTORY: .output
+  PROJECT_NAME: myextension
+
+name: Release
+
+on:
+  push:
+    branches: ['main']
+  pull_request:
+    branches: ['main']
+
+jobs:
+  Version:
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.get_version.outputs.version }}
+      version_changed: ${{ steps.check_version.outputs.version_changed }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Check for version change
+        id: check_version
+        run: |
+          if git diff --name-only HEAD~1..HEAD | grep -q '^package\.json$'; then
+            VERSION_CHANGED=1
+          else
+            VERSION_CHANGED=0
+          fi
+          echo "version_changed=$VERSION_CHANGED" >> "$GITHUB_OUTPUT"
+      - name: Get version
+        if: ${{ steps.check_version.outputs.version_changed == '1' }}
+        id: get_version
+        run: |
+          VERSION=$(jq -r .version package.json)
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
+  Submit:
+    needs: Version
+    if: ${{ needs.Version.outputs.version_changed == '1' }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Use Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+      - name: Install dependencies
+        run: npm install
+      - name: Build extensions
+        run: |
+          npm run build && 
+          npm run build:firefox
+      - name: Zip extensions
+        run: |
+          npm run zip && 
+          npm run zip:firefox
+      - name: Submit to stores
+        run: |
+          npm wxt submit \
+            --chrome-zip ${{ env.DIRECTORY }}/${{env.PROJECT_NAME}}-${{ needs.Version.outputs.version }}-chrome.zip \
+            --firefox-zip ${{ env.DIRECTORY }}/${{env.PROJECT_NAME}}-${{ needs.Version.outputs.version }}-firefox.zip \
+            --firefox-sources-zip ${{ env.DIRECTORY }}/${{env.PROJECT_NAME}}-${{ needs.Version.outputs.version }}-sources.zip
+        env:
+          CHROME_EXTENSION_ID: ${{ secrets.CHROME_EXTENSION_ID }}
+          CHROME_CLIENT_ID: ${{ secrets.CHROME_CLIENT_ID }}
+          CHROME_CLIENT_SECRET: ${{ secrets.CHROME_CLIENT_SECRET }}
+          CHROME_REFRESH_TOKEN: ${{ secrets.CHROME_REFRESH_TOKEN }}
+          FIREFOX_EXTENSION_ID: ${{ secrets.FIREFOX_EXTENSION_ID }}
+          FIREFOX_JWT_ISSUER: ${{ secrets.FIREFOX_JWT_ISSUER }}
+          FIREFOX_JWT_SECRET: ${{ secrets.FIREFOX_JWT_SECRET }}
+```
+
+:::
 
 ## Stores
 

--- a/docs/guide/publishing.md
+++ b/docs/guide/publishing.md
@@ -64,19 +64,16 @@ See the [Firefox Addon Store](#firefox-addon-store) section for more details abo
 
 ## GitHub Action
 
-Here's an example of a GitHub Action to automate submitting new versions of your extension for review. Ensure that you've added all required secrets used in the workflow to the repo's settings.
+Here's an example of a GitHub Action that submits new versions of an extension for review. Ensure that you've added all required secrets used in the workflow to the repo's settings.
 
 ```yml
 name: Release
 
 on:
-  push:
-    branches: ['main']
-  pull_request:
-    branches: ['main']
+  workflow_dispatch:
 
 jobs:
-  Submit:
+  submit:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -95,8 +92,8 @@ jobs:
 
       - name: Zip extensions
         run: |
-          pnpm run zip && 
-          pnpm run zip:firefox
+          pnpm zip
+          pnpm zip:firefox
 
       - name: Submit to stores
         run: |
@@ -113,16 +110,12 @@ jobs:
           FIREFOX_JWT_SECRET: ${{ secrets.FIREFOX_JWT_SECRET }}
 ```
 
-:::tip Advanced Automation
+The action above lays the foundation for a basic workflow, including `zip` and `submit` steps. To further enhance your GitHub Action and delve into more complex scenarios, consider exploring the following examples from real projects. They introduce advanced features such as version management, changelog generation, and GitHub releases, tailored for different needs:
 
-The action above lays the foundation for basic automation processes, including `zip` and `submit` actions. To further enhance your GitHub Action capabilities and delve into more complex scenarios, consider exploring the following examples. They introduce advanced features such as version management and GitHub releases, tailored for different needs:
-
-- [Manual submission](https://github.com/aklinker1/github-better-line-counts/blob/main/.github/workflows/submit.yml): For scenarios requiring control and manual intervention.
-- [Automatic submission](https://github.com/GuiEpi/plex-skipper/blob/main/.github/workflows/deploy.yml): For fully automated update and deployment cycles.
+- [`aklinker1/github-better-line-counts`](https://github.com/aklinker1/github-better-line-counts/blob/main/.github/workflows/submit.yml) - Conventional commits, automated version bump and changelog generation, triggered manually, optional dry run for testing
+- [`GuiEpi/plex-skipper`](https://github.com/GuiEpi/plex-skipper/blob/main/.github/workflows/deploy.yml) - Triggered automatically when `package.json` version is changed, creates and uploads artifacts to GitHub release.
 
 > These examples are designed to provide clear insights and are a good starting point for customizing your own workflows. Feel free to explore and adapt them to your project needs.
-
-:::
 
 ## Stores
 

--- a/docs/guide/publishing.md
+++ b/docs/guide/publishing.md
@@ -121,7 +121,8 @@ The action above lays the foundation for basic automation processes, including `
 - [Automatic submission](https://github.com/GuiEpi/plex-skipper/blob/main/.github/workflows/deploy.yml): For fully automated update and deployment cycles.
 
 > These examples are designed to provide clear insights and are a good starting point for customizing your own workflows. Feel free to explore and adapt them to your project needs.
-> :::
+
+:::
 
 ## Stores
 


### PR DESCRIPTION
Here is my proposal for the github action in the publishing section of the documentation.

### Jobs
1. `Version`
Checks for changes in the `package.json` file. If there is a change, it retrieves the version of your extension.
3. `Submit`
 Submits your extension to the store using the `wxt submit` command.

`pnpm` and `npm` code-group.

Here's a[ link to my CI Deploy](https://github.com/GuiEpi/plex-skipper/actions/runs/8222114482/job/22483242808) to show you how it works.
I follow the [pnpm continuous integration guide ](https://pnpm.io/continuous-integration#github-actions) and your [publishing](https://wxt.dev/guide/publishing.html) section.