### PR TITLE
doc: detail issues with vite plugins

### DIFF
--- a/docs/guide/go-further/vite.md
+++ b/docs/guide/go-further/vite.md
@@ -32,10 +32,6 @@ export default defineConfig({
 });
 ```
 
-:::info
-There are caveats with vite plugins due to the way WXT implement vite builds:
-- plugins may not work out of the box
-- plugins may be executed multiple times
-
-If you encounter issues, please open a GitHub issue for the vite plugin.
+:::warning UNEXPECTED BEHAVIOR
+Due to the way WXT implements vite builds, the plugin may not work as expected. You may open a [GitHub issue](https://github.com/wxt-dev/wxt/issues) to report this problem.
 :::

--- a/docs/guide/go-further/vite.md
+++ b/docs/guide/go-further/vite.md
@@ -18,9 +18,7 @@ export default defineConfig({
 
 ## Using Plugins
 
-Plugins can be passed into the `vite` configuration in you `wxt.config.ts` file, just like any other option.
-
-All plugins should work in WXT, but it is worth pointing out that since WXT orchestrates multiple vite builds to bundle an extension, plugins will be executed multiple times if necessary.
+Plugins can be passed into the `vite` configuration in your `wxt.config.ts` file, just like any other option.
 
 ```ts
 import { defineConfig } from 'wxt';
@@ -33,3 +31,11 @@ export default defineConfig({
   }),
 });
 ```
+
+:::info
+There are caveats with vite plugins due to the way WXT implement vite builds:
+- plugins may not work out of the box
+- plugins may be executed multiple times
+
+If you encounter issues, please open a GitHub issue for the vite plugin.
+:::

--- a/docs/guide/go-further/vite.md
+++ b/docs/guide/go-further/vite.md
@@ -33,7 +33,7 @@ export default defineConfig({
 ```
 
 :::warning UNEXPECTED BEHAVIOR
-Due to the way WXT implements Vite's bundling, the plugin may not work as expected. Search [GitHub issues](https://github.com/wxt-dev/wxt/issues) for the implementation of your specific plugin.
+Due to the way WXT orchestrates Vite builds, some plugins may not work as expected. Search [GitHub issues](https://github.com/wxt-dev/wxt/issues?q=is%3Aissue+label%3A%22vite+plugin%22) if you run into issues with a specific plugin.
 
-If one doesn't exist, you may open a [new issue](https://github.com/wxt-dev/wxt/issues/new/choose).
+If one doesn't exist, please open a [new issue](https://github.com/wxt-dev/wxt/issues/new/choose)!
 :::

--- a/docs/guide/go-further/vite.md
+++ b/docs/guide/go-further/vite.md
@@ -33,5 +33,7 @@ export default defineConfig({
 ```
 
 :::warning UNEXPECTED BEHAVIOR
-Due to the way WXT implements vite builds, the plugin may not work as expected. You may open a [GitHub issue](https://github.com/wxt-dev/wxt/issues) to report this problem.
+Due to the way WXT implements Vite's bundling, the plugin may not work as expected. Search [GitHub issues](https://github.com/wxt-dev/wxt/issues) for the implementation of your specific plugin.
+
+If one doesn't exist, you may open a [new issue](https://github.com/wxt-dev/wxt/issues/new/choose).
 :::


### PR DESCRIPTION
closes #798 

I removed the specifics, but I'm unsure if you want to go into more detail on why plugins wouldn't work as expected.

We should make searching easier by adding a `vite-plugin` tag or standardizing issue titles like "[VITE-PLUGIN] {name of plugin}"