### PR TITLE
chore: Refactor order of config resolution

### DIFF
--- a/src/core/builders/vite/plugins/devHtmlPrerender.ts
+++ b/src/core/builders/vite/plugins/devHtmlPrerender.ts
@@ -13,6 +13,7 @@ let reactRefreshPreamble = '';
  */
 export function devHtmlPrerender(
   config: Omit<ResolvedConfig, 'builder'>,
+  server: WxtDevServer | undefined,
 ): vite.PluginOption {
   const htmlReloadId = '@wxt/reload-html';
   const resolvedHtmlReloadId = resolve(
@@ -38,7 +39,6 @@ export function devHtmlPrerender(
       // Convert scripts like src="./main.tsx" -> src="http://localhost:3000/entrypoints/popup/main.tsx"
       // before the paths are replaced with their bundled path
       transform(code, id) {
-        const server = config.server;
         if (
           config.command !== 'serve' ||
           server == null ||
@@ -68,7 +68,6 @@ export function devHtmlPrerender(
 
       // Pass the HTML through the dev server to add dev-mode specific code
       async transformIndexHtml(html, ctx) {
-        const server = config.server;
         if (config.command !== 'serve' || server == null) return;
 
         const originalUrl = `${server.origin}${ctx.path}`;

--- a/src/core/builders/vite/plugins/devServerGlobals.ts
+++ b/src/core/builders/vite/plugins/devServerGlobals.ts
@@ -1,22 +1,23 @@
 import { Plugin } from 'vite';
-import { ResolvedConfig } from '~/types';
+import { ResolvedConfig, WxtDevServer } from '~/types';
 
 /**
  * Defines global constants about the dev server. Helps scripts connect to the server's web socket.
  */
 export function devServerGlobals(
   config: Omit<ResolvedConfig, 'builder'>,
+  server: WxtDevServer | undefined,
 ): Plugin {
   return {
     name: 'wxt:dev-server-globals',
     config() {
-      if (config.server == null || config.command == 'build') return;
+      if (server == null || config.command == 'build') return;
 
       return {
         define: {
           __DEV_SERVER_PROTOCOL__: JSON.stringify('ws:'),
-          __DEV_SERVER_HOSTNAME__: JSON.stringify(config.server.hostname),
-          __DEV_SERVER_PORT__: JSON.stringify(config.server.port),
+          __DEV_SERVER_HOSTNAME__: JSON.stringify(server.hostname),
+          __DEV_SERVER_PORT__: JSON.stringify(server.port),
         },
       };
     },

--- a/src/core/create-server.ts
+++ b/src/core/create-server.ts
@@ -40,12 +40,9 @@ import { mapWxtOptionsToRegisteredContentScript } from './utils/content-scripts'
 export async function createServer(
   inlineConfig?: InlineConfig,
 ): Promise<WxtDevServer> {
-  await registerWxt('serve', inlineConfig, (config) => {
-    if (config.dev.server == null) {
-      throw Error('Dev server config missing, cannot start dev server');
-    }
-
-    const { port, hostname } = config.dev.server;
+  await registerWxt('serve', inlineConfig, async (_config) => {
+    const port = await getPort();
+    const hostname = 'localhost';
     const serverInfo: ServerInfo = {
       port,
       hostname,
@@ -139,6 +136,11 @@ export async function createServer(
   server.watcher.on('all', reloadOnChange);
 
   return server;
+}
+
+async function getPort(): Promise<number> {
+  const { default: getPort, portNumbers } = await import('get-port');
+  return await getPort({ port: portNumbers(3000, 3010) });
 }
 
 /**

--- a/src/core/utils/building/build-entrypoints.ts
+++ b/src/core/utils/building/build-entrypoints.ts
@@ -18,7 +18,7 @@ export async function buildEntrypoints(
     spinner.text =
       pc.dim(`[${i + 1}/${groups.length}]`) + ` ${groupNameColored}`;
     try {
-      steps.push(await wxt.config.builder.build(group));
+      steps.push(await wxt.builder.build(group));
     } catch (err) {
       spinner.stop().clear();
       wxt.logger.error(err);

--- a/src/core/utils/building/internal-build.ts
+++ b/src/core/utils/building/internal-build.ts
@@ -37,7 +37,7 @@ export async function internalBuild(): Promise<BuildOutput> {
   const target = `${wxt.config.browser}-mv${wxt.config.manifestVersion}`;
   wxt.logger.info(
     `${verb} ${pc.cyan(target)} for ${pc.cyan(wxt.config.mode)} with ${pc.green(
-      `${wxt.config.builder.name} ${wxt.config.builder.version}`,
+      `${wxt.builder.name} ${wxt.builder.version}`,
     )}`,
   );
   const startTime = Date.now();

--- a/src/core/utils/building/resolve-config.ts
+++ b/src/core/utils/building/resolve-config.ts
@@ -90,16 +90,6 @@ export async function resolveConfig(
   const outBaseDir = path.resolve(root, mergedConfig.outDir ?? '.output');
   const outDir = path.resolve(outBaseDir, `${browser}-mv${manifestVersion}`);
   const reloadCommand = mergedConfig.dev?.reloadCommand ?? 'Alt+R';
-  let devServer: ResolvedConfig['dev']['server'] = undefined;
-  if (command === 'serve') {
-    const { default: getPort, portNumbers } = await import('get-port');
-    devServer = {
-      hostname: 'localhost',
-      port:
-        mergedConfig.dev?.server?.port ??
-        (await getPort({ port: portNumbers(3000, 3010) })),
-    };
-  }
 
   const runnerConfig = await loadConfig<ExtensionRunnerConfig>({
     name: 'web-ext',
@@ -151,7 +141,6 @@ export async function resolveConfig(
       includeBrowserPolyfill: true,
     }),
     dev: {
-      server: devServer,
       reloadCommand,
     },
     hooks: mergedConfig.hooks ?? {},

--- a/src/core/utils/manifest.ts
+++ b/src/core/utils/manifest.ts
@@ -455,8 +455,8 @@ function discoverIcons(
 }
 
 function addDevModeCsp(manifest: Manifest.WebExtensionManifest): void {
-  const permission = `http://${wxt.config.server?.hostname ?? ''}/*`;
-  const allowedCsp = wxt.config.server?.origin ?? 'http://localhost:*';
+  const permission = `http://${wxt.server?.hostname ?? ''}/*`;
+  const allowedCsp = wxt.server?.origin ?? 'http://localhost:*';
 
   if (manifest.manifest_version === 3) {
     addHostPermission(manifest, permission);
@@ -473,7 +473,7 @@ function addDevModeCsp(manifest: Manifest.WebExtensionManifest): void {
         "script-src 'self'; object-src 'self';", // default CSP for MV2
   );
 
-  if (wxt.config.server) csp.add('script-src', allowedCsp);
+  if (wxt.server) csp.add('script-src', allowedCsp);
 
   if (manifest.manifest_version === 3) {
     manifest.content_security_policy ??= {};

--- a/src/core/utils/testing/fake-objects.ts
+++ b/src/core/utils/testing/fake-objects.ts
@@ -270,7 +270,6 @@ export const fakeResolvedConfig = fakeObjectCreator<ResolvedConfig>(() => {
     srcDir: fakeDir(),
     typesDir: fakeDir(),
     wxtDir: fakeDir(),
-    server: mock<WxtDevServer>(),
     analysis: {
       enabled: false,
       open: false,
@@ -296,11 +295,11 @@ export const fakeResolvedConfig = fakeObjectCreator<ResolvedConfig>(() => {
     experimental: {
       includeBrowserPolyfill: true,
     },
-    builder: mock(),
     dev: {
       reloadCommand: 'Alt+R',
     },
     hooks: {},
+    vite: () => ({}),
   };
 });
 
@@ -310,6 +309,8 @@ export const fakeWxt = fakeObjectCreator<Wxt>(() => ({
   logger: mock(),
   reloadConfig: vi.fn(),
   pm: mock(),
+  server: faker.helpers.arrayElement([undefined, mock<WxtDevServer>()]),
+  builder: mock(),
 }));
 
 export function setFakeWxt(overrides?: DeepPartial<Wxt>) {

--- a/src/core/wxt.ts
+++ b/src/core/wxt.ts
@@ -23,11 +23,11 @@ export let wxt: Wxt;
 export async function registerWxt(
   command: WxtCommand,
   inlineConfig: InlineConfig = {},
-  getServer?: (config: ResolvedConfig) => WxtDevServer,
+  getServer?: (config: ResolvedConfig) => Promise<WxtDevServer>,
 ): Promise<void> {
   const hooks = createHooks<WxtHooks>();
   const config = await resolveConfig(inlineConfig, command);
-  const server = getServer?.(config);
+  const server = await getServer?.(config);
   const builder = await createViteBuilder(config, server);
   const pm = await createWxtPackageManager(config.root);
 

--- a/src/core/wxt.ts
+++ b/src/core/wxt.ts
@@ -42,6 +42,7 @@ export async function registerWxt(
     },
     pm,
     builder,
+    server,
   };
 
   // Initialize hooks

--- a/src/core/wxt.ts
+++ b/src/core/wxt.ts
@@ -1,7 +1,15 @@
-import { InlineConfig, Wxt, WxtCommand, WxtDevServer, WxtHooks } from '~/types';
+import {
+  InlineConfig,
+  ResolvedConfig,
+  Wxt,
+  WxtCommand,
+  WxtDevServer,
+  WxtHooks,
+} from '~/types';
 import { resolveConfig } from './utils/building';
 import { createHooks } from 'hookable';
 import { createWxtPackageManager } from './package-managers';
+import { createViteBuilder } from './builders/vite';
 
 /**
  * Global variable set once `createWxt` is called once. Since this variable is used everywhere, this
@@ -15,10 +23,12 @@ export let wxt: Wxt;
 export async function registerWxt(
   command: WxtCommand,
   inlineConfig: InlineConfig = {},
-  server?: WxtDevServer,
+  getServer?: (config: ResolvedConfig) => WxtDevServer,
 ): Promise<void> {
-  const config = await resolveConfig(inlineConfig, command, server);
   const hooks = createHooks<WxtHooks>();
+  const config = await resolveConfig(inlineConfig, command);
+  const server = getServer?.(config);
+  const builder = await createViteBuilder(config, server);
   const pm = await createWxtPackageManager(config.root);
 
   wxt = {
@@ -28,9 +38,10 @@ export async function registerWxt(
       return config.logger;
     },
     async reloadConfig() {
-      wxt.config = await resolveConfig(inlineConfig, command, server);
+      wxt.config = await resolveConfig(inlineConfig, command);
     },
     pm,
+    builder,
   };
 
   // Initialize hooks

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1077,13 +1077,6 @@ export interface ResolvedConfig {
     includeBrowserPolyfill: boolean;
   };
   dev: {
-    /**
-     * Defined during dev only
-     */
-    server?: {
-      hostname: string;
-      port: number;
-    };
     reloadCommand: string | false;
   };
   hooks: NestedHooks<WxtHooks>;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -345,6 +345,11 @@ export interface InlineConfig {
 }
 
 // TODO: Move into @wxt/vite-builder
+export interface ResolvedConfig {
+  vite: (env: ConfigEnv) => WxtViteConfig | Promise<WxtViteConfig>;
+}
+
+// TODO: Move into @wxt/vite-builder
 export type WxtViteConfig = Omit<
   vite.UserConfig,
   'root' | 'configFile' | 'mode'
@@ -1002,6 +1007,14 @@ export interface Wxt {
    * Package manager utilities.
    */
   pm: WxtPackageManager;
+  /**
+   * If the dev server was started, it will be availble.
+   */
+  server?: WxtDevServer;
+  /**
+   * The module in charge of executing all the build steps.
+   */
+  builder: WxtBuilder;
 }
 
 export interface ResolvedConfig {
@@ -1028,7 +1041,6 @@ export interface ResolvedConfig {
   imports: false | WxtResolvedUnimportOptions;
   manifest: UserManifest;
   fsCache: FsCache;
-  server?: WxtDevServer;
   runnerConfig: C12ResolvedConfig<ExtensionRunnerConfig>;
   zip: {
     name?: string;
@@ -1064,11 +1076,17 @@ export interface ResolvedConfig {
   experimental: {
     includeBrowserPolyfill: boolean;
   };
-  builder: WxtBuilder;
   dev: {
+    /**
+     * Defined during dev only
+     */
+    server?: {
+      hostname: string;
+      port: number;
+    };
     reloadCommand: string | false;
   };
-  hooks: Partial<WxtHooks>;
+  hooks: NestedHooks<WxtHooks>;
 }
 
 export interface FsCache {


### PR DESCRIPTION
See https://github.com/wxt-dev/wxt/pull/577#issuecomment-2026542566. Now config is always resolved immediately at the beginning of all public APIs.