### PR TITLE
docs: Fix typo on example for wxt.config.ts.

### DIFF
--- a/docs/guide/manifest.md
+++ b/docs/guide/manifest.md
@@ -11,7 +11,7 @@ The manifest.json is generated at build-time based on files in the `entrypoints/
 While entrypoints are generated and added to the manifest at build-time, you can customize or add to your `manifest.json` in the config file.
 
 ```ts
-// wxt.config.tsentrypoint of your extension
+// wxt.config.ts entrypoint of your extension
 import { defineConfig } from 'wxt';
 
 export default defineConfig({


### PR DESCRIPTION
A single-byte space was missing from the sample comment in `wxt.config.ts` .