### PR TITLE
fix(dev): Catch error when attempting to reload a tab in a saved tab group

### DIFF
--- a/packages/wxt/src/virtual/utils/reload-content-scripts.ts
+++ b/packages/wxt/src/virtual/utils/reload-content-scripts.ts
@@ -81,7 +81,15 @@ async function reloadTabsForContentScript(contentScript: ContentScript) {
     if (!url) return false;
     return !!matchPatterns.find((pattern) => pattern.includes(url));
   });
-  await Promise.all(matchingTabs.map((tab) => browser.tabs.reload(tab.id)));
+  await Promise.all(
+    matchingTabs.map(async (tab) => {
+      try {
+        await browser.tabs.reload(tab.id);
+      } catch (err) {
+        logger.warn('Failed to reload tab:', err);
+      }
+    }),
+  );
 }
 
 export async function reloadContentScriptMv2(


### PR DESCRIPTION
This closes #781

Instead of throwing an uncaught error and being reported to the `chrome://extension` page...

<details>

![image](https://github.com/wxt-dev/wxt/assets/10101283/59e65782-0c3d-4ea6-ac97-f059101a134b)

</details>


Just log a warning:

<img width="638" alt="Screenshot 2024-07-01 at 4 03 59 PM" src="https://github.com/wxt-dev/wxt/assets/10101283/374e0b74-0026-4e16-8549-c3da44289e1c">
