### PR TITLE
fix(modules): `addViteConfig` ignored user vite config

### DIFF
--- a/packages/wxt/src/__tests__/modules.test.ts
+++ b/packages/wxt/src/__tests__/modules.test.ts
@@ -13,7 +13,7 @@ describe('Module Utilities', () => {
       const userConfig = {};
       const moduleConfig = { build: { sourcemap: true } };
 
-      wxt.config.vite = () => userConfig;
+      wxt.config.vite = () => Promise.resolve(userConfig);
       addViteConfig(wxt, () => moduleConfig);
       await wxt.hooks.callHook('ready', wxt);
       const actual: any = wxt.config.vite(wxt.config.env);

--- a/packages/wxt/src/__tests__/modules.test.ts
+++ b/packages/wxt/src/__tests__/modules.test.ts
@@ -16,7 +16,7 @@ describe('Module Utilities', () => {
       wxt.config.vite = () => Promise.resolve(userConfig);
       addViteConfig(wxt, () => moduleConfig);
       await wxt.hooks.callHook('ready', wxt);
-      const actual: any = wxt.config.vite(wxt.config.env);
+      const actual = await wxt.config.vite(wxt.config.env);
 
       expect(actual).toEqual(expected);
     });
@@ -32,7 +32,7 @@ describe('Module Utilities', () => {
       wxt.config.vite = () => userConfig;
       addViteConfig(wxt, () => moduleConfig);
       await wxt.hooks.callHook('ready', wxt);
-      const actual: any = wxt.config.vite(wxt.config.env);
+      const actual = await wxt.config.vite(wxt.config.env);
 
       expect(actual).toEqual(expected);
     });

--- a/packages/wxt/src/modules.ts
+++ b/packages/wxt/src/modules.ts
@@ -104,13 +104,11 @@ export function addViteConfig(
 ): void {
   wxt.hooks.hook('ready', (wxt) => {
     const userVite = wxt.config.vite;
-    wxt.config.vite = (env) =>
-      vite.mergeConfig(
-        // Use config added by module as base
-        viteConfig(env) ?? {},
-        // Overwrite module config with user config
-        userVite(env),
-      );
+    wxt.config.vite = async (env) => {
+      const fromUser = await userVite(env);
+      const fromModule = viteConfig(env) ?? {};
+      return vite.mergeConfig(fromModule, fromUser);
+    };
   });
 }
 


### PR DESCRIPTION
If you used `addViteConfig` in a module, it cause WXT to ignore any `vite` config from your `wxt.config.ts` file. Because I forgot to await a promise 🤦 