### PR TITLE
fix: Add `target: esnext` by default

### DIFF
--- a/packages/module-solid/README.md
+++ b/packages/module-solid/README.md
@@ -4,7 +4,7 @@ Enables the use of [SolidJS](https://www.solidjs.com/) in your web extension, in
 
 This plugin makes a few changes:
 
-1. Adds `vite-plugin-solid` to vite
+1. Adds `vite-plugin-solid` to and sets `build.target: esnext` in the vite config
 2. Adds the [`solid-js` preset](https://github.com/unjs/unimport/blob/main/src/presets/solid.ts) to auto-imports
 
 ## Usage

--- a/packages/module-solid/src/index.ts
+++ b/packages/module-solid/src/index.ts
@@ -10,6 +10,9 @@ export default defineWxtModule<SolidModuleOptions>({
 
     addViteConfig(wxt, () => ({
       plugins: [solid(vite)],
+      build: {
+        target: 'esnext',
+      },
     }));
 
     addImportPreset(wxt, 'solid-js');


### PR DESCRIPTION
Forgot to add this from the template.