### PR TITLE
doc: Fix bad extension API examples

### DIFF
--- a/docs/guide/extension-apis.md
+++ b/docs/guide/extension-apis.md
@@ -39,9 +39,9 @@ Then we can use `browser.storage` to save the install date to local storage.
 ```ts
 // background.ts
 export default defineBackground(() => {
-  browser.runtime.onInstall.addEventListener(({ reason }) => {
+  browser.runtime.onInstalled.addListener(({ reason }) => {
     if (reason === 'install') {
-      browser.storage.local.setItem({ installDate: Date.now() });
+      browser.storage.local.set({ installDate: Date.now() });
     }
   });
 });


### PR DESCRIPTION
is it new version,but no doc?,there is no `browser.runtime.onInstall.addEventListener` or `browser.storage.local.setItem`,but there is `browser.runtime.onInstalled.addListener` and `browser.storage.local.set`,and it does work