### PR TITLE
feat(runner): Add `keepProfileChanges` option

### DIFF
--- a/packages/wxt/src/core/runners/web-ext.ts
+++ b/packages/wxt/src/core/runners/web-ext.ts
@@ -35,6 +35,7 @@ export function createWebExtRunner(): ExtensionRunner {
         console: wxtUserConfig?.openConsole,
         devtools: wxtUserConfig?.openDevtools,
         startUrl: wxtUserConfig?.startUrls,
+        keepProfileChanges: wxtUserConfig?.keepProfileChanges,
         ...(wxt.config.browser === 'firefox'
           ? {
               firefox: wxtUserConfig?.binaries?.firefox,

--- a/packages/wxt/src/types/index.ts
+++ b/packages/wxt/src/types/index.ts
@@ -927,6 +927,10 @@ export interface ExtensionRunnerConfig {
    * @see https://extensionworkshop.com/documentation/develop/web-ext-command-reference/#start-url
    */
   startUrls?: string[];
+  /**
+   * @see https://extensionworkshop.com/documentation/develop/web-ext-command-reference/#keep-profile-changes
+   */
+  keepProfileChanges?: boolean;
 }
 
 export interface WxtBuilder {


### PR DESCRIPTION
This will add the [`keepProfileChanges`](https://extensionworkshop.com/documentation/develop/web-ext-command-reference/#keep-profile-changes) to the runner config.

I was trying to use the `--keep-profile-changes` in the `args` but it was not working, so I added as a option for the runner, just like `startUrls`.

Usage:

```ts
// wxt.config.ts
import { defineConfig } from 'wxt';

export default defineConfig({
  ...
  runner: {
    keepProfileChanges: true
  },
});
```

or

```ts
// web-ext.config.ts
import { defineRunnerConfig } from 'wxt';

export default defineRunnerConfig({
  keepProfileChanges: true
});
```