### PR TITLE
feat: Support returning values from scripts executed with the scripting API

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,16 +45,11 @@
     "*": "prettier --ignore-unknown --write"
   },
   "changelog": {
-    "excludeAuthors": [
-      "aaronklinker1@gmail.com"
-    ]
+    "excludeAuthors": ["aaronklinker1@gmail.com"]
   },
   "pnpm": {
     "peerDependencyRules": {
-      "ignoreMissing": [
-        "@algolia/client-search",
-        "search-insights"
-      ]
+      "ignoreMissing": ["@algolia/client-search", "search-insights"]
     }
   }
 }

--- a/packages/wxt/e2e/tests/output-structure.test.ts
+++ b/packages/wxt/e2e/tests/output-structure.test.ts
@@ -362,11 +362,13 @@ describe('Output Directory Structure', () => {
           function logHello(name) {
             console.log(\`Hello \${name}!\`);
           }
+          _background;
           const definition = defineBackground({
             main() {
               logHello("background");
             }
           });
+          _background;
           chrome;
           function print(method, ...args) {
             return;
@@ -389,6 +391,7 @@ describe('Output Directory Structure', () => {
             throw err;
           }
         })();
+        _background;
         "
       `);
   });

--- a/packages/wxt/src/core/utils/__tests__/strings.test.ts
+++ b/packages/wxt/src/core/utils/__tests__/strings.test.ts
@@ -2,7 +2,8 @@ import { describe, expect, it } from 'vitest';
 import {
   kebabCaseAlphanumeric,
   removeImportStatements,
-} from '~/core/utils/strings';
+  safeVarName,
+} from '../strings';
 
 describe('String utils', () => {
   describe('kebabCaseAlphanumeric', () => {
@@ -18,6 +19,23 @@ describe('String utils', () => {
     });
   });
 
+  describe('safeVarName', () => {
+    it.each([
+      ['Hello world!', '_hello_world'],
+      ['123', '_123'],
+      ['abc-123', '_abc_123'],
+      ['', '_'],
+      [' ', '_'],
+      ['_', '_'],
+    ])(
+      "should convert '%s' to '%s', which can be used for a variable name",
+      (input, expected) => {
+        const actual = safeVarName(input);
+        expect(actual).toBe(expected);
+      },
+    );
+  });
+
   describe('removeImportStatements', () => {
     it('should remove all import formats', () => {
       const imports = `
@@ -30,7 +48,7 @@ import{ registerGithubService, createGithubApi }from "@/utils/github";
 import GitHub from "@/utils/github";
 import "@/utils/github";
 import '@/utils/github';
-import"@/utils/github" 
+import"@/utils/github"
  import'@/utils/github';
     `;
       expect(removeImportStatements(imports).trim()).toEqual('');

--- a/packages/wxt/src/core/utils/strings.ts
+++ b/packages/wxt/src/core/utils/strings.ts
@@ -6,6 +6,14 @@ export function kebabCaseAlphanumeric(str: string): string {
 }
 
 /**
+ * Return a safe variable name for a given string.
+ */
+export function safeVarName(str: string): string {
+  // _ prefix to ensure it doesn't start with a number
+  return '_' + kebabCaseAlphanumeric(str).replace('-', '_');
+}
+
+/**
  * Removes import statements from the top of a file. Keeps import.meta and inline, async `import()`
  * calls.
  */

--- a/packages/wxt/src/core/utils/strings.ts
+++ b/packages/wxt/src/core/utils/strings.ts
@@ -10,7 +10,7 @@ export function kebabCaseAlphanumeric(str: string): string {
  */
 export function safeVarName(str: string): string {
   // _ prefix to ensure it doesn't start with a number
-  return '_' + kebabCaseAlphanumeric(str).replace('-', '_');
+  return '_' + kebabCaseAlphanumeric(str.trim()).replace('-', '_');
 }
 
 /**

--- a/packages/wxt/src/types/index.ts
+++ b/packages/wxt/src/types/index.ts
@@ -737,16 +737,24 @@ export interface IsolatedWorldContentScriptDefinition
   extends IsolatedWorldContentScriptEntrypointOptions {
   /**
    * Main function executed when the content script is loaded.
+   *
+   * When running a content script with `browser.scripting.executeScript`,
+   * values returned from this function will be returned in the `executeScript`
+   * result as well. Otherwise returning a value does nothing.
    */
-  main(ctx: ContentScriptContext): void | Promise<void>;
+  main(ctx: ContentScriptContext): any | Promise<any>;
 }
 
 export interface MainWorldContentScriptDefinition
   extends MainWorldContentScriptEntrypointOptions {
   /**
    * Main function executed when the content script is loaded.
+   *
+   * When running a content script with `browser.scripting.executeScript`,
+   * values returned from this function will be returned in the `executeScript`
+   * result as well. Otherwise returning a value does nothing.
    */
-  main(): void | Promise<void>;
+  main(): any | Promise<any>;
 }
 
 export type ContentScriptDefinition =
@@ -763,8 +771,12 @@ export interface BackgroundDefinition extends BackgroundEntrypointOptions {
 export interface UnlistedScriptDefinition extends BaseEntrypointOptions {
   /**
    * Main function executed when the unlisted script is ran.
+   *
+   * When running a content script with `browser.scripting.executeScript`,
+   * values returned from this function will be returned in the `executeScript`
+   * result as well. Otherwise returning a value does nothing.
    */
-  main(): void | Promise<void>;
+  main(): any | Promise<any>;
 }
 
 /**

--- a/packages/wxt/src/virtual/content-script-isolated-world-entrypoint.ts
+++ b/packages/wxt/src/virtual/content-script-isolated-world-entrypoint.ts
@@ -2,16 +2,22 @@ import definition from 'virtual:user-content-script-isolated-world-entrypoint';
 import { logger } from '../sandbox/utils/logger';
 import { ContentScriptContext } from 'wxt/client';
 
-(async () => {
+const result = (async () => {
   try {
     const { main, ...options } = definition;
     const ctx = new ContentScriptContext(import.meta.env.ENTRYPOINT, options);
 
-    await main(ctx);
+    return await main(ctx);
   } catch (err) {
     logger.error(
       `The content script "${import.meta.env.ENTRYPOINT}" crashed on startup!`,
       err,
     );
+    throw err;
   }
 })();
+
+// Return the main function's result to the background when executed via the scripting API.
+// https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/scripting/executeScript#return_value
+// Tested on both Chrome and Firefox
+result;

--- a/packages/wxt/src/virtual/content-script-isolated-world-entrypoint.ts
+++ b/packages/wxt/src/virtual/content-script-isolated-world-entrypoint.ts
@@ -17,7 +17,8 @@ const result = (async () => {
   }
 })();
 
-// Return the main function's result to the background when executed via the scripting API.
+// Return the main function's result to the background when executed via the
+// scripting API. Default export causes the IIFE to return a value.
 // https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/scripting/executeScript#return_value
 // Tested on both Chrome and Firefox
-result;
+export default result;

--- a/packages/wxt/src/virtual/content-script-main-world-entrypoint.ts
+++ b/packages/wxt/src/virtual/content-script-main-world-entrypoint.ts
@@ -14,7 +14,8 @@ const result = (async () => {
   }
 })();
 
-// Return the main function's result to the background when executed via the scripting API.
+// Return the main function's result to the background when executed via the
+// scripting API. Default export causes the IIFE to return a value.
 // https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/scripting/executeScript#return_value
 // Tested on both Chrome and Firefox
-result;
+export default result;

--- a/packages/wxt/src/virtual/content-script-main-world-entrypoint.ts
+++ b/packages/wxt/src/virtual/content-script-main-world-entrypoint.ts
@@ -1,14 +1,20 @@
 import definition from 'virtual:user-content-script-main-world-entrypoint';
 import { logger } from '../sandbox/utils/logger';
 
-(async () => {
+const result = (async () => {
   try {
     const { main } = definition;
-    await main();
+    return await main();
   } catch (err) {
     logger.error(
       `The content script "${import.meta.env.ENTRYPOINT}" crashed on startup!`,
       err,
     );
+    throw err;
   }
 })();
+
+// Return the main function's result to the background when executed via the scripting API.
+// https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/scripting/executeScript#return_value
+// Tested on both Chrome and Firefox
+result;

--- a/packages/wxt/src/virtual/unlisted-script-entrypoint.ts
+++ b/packages/wxt/src/virtual/unlisted-script-entrypoint.ts
@@ -1,13 +1,19 @@
 import definition from 'virtual:user-unlisted-script-entrypoint';
 import { logger } from '../sandbox/utils/logger';
 
-(async () => {
+const result = (async () => {
   try {
-    await definition.main();
+    return await definition.main();
   } catch (err) {
     logger.error(
       `The unlisted script "${import.meta.env.ENTRYPOINT}" crashed on startup!`,
       err,
     );
+    throw err;
   }
 })();
+
+// Return the main function's result to the background when executed via the scripting API.
+// https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/scripting/executeScript#return_value
+// Tested on both Chrome and Firefox
+result;

--- a/packages/wxt/src/virtual/unlisted-script-entrypoint.ts
+++ b/packages/wxt/src/virtual/unlisted-script-entrypoint.ts
@@ -13,7 +13,8 @@ const result = (async () => {
   }
 })();
 
-// Return the main function's result to the background when executed via the scripting API.
+// Return the main function's result to the background when executed via the
+// scripting API. Default export causes the IIFE to return a value.
 // https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/scripting/executeScript#return_value
 // Tested on both Chrome and Firefox
-result;
+export default result;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4832,8 +4832,8 @@ packages:
       loose-envify: 1.4.0
     dev: false
 
-  /scule@1.0.0:
-    resolution: {integrity: sha512-4AsO/FrViE/iDNEPaAQlb77tf0csuq27EsVpy6ett584EcRTp6pTDLoGWVxCD77y5iU5FauOvhsI4o1APwPoSQ==}
+  /scule@1.3.0:
+    resolution: {integrity: sha512-6FtHJEvt+pVMIB9IBY+IcCJ6Z5f1iQnytgyfKMhDKgmzYG+TeH/wx1y3l27rshSbLiSanrR9ffZDrEsmjlQF2g==}
     dev: false
 
   /semver-diff@4.0.0:
@@ -5473,7 +5473,7 @@ packages:
       mlly: 1.6.1
       pathe: 1.1.2
       pkg-types: 1.0.3
-      scule: 1.0.0
+      scule: 1.3.0
       strip-literal: 1.3.0
       unplugin: 1.5.0
     transitivePeerDependencies:


### PR DESCRIPTION
This closes #622.

Adds support for returning values from both content scripts (likely with `registration: 'runtime'`, but not necessarily) and unlisted scripts.

Just return a value from the script's main function and the background will get the value, even if it's an async function.

```ts
// Sync function's work
export default defineUnlistedScript(() => {
  // ...
  return "return value"
});

// Async functions also work
export default defineUnlistedScript(async () => {
  // ...
  return "return value"
});
```