### PR TITLE
fix: Ignore .wxt file changes in dev

### DIFF
--- a/packages/wxt/src/core/create-server.ts
+++ b/packages/wxt/src/core/create-server.ts
@@ -153,6 +153,7 @@ function createFileReloader(server: WxtDevServer) {
 
     // Here, "path" is a non-normalized path (ie: C:\\users\\... instead of C:/users/...)
     if (path.startsWith(wxt.config.outBaseDir)) return;
+    if (path.startsWith(wxt.config.wxtDir)) return;
     changeQueue.push([event, path]);
 
     await fileChangedMutex.runExclusive(async () => {


### PR DESCRIPTION
I noticed when you first saved a change to the project, WXT would report `.wxt/tsconfig.json` as a changed file along with the actual file you changed. That's unnecessary, the directory doesn't effect any runtime code. So this PR ignores these files in the watcher.

| Before | After |
| --- | --- |
| <img width="611" alt="Screenshot 2024-06-19 at 8 31 54 AM" src="https://github.com/wxt-dev/wxt/assets/10101283/561d03fa-826f-45e5-bb74-74adcd7b6967"> | <img width="507" alt="Screenshot 2024-06-19 at 8 32 10 AM" src="https://github.com/wxt-dev/wxt/assets/10101283/19f5fa54-fd4a-4cf3-ba3a-7df9c6f3a829"> |

As you can see, this was causing an unnecessary extension reload, when really, the HTML pages just needed reloaded.