### PR TITLE
feat: Add `{{mode}}` Template Variable

### DIFF
--- a/e2e/tests/zip.test.ts
+++ b/e2e/tests/zip.test.ts
@@ -71,4 +71,34 @@ describe('Zipping', () => {
       }"
     `);
   });
+
+  it('should correctly apply template variables for zip file names based on provided config', async () => {
+    const project = new TestProject({
+      name: 'test',
+      version: '1.0.0',
+      dependencies: {
+        flatten: '1.0.3',
+      },
+    });
+    project.addFile(
+      'entrypoints/background.ts',
+      'export default defineBackground(() => {});',
+    );
+    const artifactZip = '.output/test-1.0.0-firefox-development.zip';
+    const sourcesZip = '.output/test-1.0.0-development-sources.zip';
+
+    await project.zip({
+      browser: 'firefox',
+      mode: 'development',
+      zip: {
+        artifactTemplate: '{{name}}-{{version}}-{{browser}}-{{mode}}.zip',
+        sourcesTemplate: '{{name}}-{{version}}-{{mode}}-sources.zip',
+        downloadPackages: ['flatten'],
+      },
+    });
+    expect(await project.fileExists('.output/')).toBe(true);
+
+    await expect(project.fileExists(artifactZip)).resolves.toBe(true);
+    await expect(project.fileExists(sourcesZip)).resolves.toBe(true);
+  });
 });

--- a/e2e/tests/zip.test.ts
+++ b/e2e/tests/zip.test.ts
@@ -76,9 +76,6 @@ describe('Zipping', () => {
     const project = new TestProject({
       name: 'test',
       version: '1.0.0',
-      dependencies: {
-        flatten: '1.0.3',
-      },
     });
     project.addFile(
       'entrypoints/background.ts',
@@ -93,12 +90,10 @@ describe('Zipping', () => {
       zip: {
         artifactTemplate: '{{name}}-{{version}}-{{browser}}-{{mode}}.zip',
         sourcesTemplate: '{{name}}-{{version}}-{{mode}}-sources.zip',
-        downloadPackages: ['flatten'],
       },
     });
-    expect(await project.fileExists('.output/')).toBe(true);
 
-    await expect(project.fileExists(artifactZip)).resolves.toBe(true);
-    await expect(project.fileExists(sourcesZip)).resolves.toBe(true);
+    expect(await project.fileExists(artifactZip)).toBe(true);
+    expect(await project.fileExists(sourcesZip)).toBe(true);
   });
 });

--- a/src/core/zip.ts
+++ b/src/core/zip.ts
@@ -38,6 +38,7 @@ export async function zip(config?: InlineConfig): Promise<string[]> {
         '{{version}}',
         output.manifest.version_name ?? output.manifest.version,
       )
+      .replaceAll('{{mode}}', wxt.config.mode)
       .replaceAll('{{manifestVersion}}', `mv${wxt.config.manifestVersion}`);
 
   await fs.ensureDir(wxt.config.outBaseDir);

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -117,10 +117,11 @@ export interface InlineConfig {
      *
      * Available template variables:
      *
-     * - `{{name}}` - The project's name converted to kebab-case
-     * - `{{version}}` - The version_name or version from the manifest
-     * - `{{browser}}` - The target browser from the `--browser` CLI flag
-     * - `{{manifestVersion}}` - Either "2" or "3"
+     * - <span v-pre>`{{name}}`</span> - The project's name converted to kebab-case
+     * - <span v-pre>`{{version}}`</span> - The version_name or version from the manifest
+     * - <span v-pre>`{{browser}}`</span> - The target browser from the `--browser` CLI flag
+     * - <span v-pre>`{{mode}}`</span> - The current mode
+     * - <span v-pre>`{{manifestVersion}}`</span> - Either "2" or "3"
      *
      * @default "{{name}}-{{version}}-{{browser}}.zip"
      */
@@ -130,10 +131,11 @@ export interface InlineConfig {
      *
      * Available template variables:
      *
-     * - `{{name}}` - The project's name converted to kebab-case
-     * - `{{version}}` - The version_name or version from the manifest
-     * - `{{browser}}` - The target browser from the `--browser` CLI flag
-     * - `{{manifestVersion}}` - Either "2" or "3"
+     * - <span v-pre>`{{name}}`</span> - The project's name converted to kebab-case
+     * - <span v-pre>`{{version}}`</span> - The version_name or version from the manifest
+     * - <span v-pre>`{{browser}}`</span> - The target browser from the `--browser` CLI flag
+     * - <span v-pre>`{{mode}}`</span> - The current mode
+     * - <span v-pre>`{{manifestVersion}}`</span> - Either "2" or "3"
      *
      * @default "{{name}}-{{version}}-sources.zip"
      */


### PR DESCRIPTION
### Add `{{mode}}` Template Variable

- Fix do not [escape Vue interpolations](https://vitepress.dev/guide/using-vue#escaping)
- Add test correctly applies template variables for zip file names