### PR TITLE
docs: fix links to Guide pages

### DIFF
--- a/packages/wxt/src/core/utils/manifest.ts
+++ b/packages/wxt/src/core/utils/manifest.ts
@@ -60,7 +60,7 @@ export async function generateManifest(
   if (versionName == null) {
     versionName = '0.0.0';
     wxt.logger.warn(
-      'Extension version not found, defaulting to "0.0.0". Add a version to your `package.json` or `wxt.config.ts` file. For more details, see: https://wxt.dev/guide/manifest.html#version-and-version-name',
+      'Extension version not found, defaulting to "0.0.0". Add a version to your `package.json` or `wxt.config.ts` file. For more details, see: https://wxt.dev/guide/key-concepts/manifest.html#version-and-version-name',
     );
   }
   const version = wxt.config.manifest.version ?? simplifyVersion(versionName);

--- a/packages/wxt/src/storage.ts
+++ b/packages/wxt/src/storage.ts
@@ -1,7 +1,7 @@
 /**
  * Simplified storage APIs with support for versioned fields, snapshots, metadata, and item definitions.
  *
- * See [the guide](https://wxt.dev/guide/storage.html) for more information.
+ * See [the guide](https://wxt.dev/guide/extension-apis/storage.html) for more information.
  *
  * @module wxt/storage
  */
@@ -350,7 +350,7 @@ function createDriver(storageArea: StorageArea): WxtStorageDriver {
         [
           "'wxt/storage' must be loaded in a web extension environment",
           '\n - If thrown during a build, see https://github.com/wxt-dev/wxt/issues/371',
-          " - If thrown during tests, mock 'wxt/browser' correctly. See https://wxt.dev/guide/testing.html\n",
+          " - If thrown during tests, mock 'wxt/browser' correctly. See https://wxt.dev/guide/go-further/testing.html\n",
         ].join('\n'),
       );
     }
@@ -539,7 +539,7 @@ export interface WxtStorage {
   /**
    * Define a storage item with a default value, type, or versioning.
    *
-   * Read full docs: https://wxt.dev/guide/storage.html#defining-storage-items
+   * Read full docs: https://wxt.dev/guide/extension-apis/storage.html#defining-storage-items
    */
   defineItem<TValue, TMetadata extends Record<string, unknown> = {}>(
     key: StorageItemKey,

--- a/packages/wxt/src/types/index.ts
+++ b/packages/wxt/src/types/index.ts
@@ -862,7 +862,7 @@ export interface ConfigEnv {
   browser: TargetBrowser;
   /**
    * Manifest version passed in from the CLI via the `--mv2` or `--mv3` flags. When not passed, it depends on the target browser. See
-   * [the guide](https://wxt.dev/guide/multiple-browsers.html#target-manifest-version) for more
+   * [the guide](https://wxt.dev/guide/key-concepts/multiple-browsers.html#target-manifest-version) for more
    * details.
    */
   manifestVersion: 2 | 3;


### PR DESCRIPTION
The link to guide page was broken and has been corrected.