### PR TITLE
fix: To fix the issue with Entrypoint Side Effects link errors

### DIFF
--- a/packages/wxt/src/core/utils/building/import-entrypoint.ts
+++ b/packages/wxt/src/core/utils/building/import-entrypoint.ts
@@ -90,7 +90,7 @@ export async function importEntrypointFile<T>(path: string): Promise<T> {
       // "XXX is not defined" - usually due to WXT removing imports
       const variableName = err.message.replace(' is not defined', '');
       throw Error(
-        `${filePath}: Cannot use imported variable "${variableName}" outside the main function. See https://wxt.dev/guide/entrypoints.html#side-effects`,
+        `${filePath}: Cannot use imported variable "${variableName}" outside the main function. See https://wxt.dev/guide/go-further/entrypoint-side-effects.html`,
         { cause: err },
       );
     } else {


### PR DESCRIPTION
The current console error message displays an incorrect link, which results in a 404 error. Specifically, it points to: <https://wxt.dev/guide/entrypoints.html#side-effects>

<img width="1043" alt="image" src="https://github.com/wxt-dev/wxt/assets/24560368/2561f54b-2466-4ad8-8a75-e43f419e70ff">
<img width="948" alt="image" src="https://github.com/wxt-dev/wxt/assets/24560368/0e24e2a8-a8fc-47a2-aac6-43fc4ac0f19f">

Upon checking, I found that the correct link is <https://wxt.dev/guide/go-further/entrypoint-side-effects.html>, so I should quickly submit a PR to fix it.

<img width="948" alt="image" src="https://github.com/wxt-dev/wxt/assets/24560368/7ce41354-e35b-4bea-b290-5c525029ae8a">

---

Additionally, the homepage link also resulted in a 404 error yesterday. Have you been restructuring the documentation recently? Is there any linting or other validation in place to check for broken links after making adjustments to the documentation?