### PR TITLE
fix: Respect custom `outDir` when cleaning and zipping

### DIFF
--- a/packages/wxt/src/cli/__tests__/index.test.ts
+++ b/packages/wxt/src/cli/__tests__/index.test.ts
@@ -345,14 +345,32 @@ describe('CLI', () => {
       mockArgv('clean');
       await importCli();
 
-      expect(cleanMock).toBeCalledWith(undefined);
+      expect(cleanMock).toBeCalledWith({});
     });
 
     it('should respect passing a custom root', async () => {
       mockArgv('clean', 'path/to/root');
       await importCli();
 
-      expect(cleanMock).toBeCalledWith('path/to/root');
+      expect(cleanMock).toBeCalledWith({ root: 'path/to/root' });
+    });
+
+    it('should respect a custom config file', async () => {
+      mockArgv('clean', '-c', './path/to/config.ts');
+      await importCli();
+
+      expect(cleanMock).toBeCalledWith({
+        configFile: './path/to/config.ts',
+      });
+    });
+
+    it('should respect passing --debug', async () => {
+      mockArgv('clean', '--debug');
+      await importCli();
+
+      expect(cleanMock).toBeCalledWith({
+        debug: true,
+      });
     });
   });
 

--- a/packages/wxt/src/cli/commands.ts
+++ b/packages/wxt/src/cli/commands.ts
@@ -126,9 +126,10 @@ cli
 cli
   .command('clean [root]', 'clean generated files and caches')
   .alias('cleanup')
+  .option('-c, --config <file>', 'use specified config file')
   .action(
     wrapAction(async (root, flags) => {
-      await clean(root);
+      await clean({ root, configFile: flags.config, debug: flags.debug });
     }),
   );
 

--- a/packages/wxt/src/core/clean.ts
+++ b/packages/wxt/src/core/clean.ts
@@ -13,7 +13,24 @@ import { registerWxt, wxt } from './wxt';
  * @example
  * await clean();
  */
-export async function clean(config?: InlineConfig) {
+export async function clean(config?: InlineConfig): Promise<void>;
+/**
+ * Remove generated/temp files from the directory.
+ *
+ * @deprecated
+ *
+ * @param root The directory to look for generated/temp files in. Defaults to `process.cwd()`. Can be relative to `process.cwd()` or absolute.
+ *
+ * @example
+ * await clean();
+ */
+export async function clean(root?: string): Promise<void>;
+
+export async function clean(config?: string | InlineConfig) {
+  if (typeof config === 'string') {
+    config = { root: config };
+  }
+
   await registerWxt('build', config);
   wxt.logger.info('Cleaning Project');
 

--- a/packages/wxt/src/core/clean.ts
+++ b/packages/wxt/src/core/clean.ts
@@ -1,44 +1,48 @@
 import path from 'node:path';
 import glob from 'fast-glob';
 import fs from 'fs-extra';
-import { consola } from 'consola';
 import pc from 'picocolors';
+import { InlineConfig } from '~/types';
+import { registerWxt, wxt } from './wxt';
 
 /**
  * Remove generated/temp files from the directory.
  *
- * @param root The directory to look for generated/temp files in. Defaults to `process.cwd()`. Can be relative to `process.cwd()` or absolute.
+ * @param config Optional config that will override your `<root>/wxt.config.ts`.
  *
  * @example
  * await clean();
  */
-export async function clean(root = process.cwd()) {
-  consola.info('Cleaning Project');
+export async function clean(config?: InlineConfig) {
+  await registerWxt('build', config);
+  wxt.logger.info('Cleaning Project');
+
+  const root = wxt.config.root;
 
   const tempDirs = [
     'node_modules/.vite',
     'node_modules/.cache',
     '**/.wxt',
-    '.output/*',
+    `${path.relative(root, wxt.config.outBaseDir)}/*`,
   ];
-  consola.debug('Looking for:', tempDirs.map(pc.cyan).join(', '));
+  wxt.logger.debug('Looking for:', tempDirs.map(pc.cyan).join(', '));
   const directories = await glob(tempDirs, {
-    cwd: path.resolve(root),
+    cwd: root,
     absolute: true,
     onlyDirectories: true,
     deep: 2,
   });
   if (directories.length === 0) {
-    consola.debug('No generated files found.');
+    wxt.logger.debug('No generated files found.');
     return;
   }
 
-  consola.debug(
+  wxt.logger.debug(
     'Found:',
     directories.map((dir) => pc.cyan(path.relative(root, dir))).join(', '),
   );
   for (const directory of directories) {
     await fs.rm(directory, { force: true, recursive: true });
-    consola.debug('Deleted ' + pc.cyan(path.relative(root, directory)));
+    wxt.logger.debug('Deleted ' + pc.cyan(path.relative(root, directory)));
   }
 }

--- a/packages/wxt/src/core/utils/building/resolve-config.ts
+++ b/packages/wxt/src/core/utils/building/resolve-config.ts
@@ -160,7 +160,7 @@ export async function resolveConfig(
     srcDir,
     typesDir,
     wxtDir,
-    zip: resolveZipConfig(root, mergedConfig),
+    zip: resolveZipConfig(root, outBaseDir, mergedConfig),
     transformManifest: mergedConfig.transformManifest,
     analysis: resolveAnalysisConfig(root, mergedConfig),
     userConfigMetadata: userConfigMetadata ?? {},
@@ -233,6 +233,7 @@ async function mergeInlineConfig(
 
 function resolveZipConfig(
   root: string,
+  outBaseDir: string,
   mergedConfig: InlineConfig,
 ): NullablyRequired<ResolvedConfig['zip']> {
   const downloadedPackagesDir = path.resolve(root, '.wxt/local_modules');
@@ -254,7 +255,7 @@ function resolveZipConfig(
       '**/__tests__/**',
       '**/*.+(test|spec).?(c|m)+(j|t)s?(x)',
       // Output directory
-      `${mergedConfig.outDir ?? '.output'}/**`,
+      `${path.relative(root, outBaseDir)}/**`,
       // From user
       ...(mergedConfig.zip?.excludeSources ?? []),
     ],

--- a/packages/wxt/src/core/utils/building/resolve-config.ts
+++ b/packages/wxt/src/core/utils/building/resolve-config.ts
@@ -253,6 +253,8 @@ function resolveZipConfig(
       // Tests
       '**/__tests__/**',
       '**/*.+(test|spec).?(c|m)+(j|t)s?(x)',
+      // Output directory
+      `${mergedConfig.outDir ?? '.output'}/**`,
       // From user
       ...(mergedConfig.zip?.excludeSources ?? []),
     ],


### PR DESCRIPTION
1. `wxt clean` now removes output directory contents based on the config instead of `.output`, and also improvement on the command (config, logger, etc.); also a question here why we only remove its sub dirs but keep generated zips?
2. `wxt zip` now exclude output directory for firefox sources by default since user may specify a `outDir` that does not start with a dot and it's annoying to specify it again in `excludeSources` manually