### PR TITLE
chore(dev-deps): Upgrade @aklinker1/buildc to 1.0.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "docs:preview": "pnpm -s docs:gen && vitepress preview docs"
   },
   "devDependencies": {
-    "@aklinker1/buildc": "^1.0.5",
+    "@aklinker1/buildc": "^1.0.6",
     "@aklinker1/check": "^1.3.1",
     "@types/fs-extra": "^11.0.4",
     "@vitest/coverage-v8": "^1.6.0",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "docs:preview": "pnpm -s docs:gen && vitepress preview docs"
   },
   "devDependencies": {
-    "@aklinker1/buildc": "^1.0.6",
+    "@aklinker1/buildc": "^1.0.7",
     "@aklinker1/check": "^1.3.1",
     "@types/fs-extra": "^11.0.4",
     "@vitest/coverage-v8": "^1.6.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     devDependencies:
       '@aklinker1/buildc':
-        specifier: ^1.0.5
-        version: 1.0.5(typescript@5.4.5)
+        specifier: ^1.0.6
+        version: 1.0.6(typescript@5.4.5)
       '@aklinker1/check':
         specifier: ^1.3.1
         version: 1.3.1(typescript@5.4.5)
@@ -377,8 +377,8 @@ importers:
 
 packages:
 
-  /@aklinker1/buildc@1.0.5(typescript@5.4.5):
-    resolution: {integrity: sha512-xM9tA6VpkHh2qTCVBwuXUGdBpgxtnj35zrDT0hMBWBLAoAvNXjQrGf4DaFN+gnBsd32TtFPDg1IfcW2ZcUF0ZQ==}
+  /@aklinker1/buildc@1.0.6(typescript@5.4.5):
+    resolution: {integrity: sha512-yVNU92gJEc3VG1/z+ftjppobcKgBElv6pjCDiA69r0Ls3cmt84gzg2UlxG1SDT8VquCFvylFTAUwl0PINlYQcA==}
     hasBin: true
     peerDependencies:
       typescript: ^5.0.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     devDependencies:
       '@aklinker1/buildc':
-        specifier: ^1.0.6
-        version: 1.0.6(typescript@5.4.5)
+        specifier: ^1.0.7
+        version: 1.0.7(typescript@5.4.5)
       '@aklinker1/check':
         specifier: ^1.3.1
         version: 1.3.1(typescript@5.4.5)
@@ -377,8 +377,8 @@ importers:
 
 packages:
 
-  /@aklinker1/buildc@1.0.6(typescript@5.4.5):
-    resolution: {integrity: sha512-yVNU92gJEc3VG1/z+ftjppobcKgBElv6pjCDiA69r0Ls3cmt84gzg2UlxG1SDT8VquCFvylFTAUwl0PINlYQcA==}
+  /@aklinker1/buildc@1.0.7(typescript@5.4.5):
+    resolution: {integrity: sha512-8njwYe/uxeeyqfj1ryOOwWolNaoJpVjFMoR8muNezo4D6IL6NBNN2XNhqaCShlDBjHM5NG7mdsd/5rueqsKReg==}
     hasBin: true
     peerDependencies:
       typescript: ^5.0.0


### PR DESCRIPTION
1.0.5 switched to using `spawn` instead of `exec`, which doesn't throw an error automatically when it fails. 1.0.7 throws the error so the build fails.