### PR TITLE
fix: wrong module hook type

### DIFF
--- a/packages/wxt/src/types/index.ts
+++ b/packages/wxt/src/types/index.ts
@@ -1353,7 +1353,7 @@ export interface WxtModule<TOptions extends WxtModuleOptions> {
    * Alternative to adding hooks in setup function with `wxt.hooks`. Hooks are
    * added before the `setup` function is called.
    */
-  hooks?: WxtHooks;
+  hooks?: Partial<WxtHooks>;
   /**
    * A custom function that can be used to setup hooks and call module-specific
    * APIs.


### PR DESCRIPTION
I noticed that if you define the hooks object the type requires you to set all hooks which isn't correct