### PR TITLE
fix: Remove `import * as` imports from entrypoints during build

### DIFF
--- a/packages/wxt/src/core/utils/__tests__/strings.test.ts
+++ b/packages/wxt/src/core/utils/__tests__/strings.test.ts
@@ -50,6 +50,7 @@ import "@/utils/github";
 import '@/utils/github';
 import"@/utils/github"
  import'@/utils/github';
+import * as abc from "@/utils/github"
     `;
       expect(removeImportStatements(imports).trim()).toEqual('');
     });

--- a/packages/wxt/src/core/utils/strings.ts
+++ b/packages/wxt/src/core/utils/strings.ts
@@ -19,7 +19,7 @@ export function safeVarName(str: string): string {
  */
 export function removeImportStatements(text: string): string {
   return text.replace(
-    /(import\s?[{\w][\s\S]*?from\s?["'][\s\S]*?["'];?|import\s?["'][\s\S]*?["'];?)/gm,
+    /(import\s?[\s\S]*?from\s?["'][\s\S]*?["'];?|import\s?["'][\s\S]*?["'];?)/gm,
     '',
   );
 }


### PR DESCRIPTION
This closes #668 