### PR TITLE
fix(init): Don't overwrite existing files when bootstrapping a new project

### DIFF
--- a/src/core/initialize.ts
+++ b/src/core/initialize.ts
@@ -63,7 +63,7 @@ export async function initialize(options: {
   if (isExists) {
     const isEmpty = (await fs.readdir(input.directory)).length === 0;
     if (!isEmpty) {
-      consola.warn(`The directory ${input.directory} is not empty. Aborted.`);
+      consola.error(`The directory ${path.resolve(input.directory)} is not empty. Aborted.`);
       process.exit(1);
     }
   }

--- a/src/core/initialize.ts
+++ b/src/core/initialize.ts
@@ -59,6 +59,14 @@ export async function initialize(options: {
   input.template ??= defaultTemplate;
   input.packageManager ??= options.packageManager;
 
+  const isExists = await fs.pathExists(input.directory);
+  if (isExists) {
+    const isEmpty = (await fs.readdir(input.directory)).length === 0;
+    if (!isEmpty) {
+      consola.warn(`The directory ${input.directory} is not empty. Aborted.`);
+      process.exit(1);
+    }
+  }
   await cloneProject(input);
 
   const cdPath = path.relative(process.cwd(), path.resolve(input.directory));

--- a/src/core/initialize.ts
+++ b/src/core/initialize.ts
@@ -63,7 +63,9 @@ export async function initialize(options: {
   if (isExists) {
     const isEmpty = (await fs.readdir(input.directory)).length === 0;
     if (!isEmpty) {
-      consola.error(`The directory ${path.resolve(input.directory)} is not empty. Aborted.`);
+      consola.error(
+        `The directory ${path.resolve(input.directory)} is not empty. Aborted.`,
+      );
       process.exit(1);
     }
   }

--- a/src/core/initialize.ts
+++ b/src/core/initialize.ts
@@ -145,6 +145,9 @@ async function cloneProject({
       .move(
         path.join(directory, '_gitignore'),
         path.join(directory, '.gitignore'),
+        {
+          overwrite: true,
+        },
       )
       .catch((err) =>
         consola.warn('Failed to move _gitignore to .gitignore:', err),


### PR DESCRIPTION
When initializing a project in a certain folder, if a `.gitignore` file exists in the project, a warning message will appear.

![image](https://github.com/wxt-dev/wxt/assets/24516654/7dceff66-4d55-4aea-9b0c-e2c6159b0daa)

I still have a question, when the folder where we initialize the project contains other content, do we need to clear the content before downloading the template? 🤔
