### PR TITLE
FIX: Chromium window-size example format

### DIFF
--- a/docs/guide/development.md
+++ b/docs/guide/development.md
@@ -89,7 +89,7 @@ import { defineRunnerConfig } from 'wxt';
 export default defineRunnerConfig({
   startUrls: ['https://google.com', 'https://duckduckgo.com'],
   chromiumProfile: '/path/to/profile/to/use',
-  chromiumArgs: ['--window-size=400x300'],
+  chromiumArgs: ['--window-size=400,300'],
 });
 ```
 


### PR DESCRIPTION
Just a fix for `chromiumArgs: ['--window-size=400x300'],` in the documentation.
`400x300` is not the correct format, should be `400,300`.

More info: https://source.chromium.org/chromium/chromium/src/+/main:headless/lib/switches.cc;l=116-117?q=kWindowSize&ss=chromium