### PR TITLE
feat(config): `dev.server.hostname`

### DIFF
--- a/packages/wxt/src/core/utils/building/resolve-config.ts
+++ b/packages/wxt/src/core/utils/building/resolve-config.ts
@@ -126,7 +126,7 @@ export async function resolveConfig(
     }
     devServerConfig = {
       port,
-      hostname: 'localhost',
+      hostname: mergedConfig.dev?.server?.hostname ?? 'localhost',
     };
   }
 

--- a/packages/wxt/src/types/index.ts
+++ b/packages/wxt/src/types/index.ts
@@ -338,6 +338,12 @@ export interface InlineConfig {
        * Port to run the dev server on. Defaults to the first open port from 3000 to 3010.
        */
       port?: number;
+      /**
+       * Hostname to run the dev server on.
+       *
+       * @default "localhost"
+       */
+      hostname?: string;
     };
     /**
      * Controls whether a custom keyboard shortcut command, `Alt+R`, is added during dev mode to


### PR DESCRIPTION
This closes #759. Already had internal config for this, just adding user config.