### PR TITLE
fix: `ctx.onInvalidated` does not work

### DIFF
--- a/packages/wxt/src/client/content-scripts/content-script-context.ts
+++ b/packages/wxt/src/client/content-scripts/content-script-context.ts
@@ -217,7 +217,7 @@ export class ContentScriptContext implements AbortController {
     // Use postMessage so it get's sent to all the frames of the page.
     window.postMessage(
       {
-        event: ContentScriptContext.SCRIPT_STARTED_MESSAGE_TYPE,
+        type: ContentScriptContext.SCRIPT_STARTED_MESSAGE_TYPE,
         contentScriptName: this.contentScriptName,
       },
       '*',


### PR DESCRIPTION
When the content script is loaded repeatedly, `ctx.onInvalidated` does not work.

This is because the code below uses `data.type`:
https://github.com/wxt-dev/wxt/blob/7b849b80cbc1e47ff0ee34450a2fcb46a29467fa/packages/wxt/src/client/content-scripts/content-script-context.ts#L230

Whereas the events sent out by postMessage use `event` as the key.
https://github.com/wxt-dev/wxt/blob/7b849b80cbc1e47ff0ee34450a2fcb46a29467fa/packages/wxt/src/client/content-scripts/content-script-context.ts#L220