### PR TITLE
feat(experimental): Load entrypoint options with Vite Runtime API

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   },
   "packageManager": "pnpm@8.6.3",
   "scripts": {
-    "check": "pnpm -r run check",
+    "check": "check && pnpm -r run check",
     "test": "vitest",
     "test:coverage": "vitest run --coverage.enabled \"--coverage.include=packages/wxt/src/**\" \"--coverage.exclude=packages/wxt/src/core/utils/testing/**\" \"--coverage.exclude=**/*.d.ts\" \"--coverage.exclude=**/fixtures/**\"",
     "prepare": "simple-git-hooks",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "scripts": {
     "check": "pnpm -r run check",
     "test": "vitest",
-    "test:coverage": "vitest run --coverage.enabled \"--coverage.include=packages/wxt/src/**\" \"--coverage.exclude=packages/wxt/src/core/utils/testing/**\" \"--coverage.exclude=**/*.d.ts\"",
+    "test:coverage": "vitest run --coverage.enabled \"--coverage.include=packages/wxt/src/**\" \"--coverage.exclude=packages/wxt/src/core/utils/testing/**\" \"--coverage.exclude=**/*.d.ts\" \"--coverage.exclude=**/fixtures/**\"",
     "prepare": "simple-git-hooks",
     "prepublish": "pnpm -s build",
     "docs:gen": "typedoc --options docs/typedoc.json",
@@ -45,11 +45,16 @@
     "*": "prettier --ignore-unknown --write"
   },
   "changelog": {
-    "excludeAuthors": ["aaronklinker1@gmail.com"]
+    "excludeAuthors": [
+      "aaronklinker1@gmail.com"
+    ]
   },
   "pnpm": {
     "peerDependencyRules": {
-      "ignoreMissing": ["@algolia/client-search", "search-insights"]
+      "ignoreMissing": [
+        "@algolia/client-search",
+        "search-insights"
+      ]
     }
   }
 }

--- a/packages/wxt-demo/wxt.config.ts
+++ b/packages/wxt-demo/wxt.config.ts
@@ -18,4 +18,7 @@ export default defineConfig({
   analysis: {
     open: true,
   },
+  experimental: {
+    viteRuntime: true,
+  },
 });

--- a/packages/wxt/e2e/tests/manifest-content.test.ts
+++ b/packages/wxt/e2e/tests/manifest-content.test.ts
@@ -1,33 +1,36 @@
 import { describe, it, expect } from 'vitest';
 import { TestProject } from '../utils';
 
