### PR TITLE
fix(modules): Add types from all wxt node_modules, not just ones with config

### DIFF
--- a/packages/wxt/src/core/utils/building/generate-wxt-dir.ts
+++ b/packages/wxt/src/core/utils/building/generate-wxt-dir.ts
@@ -30,8 +30,7 @@ export async function generateTypesDir(
   // in <root>/modules are already apart of the project, so we don't need to
   // add them.
   wxt.config.userModules.forEach((module) => {
-    if (module.type === 'node_module' && module.configKey != null)
-      entries.push({ module: module.id });
+    if (module.type === 'node_module') entries.push({ module: module.id });
   });
 
   // browser.runtime.getURL


### PR DESCRIPTION
This lets the project setup module augmentation for types other than user config, like app config: https://github.com/wxt-dev/wxt/blob/c0e9fbbb0e18d274a2912488907ea0a3f19c48d3/packages/analytics/modules/analytics/index.ts#L8-L12