### PR TITLE
docs: typo manifest word

### DIFF
--- a/docs/guide/key-concepts/manifest.md
+++ b/docs/guide/key-concepts/manifest.md
@@ -25,7 +25,7 @@ Here's an example `wxt.config.ts` file:
 import { defineConfig } from 'wxt';
 
 export default defineConfig({
-  mainfest: {
+  manifest: {
     action: {
       default_title: 'Some Title',
     },


### PR DESCRIPTION
docs example: mainfest -> manifest