### PR TITLE
feat: Add hooks for extending vite config

### DIFF
--- a/demo/wxt.config.ts
+++ b/demo/wxt.config.ts
@@ -1,4 +1,4 @@
-import { defineConfig, scopedVitePlugin } from 'wxt';
+import { defineConfig } from 'wxt';
 
 export default defineConfig({
   srcDir: 'src',
@@ -18,14 +18,4 @@ export default defineConfig({
   analysis: {
     open: true,
   },
-  vite: () => ({
-    plugins: [
-      scopedVitePlugin(['popup', 'ui'], () => ({
-        name: 'TEST',
-        config() {
-          console.log('SCOPE APPLIED!');
-        },
-      })),
-    ],
-  }),
 });

--- a/demo/wxt.config.ts
+++ b/demo/wxt.config.ts
@@ -1,4 +1,4 @@
-import { defineConfig } from 'wxt';
+import { defineConfig, scopedVitePlugin } from 'wxt';
 
 export default defineConfig({
   srcDir: 'src',
@@ -18,4 +18,14 @@ export default defineConfig({
   analysis: {
     open: true,
   },
+  vite: () => ({
+    plugins: [
+      scopedVitePlugin(['popup', 'ui'], () => ({
+        name: 'TEST',
+        config() {
+          console.log('SCOPE APPLIED!');
+        },
+      })),
+    ],
+  }),
 });

--- a/e2e/tests/hooks.test.ts
+++ b/e2e/tests/hooks.test.ts
@@ -9,16 +9,21 @@ const hooks: WxtHooks = {
   'build:manifestGenerated': vi.fn(),
   'entrypoints:resolved': vi.fn(),
   'entrypoints:grouped': vi.fn(),
+  'vite:build:extendConfig': vi.fn(),
+  'vite:devServer:extendConfig': vi.fn(),
 };
 
-function expectHooksToBeCalled(called: Record<keyof WxtHooks, boolean>) {
+function expectHooksToBeCalled(
+  called: Record<keyof WxtHooks, boolean | number>,
+) {
   Object.keys(hooks).forEach((key) => {
     const hookName = key as keyof WxtHooks;
-    const times = called[hookName] ? 1 : 0;
+    const value = called[hookName];
+    const times = typeof value === 'number' ? value : value ? 1 : 0;
     expect(
       hooks[hookName],
       `Expected "${hookName}" to be called ${times} time(s)`,
-    ).toBeCalledTimes(called[hookName] ? 1 : 0);
+    ).toBeCalledTimes(times);
   });
 }
 
@@ -40,6 +45,8 @@ describe('Hooks', () => {
       'build:manifestGenerated': false,
       'entrypoints:grouped': false,
       'entrypoints:resolved': true,
+      'vite:build:extendConfig': false,
+      'vite:devServer:extendConfig': false,
     });
   });
 
@@ -56,6 +63,8 @@ describe('Hooks', () => {
       'build:manifestGenerated': true,
       'entrypoints:grouped': true,
       'entrypoints:resolved': true,
+      'vite:build:extendConfig': 1,
+      'vite:devServer:extendConfig': false,
     });
   });
 
@@ -72,6 +81,8 @@ describe('Hooks', () => {
       'build:manifestGenerated': true,
       'entrypoints:grouped': true,
       'entrypoints:resolved': true,
+      'vite:build:extendConfig': 1,
+      'vite:devServer:extendConfig': false,
     });
   });
 
@@ -94,6 +105,8 @@ describe('Hooks', () => {
       'build:manifestGenerated': true,
       'entrypoints:grouped': true,
       'entrypoints:resolved': true,
+      'vite:build:extendConfig': 2,
+      'vite:devServer:extendConfig': 1,
     });
   });
 });