-describe('Manifest Content', () => {
-  it.each([
-    { browser: undefined, outDir: 'chrome-mv3', expected: undefined },
-    { browser: 'chrome', outDir: 'chrome-mv3', expected: undefined },
-    { browser: 'firefox', outDir: 'firefox-mv2', expected: true },
-    { browser: 'safari', outDir: 'safari-mv2', expected: false },
-  ])(
-    'should respect the per-browser entrypoint option with %j',
-    async ({ browser, expected, outDir }) => {
-      const project = new TestProject();
+describe.each([true, false])(
+  'Manifest Content (Vite runtime? %s)',
+  (viteRuntime) => {
+    it.each([
+      { browser: undefined, outDir: 'chrome-mv3', expected: undefined },
+      { browser: 'chrome', outDir: 'chrome-mv3', expected: undefined },
+      { browser: 'firefox', outDir: 'firefox-mv2', expected: true },
+      { browser: 'safari', outDir: 'safari-mv2', expected: false },
+    ])(
+      'should respect the per-browser entrypoint option with %j',
+      async ({ browser, expected, outDir }) => {
+        const project = new TestProject();
 
-      project.addFile(
-        'entrypoints/background.ts',
-        `export default defineBackground({
+        project.addFile(
+          'entrypoints/background.ts',
+          `export default defineBackground({
           persistent: {
             firefox: true,
             safari: false,
           },
           main: () => {},
         })`,
-      );
-      await project.build({ browser });
+        );
+        await project.build({ browser, experimental: { viteRuntime } });
 
-      const safariManifest = await project.getOutputManifest(
-        `.output/${outDir}/manifest.json`,
-      );
-      expect(safariManifest.background.persistent).toBe(expected);
-    },
-  );
-});
+        const safariManifest = await project.getOutputManifest(
+          `.output/${outDir}/manifest.json`,
+        );
+        expect(safariManifest.background.persistent).toBe(expected);
+      },
+    );
+  },
+);

--- a/packages/wxt/package.json
+++ b/packages/wxt/package.json
@@ -115,6 +115,7 @@
     "json5": "^2.2.3",
     "jszip": "^3.10.1",
     "linkedom": "^0.16.1",
+    "magicast": "^0.3.4",
     "minimatch": "^9.0.3",
     "natural-compare": "^1.4.0",
     "normalize-path": "^3.0.0",

--- a/packages/wxt/src/core/builders/vite/__tests__/fixtures/module.ts
+++ b/packages/wxt/src/core/builders/vite/__tests__/fixtures/module.ts
@@ -1,0 +1,12 @@
+import { a } from './test';
+
+function defineSomething<T>(config: T): T {
+  return config;
+}
+
+export default defineSomething({
+  option: 'some value',
+  main: () => {
+    console.log('main', a);
+  },
+});

--- a/packages/wxt/src/core/builders/vite/__tests__/fixtures/test.ts
+++ b/packages/wxt/src/core/builders/vite/__tests__/fixtures/test.ts
@@ -1,0 +1,2 @@
+console.log('Side-effect in test.ts');
+export const a = 'a';

--- a/packages/wxt/src/core/builders/vite/__tests__/index.test.ts
+++ b/packages/wxt/src/core/builders/vite/__tests__/index.test.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect } from 'vitest';
+import { createViteBuilder } from '../index';
+import { fakeResolvedConfig } from '~/core/utils/testing/fake-objects';
+import { createHooks } from 'hookable';
+
+describe('Vite Builder', () => {
+  describe('importEntrypoint', () => {
+    it('should import entrypoints, removing runtime values (like the main function)', async () => {
+      const {
+        default: { main: _, ...expected },
+      } = await import('./fixtures/module');
+      const builder = await createViteBuilder(
+        fakeResolvedConfig({ root: __dirname }),
+        createHooks(),
+      );
+      const actual = await builder.importEntrypoint<{ default: any }>(
+        './fixtures/module.ts',
+      );
+      expect(actual).toEqual(expected);
+    });
+  });
+});

--- a/packages/wxt/src/core/builders/vite/index.ts
+++ b/packages/wxt/src/core/builders/vite/index.ts
@@ -20,7 +20,6 @@ import {
 import { Hookable } from 'hookable';
 import { toArray } from '~/core/utils/arrays';
 import { safeVarName } from '~/core/utils/strings';
-import { Module } from 'node:module';
 
 export async function createViteBuilder(
   wxtConfig: ResolvedConfig,

--- a/packages/wxt/src/core/builders/vite/index.ts
+++ b/packages/wxt/src/core/builders/vite/index.ts
@@ -20,6 +20,7 @@ import {
 import { Hookable } from 'hookable';
 import { toArray } from '~/core/utils/arrays';
 import { safeVarName } from '~/core/utils/strings';
+import { Module } from 'node:module';
 
 export async function createViteBuilder(
   wxtConfig: ResolvedConfig,
@@ -203,6 +204,22 @@ export async function createViteBuilder(
   return {
     name: 'Vite',
     version: vite.version,
+    async importEntrypoint(url) {
+      const baseConfig = await getBaseConfig();
+      const envConfig: vite.InlineConfig = {
+        plugins: [
+          wxtPlugins.webextensionPolyfillMock(wxtConfig),
+          wxtPlugins.removeEntrypointMainFunction(wxtConfig, url),
+        ],
+      };
+      const config = vite.mergeConfig(baseConfig, envConfig);
+      const server = await vite.createServer(config);
+      await server.listen();
+      const runtime = await vite.createViteRuntime(server, { hmr: false });
+      const module = await runtime.executeUrl(url);
+      await server.close();
+      return module.default;
+    },
     async build(group) {
       let entryConfig;
       if (Array.isArray(group)) entryConfig = getMultiPageConfig(group);

--- a/packages/wxt/src/core/builders/vite/plugins/index.ts
+++ b/packages/wxt/src/core/builders/vite/plugins/index.ts
@@ -13,3 +13,4 @@ export * from './webextensionPolyfillMock';
 export * from './excludeBrowserPolyfill';
 export * from './entrypointGroupGlobals';
 export * from './defineImportMeta';
+export * from './removeEntrypointMainFunction';

--- a/packages/wxt/src/core/builders/vite/plugins/removeEntrypointMainFunction.ts
+++ b/packages/wxt/src/core/builders/vite/plugins/removeEntrypointMainFunction.ts
@@ -5,7 +5,7 @@ import { removeMainFunctionCode } from '~/core/utils/transform';
 import { resolve } from 'node:path';
 
 /**
- * Transforms entrypoints, removing their main function.
+ * Transforms entrypoints, removing the main function from the entrypoint if it exists.
  */
 export function removeEntrypointMainFunction(
   config: ResolvedConfig,

--- a/packages/wxt/src/core/builders/vite/plugins/removeEntrypointMainFunction.ts
+++ b/packages/wxt/src/core/builders/vite/plugins/removeEntrypointMainFunction.ts
@@ -1,0 +1,21 @@
+import { ResolvedConfig } from '~/types';
+import * as vite from 'vite';
+import { normalizePath } from '~/core/utils/paths';
+import { removeMainFunctionCode } from '~/core/utils/transform';
+import { resolve } from 'node:path';
+
+/**
+ * Transforms entrypoints, removing their main function.
+ */
+export function removeEntrypointMainFunction(
+  config: ResolvedConfig,
+  path: string,
+): vite.Plugin {
+  const absPath = normalizePath(resolve(config.root, path));
+  return {
+    name: 'wxt:remove-entrypoint-main-function',
+    transform(code, id) {
+      if (id === absPath) return removeMainFunctionCode(code);
+    },
+  };
+}

--- a/packages/wxt/src/core/utils/__tests__/transform.test.ts
+++ b/packages/wxt/src/core/utils/__tests__/transform.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect } from 'vitest';
+import { removeMainFunctionCode } from '../transform';
+
+describe('Transform Utils', () => {
+  describe('removeMainFunctionCode', () => {
+    it.each(['defineBackground', 'defineUnlistedScript'])(
+      'should remove the first arrow function argument for %s',
+      (def) => {
+        const input = `export default ${def}(() => {
+            console.log();
+          })`;
+        const expected = `export default ${def}(() => {})`;
+
+        const actual = removeMainFunctionCode(input).code;
+
+        expect(actual).toEqual(expected);
+      },
+    );
+    it.each(['defineBackground', 'defineUnlistedScript'])(
+      'should remove the first function argument for %s',
+      (def) => {
+        const input = `export default ${def}(function () {
+            console.log();
+          })`;
+        const expected = `export default ${def}(function () {})`;
+
+        const actual = removeMainFunctionCode(input).code;
+
+        expect(actual).toEqual(expected);
+      },
+    );
+
+    it.each([
+      'defineBackground',
+      'defineContentScript',
+      'defineUnlistedScript',
+    ])('should remove the main field from %s', (def) => {
+      const input = `export default ${def}({
+        asdf: "asdf",
+        main: () => {},
+      })`;
+      const expected = `export default ${def}({
+  asdf: "asdf"
+})`;
+
+      const actual = removeMainFunctionCode(input).code;
+
+      expect(actual).toEqual(expected);
+    });
+  });
+});

--- a/packages/wxt/src/core/utils/building/find-entrypoints.ts
+++ b/packages/wxt/src/core/utils/building/find-entrypoints.ts
@@ -34,6 +34,10 @@ import { importEntrypointFile } from './import-entrypoint';
  * Return entrypoints and their configuration by looking through the project's files.
  */
 export async function findEntrypoints(): Promise<Entrypoint[]> {
+  // Make sure required TSConfig file exists to load dependencies
+  await fs.mkdir(wxt.config.wxtDir, { recursive: true });
+  await fs.writeJson(resolve(wxt.config.wxtDir, 'tsconfig.json'), {});
+
   const relativePaths = await glob(Object.keys(PATH_GLOB_TO_TYPE_MAP), {
     cwd: wxt.config.entrypointsDir,
   });

--- a/packages/wxt/src/core/utils/building/find-entrypoints.ts
+++ b/packages/wxt/src/core/utils/building/find-entrypoints.ts
@@ -14,7 +14,6 @@ import {
   OptionsEntrypointOptions,
   SidepanelEntrypoint,
   SidepanelEntrypointOptions,
-  WxtBuilder,
 } from '~/types';
 import fs from 'fs-extra';
 import { minimatch } from 'minimatch';

--- a/packages/wxt/src/core/utils/building/find-entrypoints.ts
+++ b/packages/wxt/src/core/utils/building/find-entrypoints.ts
@@ -28,6 +28,7 @@ import { VIRTUAL_NOOP_BACKGROUND_MODULE_ID } from '~/core/utils/constants';
 import { CSS_EXTENSIONS_PATTERN } from '~/core/utils/paths';
 import pc from 'picocolors';
 import { wxt } from '../../wxt';
+import { importEntrypointFile } from './import-entrypoint';
 
 /**
  * Return entrypoints and their configuration by looking through the project's files.
@@ -285,7 +286,7 @@ async function getUnlistedScriptEntrypoint({
   skipped,
 }: EntrypointInfo): Promise<GenericEntrypoint> {
   const defaultExport =
-    await wxt.builder.importEntrypoint<UnlistedScriptDefinition>(inputPath);
+    await importEntrypoint<UnlistedScriptDefinition>(inputPath);
   if (defaultExport == null) {
     throw Error(
       `${name}: Default export not found, did you forget to call "export default defineUnlistedScript(...)"?`,
@@ -310,7 +311,7 @@ async function getBackgroundEntrypoint({
   let options: Omit<BackgroundDefinition, 'main'> = {};
   if (inputPath !== VIRTUAL_NOOP_BACKGROUND_MODULE_ID) {
     const defaultExport =
-      await wxt.builder.importEntrypoint<BackgroundDefinition>(inputPath);
+      await importEntrypoint<BackgroundDefinition>(inputPath);
     if (defaultExport == null) {
       throw Error(
         `${name}: Default export not found, did you forget to call "export default defineBackground(...)"?`,
@@ -340,7 +341,7 @@ async function getContentScriptEntrypoint({
   skipped,
 }: EntrypointInfo): Promise<ContentScriptEntrypoint> {
   const { main: _, ...options } =
-    await wxt.builder.importEntrypoint<ContentScriptDefinition>(inputPath);
+    await importEntrypoint<ContentScriptDefinition>(inputPath);
   if (options == null) {
     throw Error(
       `${name}: Default export not found, did you forget to call "export default defineContentScript(...)"?`,
@@ -483,3 +484,9 @@ const PATH_GLOB_TO_TYPE_MAP: Record<string, Entrypoint['type']> = {
 };
 
 const CONTENT_SCRIPT_OUT_DIR = 'content-scripts';
+
+function importEntrypoint<T>(path: string) {
+  return wxt.config.experimental.viteRuntime
+    ? wxt.builder.importEntrypoint<T>(path)
+    : importEntrypointFile<T>(path);
+}

--- a/packages/wxt/src/core/utils/building/find-entrypoints.ts
+++ b/packages/wxt/src/core/utils/building/find-entrypoints.ts
@@ -14,12 +14,12 @@ import {
   OptionsEntrypointOptions,
   SidepanelEntrypoint,
   SidepanelEntrypointOptions,
+  WxtBuilder,
 } from '~/types';
 import fs from 'fs-extra';
 import { minimatch } from 'minimatch';
 import { parseHTML } from 'linkedom';
 import JSON5 from 'json5';
-import { importEntrypointFile } from '~/core/utils/building';
 import glob from 'fast-glob';
 import {
   getEntrypointName,
@@ -286,7 +286,7 @@ async function getUnlistedScriptEntrypoint({
   skipped,
 }: EntrypointInfo): Promise<GenericEntrypoint> {
   const defaultExport =
-    await importEntrypointFile<UnlistedScriptDefinition>(inputPath);
+    await wxt.builder.importEntrypoint<UnlistedScriptDefinition>(inputPath);
   if (defaultExport == null) {
     throw Error(
       `${name}: Default export not found, did you forget to call "export default defineUnlistedScript(...)"?`,
@@ -311,7 +311,7 @@ async function getBackgroundEntrypoint({
   let options: Omit<BackgroundDefinition, 'main'> = {};
   if (inputPath !== VIRTUAL_NOOP_BACKGROUND_MODULE_ID) {
     const defaultExport =
-      await importEntrypointFile<BackgroundDefinition>(inputPath);
+      await wxt.builder.importEntrypoint<BackgroundDefinition>(inputPath);
     if (defaultExport == null) {
       throw Error(
         `${name}: Default export not found, did you forget to call "export default defineBackground(...)"?`,
@@ -341,7 +341,7 @@ async function getContentScriptEntrypoint({
   skipped,
 }: EntrypointInfo): Promise<ContentScriptEntrypoint> {
   const { main: _, ...options } =
-    await importEntrypointFile<ContentScriptDefinition>(inputPath);
+    await wxt.builder.importEntrypoint<ContentScriptDefinition>(inputPath);
   if (options == null) {
     throw Error(
       `${name}: Default export not found, did you forget to call "export default defineContentScript(...)"?`,

--- a/packages/wxt/src/core/utils/building/resolve-config.ts
+++ b/packages/wxt/src/core/utils/building/resolve-config.ts
@@ -152,6 +152,7 @@ export async function resolveConfig(
     alias,
     experimental: defu(mergedConfig.experimental, {
       includeBrowserPolyfill: true,
+      viteRuntime: false,
     }),
     dev: {
       server: devServerConfig,

--- a/packages/wxt/src/core/utils/package.ts
+++ b/packages/wxt/src/core/utils/package.ts
@@ -22,5 +22,5 @@ export async function getPackageJson(): Promise<
 }
 
 export function isModuleInstalled(name: string) {
-  return import(name).then(() => true).catch(() => false);
+  return import(/* @vite-ignore */ name).then(() => true).catch(() => false);
 }

--- a/packages/wxt/src/core/utils/testing/fake-objects.ts
+++ b/packages/wxt/src/core/utils/testing/fake-objects.ts
@@ -295,6 +295,7 @@ export const fakeResolvedConfig = fakeObjectCreator<ResolvedConfig>(() => {
     alias: {},
     experimental: {
       includeBrowserPolyfill: true,
+      viteRuntime: false,
     },
     dev: {
       reloadCommand: 'Alt+R',

--- a/packages/wxt/src/core/utils/transform.ts
+++ b/packages/wxt/src/core/utils/transform.ts
@@ -1,0 +1,25 @@
+import { parseModule } from 'magicast';
+
+export function removeMainFunctionCode(code: string): {
+  code: string;
+  map?: string;
+} {
+  const mod = parseModule(code);
+  if (mod.exports.default.$type === 'function-call') {
+    console.log(mod.exports.default.$ast?.arguments?.[0]?.properties);
+    if (mod.exports.default.$ast?.arguments?.[0]?.body) {
+      // Remove body from function
+      // ex: "fn(() => { ... })" to "fn(() => {})"
+      // ex: "fn(function () { ... })" to "fn(function () {})"
+      mod.exports.default.$ast.arguments[0].body.body = [];
+    } else if (mod.exports.default.$ast?.arguments?.[0]?.properties) {
+      // Remove main field from object
+      // ex: "fn({ ..., main: () => {} })" to "fn({ ... })"
+      mod.exports.default.$ast.arguments[0].properties =
+        mod.exports.default.$ast.arguments[0].properties.filter(
+          (prop: any) => prop.key.name !== 'main',
+        );
+    }
+  }
+  return mod.generate();
+}

--- a/packages/wxt/src/core/utils/transform.ts
+++ b/packages/wxt/src/core/utils/transform.ts
@@ -1,12 +1,21 @@
-import { parseModule } from 'magicast';
+import { ProxifiedModule, parseModule } from 'magicast';
 
+/**
+ * Removes any code used at runtime related to an entrypoint's main function.
+ * - Removes or clears out `main` function from returned object
+ * - TODO: Removes unused imports after main function has been removed to prevent importing runtime modules
+ */
 export function removeMainFunctionCode(code: string): {
   code: string;
   map?: string;
 } {
   const mod = parseModule(code);
-  if (mod.exports.default.$type === 'function-call') {
-    console.log(mod.exports.default.$ast?.arguments?.[0]?.properties);
+  emptyMainFunction(mod);
+  return mod.generate();
+}
+
+function emptyMainFunction(mod: ProxifiedModule) {
+  if (mod.exports?.default?.$type === 'function-call') {
     if (mod.exports.default.$ast?.arguments?.[0]?.body) {
       // Remove body from function
       // ex: "fn(() => { ... })" to "fn(() => {})"
@@ -21,5 +30,4 @@ export function removeMainFunctionCode(code: string): {
         );
     }
   }
-  return mod.generate();
 }

--- a/packages/wxt/src/types/index.ts
+++ b/packages/wxt/src/types/index.ts
@@ -312,6 +312,15 @@ export interface InlineConfig {
      * })
      */
     includeBrowserPolyfill?: boolean;
+    /**
+     * When set to `true`, use the Vite Runtime API to load entrypoint options instead of the default, `jiti`.
+     *
+     * Lets you use imported variables and leverage your Vite config to add support for non-standard APIs/syntax.
+     *
+     * @experimental Early access to try out the feature before it becomes the default.
+     * @default false
+     */
+    viteRuntime?: boolean;
   };
   /**
    * Config effecting dev mode only.
@@ -1128,6 +1137,7 @@ export interface ResolvedConfig {
   alias: Record<string, string>;
   experimental: {
     includeBrowserPolyfill: boolean;
+    viteRuntime: boolean;
   };
   dev: {
     /** Only defined during dev command */

--- a/packages/wxt/src/types/index.ts
+++ b/packages/wxt/src/types/index.ts
@@ -930,6 +930,10 @@ export interface WxtBuilder {
    */
   version: string;
   /**
+   * Import the entrypoint file, returning the default export containing the options.
+   */
+  importEntrypoint<T>(path: string): Promise<T>;
+  /**
    * Build a single entrypoint group. This is effectively one of the multiple "steps" during the
    * build process.
    */

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -137,6 +137,9 @@ importers:
       linkedom:
         specifier: ^0.16.1
         version: 0.16.8
+      magicast:
+        specifier: ^0.3.4
+        version: 0.3.4
       minimatch:
         specifier: ^9.0.3
         version: 9.0.3
@@ -443,31 +446,29 @@ packages:
       '@babel/highlight': 7.22.5
     dev: false
 
-  /@babel/helper-string-parser@7.23.4:
-    resolution: {integrity: sha512-803gmbQdqwdf4olxrX4AJyFBV/RTr3rSmOj0rKwesmzlfhYNDEs+/iOcznzpNWlJlIlTJC2QfPFcHB6DlzdVLQ==}
+  /@babel/helper-string-parser@7.24.1:
+    resolution: {integrity: sha512-2ofRCjnnA9y+wk8b9IAREroeUP02KHp431N2mhKniy2yKIDKpbrHv9eXwm8cBeWQYcJmzv5qKCu65P47eCF7CQ==}
     engines: {node: '>=6.9.0'}
-    dev: true
 
-  /@babel/helper-validator-identifier@7.22.20:
-    resolution: {integrity: sha512-Y4OZ+ytlatR8AI+8KZfKuL5urKp7qey08ha31L8b3BwewJAoJamTzyvxPR/5D+KkdJCGPq/+8TukHBlY10FX9A==}
+  /@babel/helper-validator-identifier@7.24.5:
+    resolution: {integrity: sha512-3q93SSKX2TWCG30M2G2kwaKeTYgEUp5Snjuj8qm729SObL6nbtUldAi37qbxkD5gg3xnBio+f9nqpSepGZMvxA==}
     engines: {node: '>=6.9.0'}
 
   /@babel/highlight@7.22.5:
     resolution: {integrity: sha512-BSKlD1hgnedS5XRnGOljZawtag7H1yPfQp0tdNJCHoH6AZ+Pcm9VvkrK59/Yy593Ypg0zMxH2BxD1VPYUQ7UIw==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/helper-validator-identifier': 7.22.20
+      '@babel/helper-validator-identifier': 7.24.5
       chalk: 2.4.2
       js-tokens: 4.0.0
     dev: false
 
-  /@babel/parser@7.24.1:
-    resolution: {integrity: sha512-Zo9c7N3xdOIQrNip7Lc9wvRPzlRtovHVE4lkz8WEDr7uYh/GMQhSiIgFxGIArRHYdJE5kxtZjAf8rT0xhdLCzg==}
+  /@babel/parser@7.24.5:
+    resolution: {integrity: sha512-EOv5IK8arwh3LI47dz1b0tKUb/1uhHAnHJOrjgtQMIpu1uXd9mlFrJg9IUgGUgZ41Ch0K8REPTYpO7B76b4vJg==}
     engines: {node: '>=6.0.0'}
     hasBin: true
     dependencies:
-      '@babel/types': 7.23.9
-    dev: true
+      '@babel/types': 7.24.5
 
   /@babel/runtime@7.23.9:
     resolution: {integrity: sha512-0CX6F+BI2s9dkUqr08KFrAIZgNFj75rdBU/DjCyYLIaV/quFjkk6T+EJ2LkZHyZTbEV4L5p97mNkUsHl2wLFAw==}
@@ -476,14 +477,13 @@ packages:
       regenerator-runtime: 0.14.0
     dev: false
 
-  /@babel/types@7.23.9:
-    resolution: {integrity: sha512-dQjSq/7HaSjRM43FFGnv5keM2HsxpmyV1PfaSVm0nzzjwwTmjOe6J4bC8e3+pTEIgHaHj+1ZlLThRJ2auc/w1Q==}
+  /@babel/types@7.24.5:
+    resolution: {integrity: sha512-6mQNsaLeXTw0nxYUYu+NSa4Hx4BlF1x1x8/PMFbiR+GBSr+2DkECc69b8hgy2frEodNcvPffeH8YfWd3LI6jhQ==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/helper-string-parser': 7.23.4
-      '@babel/helper-validator-identifier': 7.22.20
+      '@babel/helper-string-parser': 7.24.1
+      '@babel/helper-validator-identifier': 7.24.5
       to-fast-properties: 2.0.0
-    dev: true
 
   /@bcoe/v8-coverage@0.2.3:
     resolution: {integrity: sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==}
@@ -1511,7 +1511,7 @@ packages:
       istanbul-lib-source-maps: 4.0.1
       istanbul-reports: 3.1.6
       magic-string: 0.30.8
-      magicast: 0.3.3
+      magicast: 0.3.4
       picocolors: 1.0.0
       std-env: 3.6.0
       test-exclude: 6.0.0
@@ -1563,7 +1563,7 @@ packages:
   /@vue/compiler-core@3.4.21:
     resolution: {integrity: sha512-MjXawxZf2SbZszLPYxaFCjxfibYrzr3eYbKxwpLR9EQN+oaziSu3qKVbwBERj1IFIB8OLUewxB5m/BFzi613og==}
     dependencies:
-      '@babel/parser': 7.24.1
+      '@babel/parser': 7.24.5
       '@vue/shared': 3.4.21
       entities: 4.5.0
       estree-walker: 2.0.2
@@ -1580,7 +1580,7 @@ packages:
   /@vue/compiler-sfc@3.4.21:
     resolution: {integrity: sha512-me7epoTxYlY+2CUM7hy9PCDdpMPfIwrOvAXud2Upk10g4YLv9UBW7kL798TvMeDhPthkZ0CONNrK2GoeI1ODiQ==}
     dependencies:
-      '@babel/parser': 7.24.1
+      '@babel/parser': 7.24.5
       '@vue/compiler-core': 3.4.21
       '@vue/compiler-dom': 3.4.21
       '@vue/compiler-ssr': 3.4.21
@@ -3858,13 +3858,12 @@ packages:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.4.15
 
-  /magicast@0.3.3:
-    resolution: {integrity: sha512-ZbrP1Qxnpoes8sz47AM0z08U+jW6TyRgZzcWy3Ma3vDhJttwMwAFDMMQFobwdBxByBD46JYmxRzeF7w2+wJEuw==}
+  /magicast@0.3.4:
+    resolution: {integrity: sha512-TyDF/Pn36bBji9rWKHlZe+PZb6Mx5V8IHCSxk7X4aljM4e/vyDvZZYwHewdVaqiA0nb3ghfHU/6AUpDxWoER2Q==}
     dependencies:
-      '@babel/parser': 7.24.1
-      '@babel/types': 7.23.9
+      '@babel/parser': 7.24.5
+      '@babel/types': 7.24.5
       source-map-js: 1.2.0
-    dev: true
 
   /make-dir@4.0.0:
     resolution: {integrity: sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==}
@@ -5285,7 +5284,6 @@ packages:
   /to-fast-properties@2.0.0:
     resolution: {integrity: sha512-/OaKK0xYrs3DmxRYqL/yDc+FxFUVYhDlXMhRmv3z915w2HF1tnN1omB354j8VUGO/hbRzyD6Y3sA7v7GS/ceog==}
     engines: {node: '>=4'}
-    dev: true
 
   /to-regex-range@5.0.1:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}


### PR DESCRIPTION
Entrypoint options can now be extracted during the build using the [Vite Runtime API](https://vitejs.dev/guide/api-vite-runtime). Previously, these files were loaded using `jiti`.

```ts
// wxt.config.ts
export default defineConfig({
  experimental: {
    viteRuntime: true,
  },
});
```

With the experimental flag enabled, you can now:

- Use imported variables outside the `main` function of your entrypoints
- Use vite-only features like `import.meta.glob` to generate options like content script `matches`
- Leverage any Vite plugins you've listed in `wxt.config.ts` to transform your code, allowing use of non-standard syntax

Since all code is now loaded using Vite, it should also be more consistent and lead to less differences in runtime, which has caused errors.

The main downside to this approach is that it will take longer to load entrypoint options at the start of a build. WXT tries to tree-shake out as much runtime code as possible, but will not remove any explicitly listed imports.

For the demo app, the entire build goes from 1.5s to 1.9s.

---

Apart of #506. Not closing until I've released and tested all the reports again. Based on experimentation done in #585.