### PR TITLE
docs: Simplify menu configuration

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -116,7 +116,7 @@ export default defineConfig({
           ]),
           menuItem('hooks/', 'hooks'),
           menuItem('modules/', 'modules'),
-          menuGroup('public/', 'public', [
+          menuItem('public/', 'public/', [
             menuItem('_locales/', 'public/locales'),
           ]),
           menuItem('utils/', 'utils'),

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -115,7 +115,6 @@ export default defineConfig({
             menuItem('*.ts', 'unlisted-scripts.md'),
           ]),
           menuItem('hooks/', 'hooks'),
-          menuItem('modules/', 'modules'),
           menuItem('public/', 'public/', [
             menuItem('_locales/', 'public/locales'),
           ]),

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -119,7 +119,7 @@ export default defineConfig({
           menuGroup('public/', 'public', [
             menuItem('_locales/', 'public/locales'),
           ]),
-          menuItem('utils/', 'modules'),
+          menuItem('utils/', 'utils'),
 
           // Files
           menuItem('.env', 'env'),

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -1,22 +1,16 @@
-import { DefaultTheme, defineConfig } from 'vitepress';
+import { defineConfig } from 'vitepress';
 import typedocSidebar from '../api/reference/typedoc-sidebar.json';
-
-const filteredTypedocSidebar = typedocSidebar.filter(
-  (item) => item.text !== 'API',
-);
-// Typedoc's markdown theme adds collapse: true to all our items, event ones without any children,
-// so they need to be removed.
-function removeCollapsedWithNoItems(items: DefaultTheme.SidebarItem[]) {
-  for (const item of items) {
-    if (item.items) removeCollapsedWithNoItems(item.items);
-    else delete item.collapsed;
-  }
-}
-removeCollapsedWithNoItems(filteredTypedocSidebar);
+import {
+  menuGroup,
+  menuItem,
+  menuRoot,
+  navItem,
+  prepareTypedocSidebar,
+} from './utils/menus';
+import { meta, script } from './utils/head';
 
 const title = 'Next-gen Web Extension Framework';
 const titleSuffix = ' – WXT';
-
 const description =
   "WXT provides the best developer experience, making it quick, easy, and fun to develop chrome extensions for all browsers. With built-in utilities for building, zipping, and publishing your extension, it's easy to get started.";
 const ogTitle = `${title}${titleSuffix}`;
@@ -37,20 +31,16 @@ export default defineConfig({
   },
 
   head: [
-    ['meta', { property: 'og:type', content: 'website' }],
-    ['meta', { property: 'og:title', content: ogTitle }],
-    ['meta', { property: 'og:image', content: ogImage }],
-    ['meta', { property: 'og:url', content: ogUrl }],
-    ['meta', { property: 'og:description', content: description }],
-    ['meta', { name: 'twitter:card', content: 'summary_large_image' }],
-    [
-      'script',
-      {
-        async: '',
-        'data-website-id': 'c1840c18-a12c-4a45-a848-55ae85ef7915',
-        src: 'https://umami.aklinker1.io/script.js',
-      },
-    ],
+    meta('og:type', 'website'),
+    meta('og:title', ogTitle),
+    meta('og:image', ogImage),
+    meta('og:url', ogUrl),
+    meta('og:description', description),
+    meta('twitter:card', 'summary_large_image', true),
+    script('https://umami.aklinker1.io/script.js', {
+      'data-website-id': 'c1840c18-a12c-4a45-a848-55ae85ef7915',
+      async: '',
+    }),
   ],
 
   themeConfig: {
@@ -59,170 +49,116 @@ export default defineConfig({
       src: '/logo.svg',
       alt: 'WXT logo',
     },
+
     editLink: {
       pattern: 'https://github.com/wxt-dev/wxt/edit/main/docs/:path',
     },
+
     search: {
       provider: 'local',
-    },
-
-    nav: [
-      { text: 'Get Started', link: '/get-started/introduction' },
-      { text: 'Guide', link: '/guide/key-concepts/manifest' },
-      { text: 'Examples', link: '/examples' },
-      { text: 'API', link: '/api/reference/wxt' },
-    ],
-
-    sidebar: {
-      '/get-started/': [
-        {
-          text: 'Get Started',
-          base: '/get-started/',
-          items: [
-            { text: 'Introduction', link: 'introduction' },
-            { text: 'Installation', link: 'installation' },
-            { text: 'Configuration', link: 'configuration' },
-            { text: 'Entrypoints', link: 'entrypoints' },
-            { text: 'Assets', link: 'assets' },
-            { text: 'Testing', link: 'testing' },
-            { text: 'Publishing', link: 'publishing' },
-            { text: 'Migrate to WXT', link: 'migrate-to-wxt' },
-            { text: 'Compare', link: 'compare' },
-          ],
-        },
-      ],
-      '/guide/': [
-        {
-          items: [
-            {
-              text: 'Key Concepts',
-              collapsed: true,
-              base: '/guide/key-concepts/',
-              items: [
-                { text: 'Manifest', link: 'manifest' },
-                { text: 'Auto-imports', link: 'auto-imports' },
-                {
-                  text: 'Web Extension Polyfill',
-                  link: 'web-extension-polyfill',
-                },
-                { text: 'Frontend Frameworks', link: 'frontend-frameworks' },
-                { text: 'Content Script UI', link: 'content-script-ui' },
-              ],
-            },
-            {
-              text: 'Directory Structure',
-              collapsed: true,
-              base: '/guide/directory-structure/',
-              items: [
-                // Folders
-                { text: '.output/', link: 'output' },
-                { text: '.wxt/', link: 'wxt' },
-                { text: 'assets/', link: 'assets' },
-                { text: 'components/', link: 'components' },
-                { text: 'composables/', link: 'composables' },
-                {
-                  text: 'entrypoints/',
-                  base: '/guide/directory-structure/entrypoints/',
-                  collapsed: true,
-                  items: [
-                    { text: 'background', link: 'background.md' },
-                    { text: 'bookmarks', link: 'bookmarks.md' },
-                    { text: '*.content.ts', link: 'content-scripts.md' },
-                    { text: '*.css', link: 'css.md' },
-                    { text: 'devtools', link: 'devtools.md' },
-                    { text: 'history', link: 'history.md' },
-                    { text: 'newtab', link: 'newtab.md' },
-                    { text: 'options', link: 'options.md' },
-                    { text: 'popup', link: 'popup.md' },
-                    { text: 'sandbox', link: 'sandbox.md' },
-                    { text: 'sidepanel', link: 'sidepanel.md' },
-                    { text: '*.html', link: 'unlisted-pages.md' },
-                    {
-                      text: '*.ts',
-                      link: 'unlisted-scripts.md',
-                    },
-                  ],
-                },
-                { text: 'hooks/', link: 'hooks' },
-                { text: 'modules/', link: 'modules' },
-                {
-                  text: 'public/',
-                  link: 'public',
-                  items: [{ text: '_locales/', link: 'public/locales' }],
-                },
-                { text: 'utils/', link: 'modules' },
-                // Files
-                { text: '.env', link: 'env' },
-                { text: 'package.json', link: 'package' },
-                { text: 'tsconfig.json', link: 'tsconfig' },
-                { text: 'web-ext.config.ts', link: 'web-ext-config' },
-                { text: 'wxt.config.ts', link: 'wxt-config' },
-              ],
-            },
-            {
-              text: 'Extension APIs',
-              collapsed: true,
-              base: '/guide/extension-apis/',
-              items: [
-                { text: 'Storage', link: 'storage' },
-                { text: 'Messaging', link: 'messaging' },
-                { text: 'Scripting', link: 'scripting' },
-                { text: 'Others', link: 'others' },
-              ],
-            },
-            {
-              text: 'Go Further',
-              collapsed: true,
-              base: '/guide/go-further/',
-              items: [
-                { text: 'Testing', link: 'testing' },
-                { text: 'ES Modules', link: 'es-modules' },
-                { text: 'Debugging', link: 'debugging' },
-                { text: 'Handling Updates', link: 'handling-updates' },
-                { text: 'Vite', link: 'vite' },
-                { text: 'Custom Events', link: 'custom-events' },
-                { text: 'Remote Code', link: 'remote-code' },
-                {
-                  text: 'Entrypoint Side Effects',
-                  link: 'entrypoint-side-effects',
-                },
-                { text: 'How WXT Works', link: 'how-wxt-works' },
-              ],
-            },
-          ],
-        },
-      ],
-      '/api/': [
-        {
-          items: [
-            {
-              text: 'CLI',
-              collapsed: true,
-              base: '/api/cli/',
-              items: [
-                { text: 'wxt', link: 'wxt.md' },
-                { text: 'wxt build', link: 'wxt-build.md' },
-                { text: 'wxt zip', link: 'wxt-zip.md' },
-                { text: 'wxt prepare', link: 'wxt-prepare.md' },
-                { text: 'wxt clean', link: 'wxt-clean.md' },
-                { text: 'wxt init', link: 'wxt-init.md' },
-                { text: 'wxt submit', link: 'wxt-submit.md' },
-                { text: 'wxt submit init', link: 'wxt-submit-init.md' },
-              ],
-            },
-            {
-              text: 'API Reference',
-              collapsed: true,
-              items: filteredTypedocSidebar,
-            },
-          ],
-        },
-      ],
     },
 
     socialLinks: [
       { icon: 'discord', link: 'https://discord.gg/ZFsZqGery9' },
       { icon: 'github', link: 'https://github.com/wxt-dev/wxt' },
     ],
+
+    nav: [
+      navItem('Get Started', '/get-started/introduction'),
+      navItem('Guide', '/guide/key-concepts/manifest'),
+      navItem('API', '/api/reference/wxt'),
+      navItem('Examples', '/examples'),
+    ],
+
+    sidebar: {
+      '/get-started/': menuRoot([
+        menuGroup('Get Started', '/get-started/', [
+          menuItem('Introduction', 'introduction'),
+          menuItem('Installation', 'installation'),
+          menuItem('Configuration', 'configuration'),
+          menuItem('Entrypoints', 'entrypoints'),
+          menuItem('Assets', 'assets'),
+          menuItem('Testing', 'testing'),
+          menuItem('Publishing', 'publishing'),
+          menuItem('Migrate to WXT', 'migrate-to-wxt'),
+          menuItem('Compare', 'compare'),
+        ]),
+      ]),
+      '/guide/': menuRoot([
+        menuGroup('Key Concepts', '/guide/key-concepts/', [
+          menuItem('Manifest', 'manifest'),
+          menuItem('Auto-imports', 'auto-imports'),
+          menuItem('Web Extension Polyfill', 'web-extension-polyfill'),
+          menuItem('Frontend Frameworks', 'frontend-frameworks'),
+          menuItem('Content Script UI', 'content-script-ui'),
+        ]),
+        menuGroup('Directory Structure', '/guide/directory-structure/', [
+          // Folders
+          menuItem('.output/', 'output'),
+          menuItem('.wxt/', 'wxt'),
+          menuItem('assets/', 'assets'),
+          menuItem('components/', 'components'),
+          menuItem('composables/', 'composables'),
+          menuGroup('entrypoints/', '/guide/directory-structure/entrypoints/', [
+            menuItem('background', 'background.md'),
+            menuItem('bookmarks', 'bookmarks.md'),
+            menuItem('*.content.ts', 'content-scripts.md'),
+            menuItem('*.css', 'css.md'),
+            menuItem('devtools', 'devtools.md'),
+            menuItem('history', 'history.md'),
+            menuItem('newtab', 'newtab.md'),
+            menuItem('options', 'options.md'),
+            menuItem('popup', 'popup.md'),
+            menuItem('sandbox', 'sandbox.md'),
+            menuItem('sidepanel', 'sidepanel.md'),
+            menuItem('*.html', 'unlisted-pages.md'),
+            menuItem('*.ts', 'unlisted-scripts.md'),
+          ]),
+          menuItem('hooks/', 'hooks'),
+          menuItem('modules/', 'modules'),
+          menuGroup('public/', 'public', [
+            menuItem('_locales/', 'public/locales'),
+          ]),
+          menuItem('utils/', 'modules'),
+
+          // Files
+          menuItem('.env', 'env'),
+          menuItem('package.json', 'package'),
+          menuItem('tsconfig.json', 'tsconfig'),
+          menuItem('web-ext.config.ts', 'web-ext-config'),
+          menuItem('wxt.config.ts', 'wxt-config'),
+        ]),
+        menuGroup('Extension APIs', '/guide/extension-apis/', [
+          menuItem('Storage', 'storage'),
+          menuItem('Messaging', 'messaging'),
+          menuItem('Scripting', 'scripting'),
+          menuItem('Others', 'others'),
+        ]),
+        menuGroup('Go Further', '/guide/go-further/', [
+          menuItem('Testing', 'testing'),
+          menuItem('ES Modules', 'es-modules'),
+          menuItem('Debugging', 'debugging'),
+          menuItem('Handling Updates', 'handling-updates'),
+          menuItem('Vite', 'vite'),
+          menuItem('Custom Events', 'custom-events'),
+          menuItem('Remote Code', 'remote-code'),
+          menuItem('Entrypoint Side Effects', 'entrypoint-side-effects'),
+          menuItem('How WXT Works', 'how-wxt-works'),
+        ]),
+      ]),
+      '/api/': menuRoot([
+        menuGroup('CLI', '/api/cli/', [
+          menuItem('wxt', 'wxt.md'),
+          menuItem('wxt build', 'wxt-build.md'),
+          menuItem('wxt zip', 'wxt-zip.md'),
+          menuItem('wxt prepare', 'wxt-prepare.md'),
+          menuItem('wxt clean', 'wxt-clean.md'),
+          menuItem('wxt init', 'wxt-init.md'),
+          menuItem('wxt submit', 'wxt-submit.md'),
+          menuItem('wxt submit init', 'wxt-submit-init.md'),
+        ]),
+        menuGroup('API Reference', prepareTypedocSidebar(typedocSidebar)),
+      ]),
+    },
   },
 });

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -36,7 +36,7 @@ export default defineConfig({
     meta('og:image', ogImage),
     meta('og:url', ogUrl),
     meta('og:description', description),
-    meta('twitter:card', 'summary_large_image', true),
+    meta('twitter:card', 'summary_large_image', { useName: true }),
     script('https://umami.aklinker1.io/script.js', {
       'data-website-id': 'c1840c18-a12c-4a45-a848-55ae85ef7915',
       async: '',

--- a/docs/.vitepress/theme/custom.css
+++ b/docs/.vitepress/theme/custom.css
@@ -72,6 +72,45 @@
 .vp-doc .no-vertical-dividers td {
   border: none;
 }
+
 .vp-doc .no-vertical-dividers tr {
   border: 1px solid var(--vp-c-divider);
+}
+
+body {
+  overflow-y: scroll;
+}
+
+.VPSidebar {
+  user-select: none;
+}
+
+.VPSidebarItem.level-0.collapsible {
+  padding-bottom: 0.5rem;
+}
+
+.VPSidebarItem.level-0.collapsible .items {
+  /*border-left: 1px solid var(--vp-c-divider);*/
+}
+
+.VPSidebarItem.level-1 {
+  padding-left: 0.75rem;
+}
+
+.VPSidebar .group + .group {
+  border-top: none;
+  padding-top: 0;
+}
+
+.VPSidebarItem .badge {
+  display: inline-block;
+  min-width: 1.6em;
+  padding: 0.3em 0.4em 0.2em;
+  border-radius: 1rem;
+  font-size: 0.75em;
+  line-height: 1;
+  margin-left: 0.5rem;
+  text-align: center;
+  vertical-align: middle;
+  background-color: var(--vp-c-default-2);
 }

--- a/docs/.vitepress/utils/head.ts
+++ b/docs/.vitepress/utils/head.ts
@@ -1,0 +1,28 @@
+import { HeadConfig } from 'vitepress/types/shared';
+
+export function meta(
+  property: string,
+  content: string,
+  useName = false,
+): HeadConfig {
+  return [
+    'meta',
+    {
+      [useName ? 'name' : 'property']: property,
+      content,
+    },
+  ];
+}
+
+export function script(
+  src: string,
+  props: Record<string, string> = {},
+): HeadConfig {
+  return [
+    'script',
+    {
+      ...props,
+      src,
+    },
+  ];
+}

--- a/docs/.vitepress/utils/head.ts
+++ b/docs/.vitepress/utils/head.ts
@@ -3,12 +3,12 @@ import { HeadConfig } from 'vitepress/types/shared';
 export function meta(
   property: string,
   content: string,
-  useName = false,
+  options?: { useName: boolean },
 ): HeadConfig {
   return [
     'meta',
     {
-      [useName ? 'name' : 'property']: property,
+      [options?.useName ? 'name' : 'property']: property,
       content,
     },
   ];

--- a/docs/.vitepress/utils/menus.ts
+++ b/docs/.vitepress/utils/menus.ts
@@ -1,0 +1,81 @@
+import { DefaultTheme } from 'vitepress';
+
+type SidebarItem = DefaultTheme.SidebarItem;
+type NavItem = DefaultTheme.NavItem;
+
+export function navItem(text: string, link: string): NavItem {
+  return { text, link };
+}
+
+export function menuRoot(items: SidebarItem[]) {
+  return items.map((item, index) => {
+    // item.collapsed = false; // uncomment to expand all level-0 items
+    return item;
+  });
+}
+
+export function menuGroup(text: string, items: SidebarItem[]): SidebarItem;
+export function menuGroup(
+  text: string,
+  base: string,
+  items: SidebarItem[],
+): SidebarItem;
+export function menuGroup(
+  text: string,
+  a: string | SidebarItem[],
+  b?: SidebarItem[],
+): SidebarItem {
+  const collapsed = true;
+  if (typeof a === 'string') {
+    return {
+      text,
+      base: a,
+      items: b,
+      collapsed,
+    };
+  }
+  return {
+    text,
+    items: a,
+    collapsed,
+  };
+}
+
+export function menuItems(items: SidebarItem[]) {
+  return {
+    items,
+  };
+}
+
+export function menuItem(text: string, link: string): SidebarItem {
+  return { text, link };
+}
+
+/**
+ * Clean up and add badges to typedoc leaf sections
+ */
+export function prepareTypedocSidebar(items: SidebarItem[]) {
+  // skip contents file
+  const filtered = items.slice(1);
+
+  // remove Typedoc's collapse: true from text nodes
+  const prepareItems = (items: DefaultTheme.SidebarItem[], depth = 0) => {
+    for (const item of items) {
+      if (item.items) {
+        prepareItems(item.items, depth + 1);
+        const hasLeaves = item.items.some((item) => !item.items);
+        if (hasLeaves) {
+          item.text += ` <span class="badge">${item.items.length}</span>`;
+        }
+      } else {
+        delete item.collapsed;
+      }
+    }
+  };
+
+  // process
+  prepareItems(filtered);
+
+  // return
+  return filtered;
+}

--- a/docs/.vitepress/utils/menus.ts
+++ b/docs/.vitepress/utils/menus.ts
@@ -47,7 +47,14 @@ export function menuItems(items: SidebarItem[]) {
   };
 }
 
-export function menuItem(text: string, link: string): SidebarItem {
+export function menuItem(
+  text: string,
+  link: string,
+  items?: SidebarItem[],
+): SidebarItem {
+  if (items) {
+    return { text, link, items };
+  }
   return { text, link };
 }
 


### PR DESCRIPTION
This is just a little stitch-in-time PR with some menu config cleanup:

- utility functions replace raw sidebar menu config
- utility functions replace raw head config

This makes it simpler to [grok and update the sidebar menu](https://github.com/davestewart/wxt/blob/feat/docs-cleanup/docs/.vitepress/config.ts#L73) structure:

```ts
sidebar: {
  '/guide/': menuRoot([
    menuGroup('Directory Structure', '/guide/directory-structure/', [
      menuItem('.output/', 'output'),
      menuItem('composables/', 'composables'),
      menuGroup('entrypoints/', '/guide/directory-structure/entrypoints/', [
        menuItem('background', 'background.md'),
        menuItem('bookmarks', 'bookmarks.md'),
        ...
      ]),
      ...
  ]),
}
```

Additionally, some minor style updates:

- main sidebar sections now use correct level 0 (this can be [styled](https://github.com/wxt-dev/wxt/pull/709/files#diff-096f06e4edeeaa293d906d7146e243667e1377d2133e35b9e240525bd79be5b5R88-R94)):<br>![CleanShot 2024-06-10 at 13 32 37](https://github.com/wxt-dev/wxt/assets/132681/cf9329b2-c31f-4411-a43e-397c2c3092a7)
- typedoc sidebar config now [shows badges](https://github.com/wxt-dev/wxt/pull/709/files#diff-702f6a4b41fe8e3d3094e575522859877a8cfb040263991f958de4768a6b3f8fR66-R69) for leaf-level collections:<br>![CleanShot 2024-06-10 at 13 31 17](https://github.com/wxt-dev/wxt/assets/132681/f41a0acd-528a-481d-ab6b-e8f65bd1f929)

I note the original config used an interim `{ items: [ ... ] }` node to restyle the menu, but we can just do that in `theme/custom.css` if you want to tweak it further.