### PR TITLE
feat: Configure dev server port with `dev.server.port`

### DIFF
--- a/src/cli/__tests__/index.test.ts
+++ b/src/cli/__tests__/index.test.ts
@@ -116,6 +116,20 @@ describe('CLI', () => {
       });
     });
 
+    it('should respect passing --port', async () => {
+      const expectedPort = 3100;
+      mockArgv('--port', String(expectedPort));
+      await importCli();
+
+      expect(createServerMock).toBeCalledWith({
+        dev: {
+          server: {
+            port: expectedPort,
+          },
+        },
+      });
+    });
+
     it('should respect passing --debug', async () => {
       mockArgv('--debug');
       await importCli();

--- a/src/cli/commands.ts
+++ b/src/cli/commands.ts
@@ -36,11 +36,14 @@ cli
         configFile: flags.config,
         debug: flags.debug,
         filterEntrypoints: getArrayFromFlags(flags, 'filterEntrypoint'),
-        dev: {
-          server: {
-            port: flags.port != null ? parseInt(flags.port) : undefined,
-          },
-        },
+        dev:
+          flags.port == null
+            ? undefined
+            : {
+                server: {
+                  port: parseInt(flags.port),
+                },
+              },
       });
       await server.start();
       return { isOngoing: true };

--- a/src/core/create-server.ts
+++ b/src/core/create-server.ts
@@ -40,7 +40,7 @@ import { mapWxtOptionsToRegisteredContentScript } from './utils/content-scripts'
 export async function createServer(
   inlineConfig?: InlineConfig,
 ): Promise<WxtDevServer> {
-  const port = await getPort();
+  const port = inlineConfig?.dev?.port ?? (await getPort());
   const hostname = 'localhost';
   const origin = `http://${hostname}:${port}`;
   const serverInfo: ServerInfo = {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -310,6 +310,12 @@ export interface InlineConfig {
    */
   dev?: {
     /**
+     * Port to run the dev server on.
+     *
+     * @default "Any available port from 3000 to 3010, otherwise fall back to a random port"
+     */
+    port?: number;
+    /**
      * Controls whether a custom keyboard shortcut command, `Alt+R`, is added during dev mode to
      * quickly reload the extension.
      *


### PR DESCRIPTION
Added the `dev.port` field to `InlineConfig` to allow configuring the dev server port.