--- a/src/core/builders/vite/index.ts
+++ b/src/core/builders/vite/index.ts
@@ -22,8 +22,8 @@ import { toArray } from '~/core/utils/arrays';
 
 export async function createViteBuilder(
   wxtConfig: ResolvedConfig,
-  server?: WxtDevServer,
   hooks: Hookable<WxtHooks>,
+  server?: WxtDevServer,
 ): Promise<WxtBuilder> {
   const vite = await import('vite');
 

--- a/src/core/builders/vite/index.ts
+++ b/src/core/builders/vite/index.ts
@@ -6,6 +6,7 @@ import {
   WxtBuilder,
   WxtBuilderServer,
   WxtDevServer,
+  WxtHooks,
 } from '~/types';
 import * as wxtPlugins from './plugins';
 import {
@@ -16,10 +17,13 @@ import {
   VirtualEntrypointType,
   VirtualModuleId,
 } from '~/core/utils/virtual-modules';
+import { Hookable } from 'hookable';
+import { toArray } from '~/core/utils/arrays';
 
 export async function createViteBuilder(
   wxtConfig: ResolvedConfig,
   server?: WxtDevServer,
+  hooks: Hookable<WxtHooks>,
 ): Promise<WxtBuilder> {
   const vite = await import('vite');
 
@@ -27,7 +31,9 @@ export async function createViteBuilder(
    * Returns the base vite config shared by all builds based on the inline and user config.
    */
   const getBaseConfig = async () => {
-    const config: vite.InlineConfig = await wxtConfig.vite(wxtConfig.env);
+    const config: vite.InlineConfig = await wxtConfig.vite({
+      ...wxtConfig.env,
+    });
 
     config.root = wxtConfig.root;
     config.configFile = false;
@@ -198,6 +204,11 @@ export async function createViteBuilder(
       else entryConfig = getLibModeConfig(group);
 
       const buildConfig = vite.mergeConfig(await getBaseConfig(), entryConfig);
+      await hooks.callHook(
+        'vite:build:extendConfig',
+        toArray(group),
+        buildConfig,
+      );
       const result = await vite.build(buildConfig);
       return {
         entrypoints: group,
@@ -214,9 +225,9 @@ export async function createViteBuilder(
         },
       };
       const baseConfig = await getBaseConfig();
-      const viteServer = await vite.createServer(
-        vite.mergeConfig(baseConfig, serverConfig),
-      );
+      const finalConfig = vite.mergeConfig(baseConfig, serverConfig);
+      await hooks.callHook('vite:devServer:extendConfig', finalConfig);
+      const viteServer = await vite.createServer(finalConfig);
 
       const server: WxtBuilderServer = {
         async listen() {

--- a/src/core/wxt.ts
+++ b/src/core/wxt.ts
@@ -28,7 +28,7 @@ export async function registerWxt(
   const hooks = createHooks<WxtHooks>();
   const config = await resolveConfig(inlineConfig, command);
   const server = await getServer?.(config);
-  const builder = await createViteBuilder(config, server);
+  const builder = await createViteBuilder(config, server, hooks);
   const pm = await createWxtPackageManager(config.root);
 
   wxt = {

--- a/src/core/wxt.ts
+++ b/src/core/wxt.ts
@@ -28,7 +28,7 @@ export async function registerWxt(
   const hooks = createHooks<WxtHooks>();
   const config = await resolveConfig(inlineConfig, command);
   const server = await getServer?.(config);
-  const builder = await createViteBuilder(config, server, hooks);
+  const builder = await createViteBuilder(config, hooks, server);
   const pm = await createWxtPackageManager(config.root);
 
   wxt = {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -361,6 +361,29 @@ export type WxtViteConfig = Omit<
   'root' | 'configFile' | 'mode'
 >;
 
+// TODO: Move into @wxt/vite-builder
+export interface WxtHooks {
+  /**
+   * Called when WXT has created Vite's config for a build step. Useful if you
+   * want to add plugins or update the vite config per entrypoint group.
+   *
+   * @param wxt The configured WXT object.
+   * @param config The config that will be used for the dev server.
+   */
+  'vite:build:extendConfig': (
+    entrypoints: readonly Entrypoint[],
+    viteConfig: vite.InlineConfig,
+  ) => HookResult;
+  /**
+   * Called when WXT has created Vite's config for the dev server. Useful if
+   * you want to add plugins or update the vite config per entrypoint group.
+   *
+   * @param wxt The configured WXT object.
+   * @param config The config that will be used to build the entrypoints. Can be updated by reference.
+   */
+  'vite:devServer:extendConfig': (config: vite.InlineConfig) => HookResult;
+}
+
 export interface BuildOutput {
   manifest: Manifest.WebExtensionManifest;
   publicAssets: OutputAsset[];

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -367,8 +367,8 @@ export interface WxtHooks {
    * Called when WXT has created Vite's config for a build step. Useful if you
    * want to add plugins or update the vite config per entrypoint group.
    *
-   * @param wxt The configured WXT object.
-   * @param config The config that will be used for the dev server.
+   * @param entrypoints The list of entrypoints being built with the provided config.
+   * @param viteConfig The config that will be used for the dev server.
    */
   'vite:build:extendConfig': (
     entrypoints: readonly Entrypoint[],
@@ -378,8 +378,7 @@ export interface WxtHooks {
    * Called when WXT has created Vite's config for the dev server. Useful if
    * you want to add plugins or update the vite config per entrypoint group.
    *
-   * @param wxt The configured WXT object.
-   * @param config The config that will be used to build the entrypoints. Can be updated by reference.
+   * @param viteConfig The config that will be used to build the entrypoints. Can be updated by reference.
    */
   'vite:devServer:extendConfig': (config: vite.InlineConfig) => HookResult;
 }


### PR DESCRIPTION
This is useful if you need to conditionally apply config/plugins based on the build.

For example, with UnoCSS, you can add it to only entrypoints with a UI:

```ts
export default defineConfig({
  hooks: {
    'vite:build:extendConfig': (entrypoints, config) => {
      const names = entrypoints.map(entry => entry.name);
      if (names.includes("popup")) config.plugins.push(UnoCSS());
    },
    'vite:devServer:extendConfig': (entrypoints, config) => {
      config.plugins.push(UnoCSS());
    },
  },
});
```

This provides a solution to https://github.com/wxt-dev/wxt/issues/596