### PR TITLE
fix: Don't throw error if localization file is missing

### DIFF
--- a/packages/wxt/src/core/utils/building/generate-wxt-dir.ts
+++ b/packages/wxt/src/core/utils/building/generate-wxt-dir.ts
@@ -127,14 +127,14 @@ declare module "wxt/browser" {
 }
 `;
 
+  const defaultLocalePath = path.resolve(
+    wxt.config.publicDir,
+    '_locales',
+    defaultLocale ?? '',
+    'messages.json',
+  );
   let messages: Message[];
-  if (defaultLocale) {
-    const defaultLocalePath = path.resolve(
-      wxt.config.publicDir,
-      '_locales',
-      defaultLocale,
-      'messages.json',
-    );
+  if (await fs.exists(defaultLocalePath)) {
     const content = JSON.parse(await fs.readFile(defaultLocalePath, 'utf-8'));
     messages = parseI18nMessages(content);
   } else {


### PR DESCRIPTION
Before, if you listed a `default_locale` in your manifest, WXT would throw an error if you didn't provide a `public/_locales/{default_locale}/messages.json` file. This PR removes this requirement.

Instead of having WXT do this validation, we'll just let the browser report the problem when the extension is installed instead. This is because  it could be perfectly valid to not have a file there but because a module or some other custom build step adds translations to the output directory.