### PR TITLE
fix: Don't override `wxt.config.ts` options when CLI flags are not passed

### DIFF
--- a/demo/wxt.config.ts
+++ b/demo/wxt.config.ts
@@ -18,4 +18,7 @@ export default defineConfig({
   zip: {
     downloadPackages: ['sass'],
   },
+  analysis: {
+    open: true,
+  },
 });

--- a/src/core/utils/building/resolve-config.ts
+++ b/src/core/utils/building/resolve-config.ts
@@ -54,11 +54,6 @@ export async function resolveConfig(
   // Merge it into the inline config
 
   const mergedConfig = mergeInlineConfig(inlineConfig, userConfig);
-  console.log({
-    userConfig: userConfig.analysis,
-    inlineConfig: inlineConfig.analysis,
-    mergedConfig: mergedConfig.analysis,
-  });
 
   // Apply defaults to make internal config.
 
@@ -227,10 +222,6 @@ function mergeInlineConfig(
     inlineConfig.hooks ?? {},
     userConfig.hooks ?? {},
   );
-  console.log({
-    userConfig: userConfig.analysis,
-    inlineConfig: inlineConfig.analysis,
-  });
 
   return {
     root: inlineConfig.root ?? userConfig.root,

--- a/src/core/utils/building/resolve-config.ts
+++ b/src/core/utils/building/resolve-config.ts
@@ -54,6 +54,11 @@ export async function resolveConfig(
   // Merge it into the inline config
 
   const mergedConfig = mergeInlineConfig(inlineConfig, userConfig);
+  console.log({
+    userConfig: userConfig.analysis,
+    inlineConfig: inlineConfig.analysis,
+    mergedConfig: mergedConfig.analysis,
+  });
 
   // Apply defaults to make internal config.
 
@@ -222,6 +227,10 @@ function mergeInlineConfig(
     inlineConfig.hooks ?? {},
     userConfig.hooks ?? {},
   );
+  console.log({
+    userConfig: userConfig.analysis,
+    inlineConfig: inlineConfig.analysis,
+  });
 
   return {
     root: inlineConfig.root ?? userConfig.root,
@@ -241,24 +250,15 @@ function mergeInlineConfig(
     srcDir: inlineConfig.srcDir ?? userConfig.srcDir,
     outDir: inlineConfig.outDir ?? userConfig.outDir,
     zip,
-    analysis: {
-      ...userConfig.analysis,
-      ...inlineConfig.analysis,
-    },
-    alias: {
-      ...userConfig.alias,
-      ...inlineConfig.alias,
-    },
-    experimental: {
-      ...userConfig.experimental,
-      ...inlineConfig.experimental,
-    },
+    analysis: defu(inlineConfig.analysis ?? {}, userConfig.analysis ?? {}),
+    alias: defu(inlineConfig.alias ?? {}, userConfig.alias ?? {}),
+    experimental: defu(
+      inlineConfig.experimental ?? {},
+      userConfig.experimental ?? {},
+    ),
     vite: undefined,
     transformManifest: undefined,
-    dev: {
-      ...userConfig.dev,
-      ...inlineConfig.dev,
-    },
+    dev: defu(inlineConfig.dev ?? {}, userConfig.dev ?? {}),
     hooks,
   };
 }


### PR DESCRIPTION
This closes https://github.com/wxt-dev/wxt/pull/564#discussion_r1536867522, see thread for more details.

Uses defu to apply default values instead of spread to not spread undefined values over real values. Replaced 4 spreads inside the config:

- `analysis` - This is the only object effected by CLI flags and is causing a problem today, the rest are just for safety.
- `alias`
- `experimental`
- `dev`