### PR TITLE
docs: Correct event handler name in handling-updates.md

### DIFF
--- a/docs/guide/handling-updates.md
+++ b/docs/guide/handling-updates.md
@@ -84,7 +84,7 @@ To validate this, you can create a third ZIP file with a rare permission like `g
 You can setup a callback that runs after your extension updates like so:
 
 ```ts
-browser.runtime.onInstalled.addEventListener(({ reason }) => {
+browser.runtime.onInstalled.addListener(({ reason }) => {
   if (reason === 'update') {
     // Do something
   }


### PR DESCRIPTION
According to the TypeScript types and the docs https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/runtime/onInstalled the method name should be `addListener`