### PR TITLE
docs: fix link to unimport

### DIFF
--- a/packages/module-svelte/README.md
+++ b/packages/module-svelte/README.md
@@ -5,7 +5,7 @@ Enables the use of [Svelte](https://svelte.dev/) in your web extension, in HTML 
 This plugin makes a few changes:
 
 1. Adds `@sveltejs/vite-plugin-svelte` to vite
-2. Adds the [`svelte` preset](https://github.com/unjs/unimport/blob/main/src/presets/vue.ts) to auto-imports
+2. Adds the [`svelte` preset](https://github.com/unjs/unimport/blob/main/src/presets/svelte.ts) to auto-imports
 
 ## Usage
 


### PR DESCRIPTION
The link to unimport was vue.ts, so corrected it to svelte.ts.