### PR TITLE
fix: Add missing name to ESLint v9 autoImports config

### DIFF
--- a/packages/wxt/e2e/tests/__snapshots__/auto-imports.test.ts.snap
+++ b/packages/wxt/e2e/tests/__snapshots__/auto-imports.test.ts.snap
@@ -49,6 +49,7 @@ const globals = {
 }
 
 export default {
+  name: "wxt/auto-imports",
   languageOptions: {
     globals,
     sourceType: "module",

--- a/packages/wxt/src/builtin-modules/unimport.ts
+++ b/packages/wxt/src/builtin-modules/unimport.ts
@@ -139,6 +139,7 @@ export function getEslint9ConfigEntry(
     text: `const globals = ${JSON.stringify(globals, null, 2)}
 
 export default {
+  name: "wxt/auto-imports",
   languageOptions: {
     globals,
     sourceType: "module",


### PR DESCRIPTION
This PR adds a name field in ESLint v9 autoImports config.

The name is used in error messages and the config inspector to help identify which configuration object is being used.

Refs:
- [Configuration Naming Conventions](https://eslint.org/docs/latest/use/configure/configuration-files#configuration-naming-conventions)