### PR TITLE
feat!: Use `vite-node` to load entrypoints by default

### DIFF
--- a/docs/guide/go-further/entrypoint-loaders.md
+++ b/docs/guide/go-further/entrypoint-loaders.md
@@ -1,4 +1,33 @@
-# Entrypoint Side Effects
+# Entrypoint Loaders
+
+Because entrypoint options, like content script matches, are listed in the entrypoint's JS file, WXT has to import them during the build process to use those options when generating the manifest.
+
+There are two options for loading your entrypoints:
+
+1. `vite-node` - default as of `v0.19.0`
+2. `jiti` (**DEPRECATED, will be removed in `v0.20.0`**) - Default before `v0.19.0`
+
+## vite-node
+
+```ts
+export default defineConfig({
+  entrypointLoader: 'vite-node', // (or don't include the option at all)
+});
+```
+
+Since 0.19.0, WXT uses `vite-node`, the same tool that powers Vitest and Nuxt, to import your entrypoint files.
+
+There isn't really anything to add here... By default, it should "just work".
+
+## jiti
+
+```ts
+export default defineConfig({
+  entrypointLoader: 'jiti',
+});
+```
+
+The original method WXT used to import TS files. However, because it doesn't support vite plugins like `vite-node`, there is one main caveot to it's usage: **_module side-effects_**.
 
 You cannot use imported variables outside the `main` function in JS entrypoints. This includes options, as shown below:
 

--- a/docs/guide/go-further/entrypoint-loaders.md
+++ b/docs/guide/go-further/entrypoint-loaders.md
@@ -9,25 +9,21 @@ There are two options for loading your entrypoints:
 
 ## vite-node
 
-```ts
-export default defineConfig({
-  entrypointLoader: 'vite-node', // (or don't include the option at all)
-});
-```
-
 Since 0.19.0, WXT uses `vite-node`, the same tool that powers Vitest and Nuxt, to import your entrypoint files.
 
 There isn't really anything to add here... By default, it should "just work".
 
 ## jiti
 
+The original method WXT used to import TS files. However, because it doesn't support vite plugins like `vite-node`, there is one main caveot to it's usage: **_module side-effects_**.
+
+To enable `jiti`:
+
 ```ts
 export default defineConfig({
   entrypointLoader: 'jiti',
 });
 ```
-
-The original method WXT used to import TS files. However, because it doesn't support vite plugins like `vite-node`, there is one main caveot to it's usage: **_module side-effects_**.
 
 You cannot use imported variables outside the `main` function in JS entrypoints. This includes options, as shown below:
 

--- a/docs/public/_redirects
+++ b/docs/public/_redirects
@@ -2,6 +2,8 @@
 # https://docs.netlify.com/routing/redirects/
 
 # Old URLs -> New URLs
+
+# OLD
 /config.html                    /api/reference/wxt/interfaces/InlineConfig.html
 /api/config.html                /api/reference/wxt/interfaces/InlineConfig.html
 /entrypoints                    /entrypoints/background.html
@@ -29,3 +31,6 @@
 /guide/build-targets.html       /guide/multiple-browsers.html
 /guide/installation.html        /get-started/installation.html
 /guide/introduction.html        /get-started/introduction.html
+
+# 0.19.0
+/guide/go-further/entrypoint-side-effects.html /guide/go-further/entrypoint-loaders.html

--- a/packages/wxt-demo/src/entrypoints/background.ts
+++ b/packages/wxt-demo/src/entrypoints/background.ts
@@ -20,7 +20,7 @@ export default defineBackground({
     // @ts-expect-error: should only accept entrypoints or public assets
     browser.runtime.getURL('/');
     browser.runtime.getURL('/background.js');
-    browser.runtime.getURL('/icon/128.png');
+    browser.runtime.getURL('/icons/128.png');
     browser.runtime.getURL('/example.html#hash');
     browser.runtime.getURL('/example.html?query=param');
     // @ts-expect-error: should only allow hashes/query params on HTML files

--- a/packages/wxt-demo/src/entrypoints/background.ts
+++ b/packages/wxt-demo/src/entrypoints/background.ts
@@ -20,7 +20,7 @@ export default defineBackground({
     // @ts-expect-error: should only accept entrypoints or public assets
     browser.runtime.getURL('/');
     browser.runtime.getURL('/background.js');
-    browser.runtime.getURL('/icons/128.png');
+    browser.runtime.getURL('/icon/128.png');
     browser.runtime.getURL('/example.html#hash');
     browser.runtime.getURL('/example.html?query=param');
     // @ts-expect-error: should only allow hashes/query params on HTML files

--- a/packages/wxt-demo/wxt.config.ts
+++ b/packages/wxt-demo/wxt.config.ts
@@ -19,9 +19,6 @@ export default defineConfig({
   analysis: {
     open: true,
   },
-  experimental: {
-    entrypointImporter: 'vite-node',
-  },
   runner: {
     startUrls: ['https://duckduckgo.com'],
   },

--- a/packages/wxt/e2e/tests/manifest-content.test.ts
+++ b/packages/wxt/e2e/tests/manifest-content.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import { TestProject } from '../utils';
 
-describe.each(['jiti', 'vite-runtime', 'vite-node'] as const)(
+describe.each(['vite-node', 'jiti'] as const)(
   'Manifest Content (Vite runtime? %s)',
   (entrypointImporter) => {
     it.each([

--- a/packages/wxt/src/core/builders/vite/index.ts
+++ b/packages/wxt/src/core/builders/vite/index.ts
@@ -209,26 +209,10 @@ export async function createViteBuilder(
     name: 'Vite',
     version: vite.version,
     async importEntrypoint(path) {
-      switch (wxtConfig.experimental.entrypointImporter) {
+      switch (wxtConfig.entrypointLoader) {
         default:
         case 'jiti': {
           return await importEntrypointFile(path);
-        }
-        case 'vite-runtime': {
-          const baseConfig = await getBaseConfig();
-          const envConfig: vite.InlineConfig = {
-            plugins: [
-              wxtPlugins.extensionApiMock(wxtConfig),
-              wxtPlugins.removeEntrypointMainFunction(wxtConfig, path),
-            ],
-          };
-          const config = vite.mergeConfig(baseConfig, envConfig);
-          const server = await vite.createServer(config);
-          await server.listen();
-          const runtime = await vite.createViteRuntime(server, { hmr: false });
-          const module = await runtime.executeUrl(path);
-          await server.close();
-          return module.default;
         }
         case 'vite-node': {
           const baseConfig = await getBaseConfig();

--- a/packages/wxt/src/core/utils/building/resolve-config.ts
+++ b/packages/wxt/src/core/utils/building/resolve-config.ts
@@ -185,7 +185,7 @@ export async function resolveConfig(
     extensionApi,
     browserModule:
       extensionApi === 'chrome' ? 'wxt/browser/chrome' : 'wxt/browser',
-    entrypointLoader: 'vite-node' as const,
+    entrypointLoader: mergedConfig.entrypointLoader ?? 'vite-node',
     experimental: defu(mergedConfig.experimental, {}),
     dev: {
       server: devServerConfig,

--- a/packages/wxt/src/core/utils/building/resolve-config.ts
+++ b/packages/wxt/src/core/utils/building/resolve-config.ts
@@ -185,9 +185,8 @@ export async function resolveConfig(
     extensionApi,
     browserModule:
       extensionApi === 'chrome' ? 'wxt/browser/chrome' : 'wxt/browser',
-    experimental: defu(mergedConfig.experimental, {
-      entrypointImporter: 'jiti' as const,
-    }),
+    entrypointLoader: 'vite-node' as const,
+    experimental: defu(mergedConfig.experimental, {}),
     dev: {
       server: devServerConfig,
       reloadCommand,

--- a/packages/wxt/src/core/utils/testing/fake-objects.ts
+++ b/packages/wxt/src/core/utils/testing/fake-objects.ts
@@ -298,9 +298,8 @@ export const fakeResolvedConfig = fakeObjectCreator<ResolvedConfig>(() => {
     alias: {},
     extensionApi: 'webextension-polyfill',
     browserModule: 'wxt/browser',
-    experimental: {
-      entrypointImporter: 'jiti',
-    },
+    entrypointLoader: 'vite-node',
+    experimental: {},
     dev: {
       reloadCommand: 'Alt+R',
     },

--- a/packages/wxt/src/types.ts
+++ b/packages/wxt/src/types.ts
@@ -299,25 +299,27 @@ export interface InlineConfig {
    * - `"chrome"` (unstable): Use the regular `chrome` (or `browser` for Firefox/Safari) globals provided by the browser. Types provided by [`@types/chrome`](https://www.npmjs.com/package/@types/chrome), make sure to install the package or types won't work.
    *
    * @default "webextension-polyfill"
+   * @since 0.19.0
    */
   extensionApi?: 'webextension-polyfill' | 'chrome';
   /**
+   * @deprecated Will be removed in v0.20.0, please migrate to using `vite-node`, the new default.
+   *
+   * Method used to import entrypoint files during the build process to extract their options.
+   *
+   * - `"vite-node"` (default as of 0.19.0): Uses `vite-node` to import the entrypoints. Automatically includes vite config based on your wxt.config.ts file
+   * - `"jiti"`: Simplest and fastest, but doesn't allow using any imported variables outside the entrypoint's main function
+   *
+   * @see {@link https://wxt.dev/guide/go-further/entrypoint-importers.html|Entrypoint Importers}
+   *
+   * @default "vite-node"
+   * @since 0.19.0
+   */
+  entrypointLoader?: 'vite-node' | 'jiti';
+  /**
    * Experimental settings - use with caution.
    */
-  experimental?: {
-    /**
-     * Method used to import entrypoint files during the build process to extract their options.
-     *
-     * - `"jiti"`: Simplest and fastest, but doesn't allow using any imported variables outside the entrypoint's main function
-     * - `"vite-runtime"` (unstable): Uses Vite 5.3's new runtime API to import the entrypoints. Automatically includes vite config based on your wxt.config.ts file
-     * - `"vite-node"` (unstable): Uses `vite-node` to import the entrypoints. Automatically includes vite config based on your wxt.config.ts file
-     *
-     * @see {@link https://wxt.dev/guide/go-further/entrypoint-side-effects.html|Entrypoint Side-effect Docs}
-     *
-     * @default "jiti"
-     */
-    entrypointImporter?: 'jiti' | 'vite-runtime' | 'vite-node';
-  };
+  experimental?: {};
   /**
    * Config effecting dev mode only.
    */
@@ -1209,9 +1211,8 @@ export interface ResolvedConfig {
   alias: Record<string, string>;
   extensionApi: 'webextension-polyfill' | 'chrome';
   browserModule: 'wxt/browser' | 'wxt/browser/chrome';
-  experimental: {
-    entrypointImporter: 'jiti' | 'vite-runtime' | 'vite-node';
-  };
+  entrypointLoader: 'vite-node' | 'jiti';
+  experimental: {};
   dev: {
     /** Only defined during dev command */
     server?: {


### PR DESCRIPTION
BREAKING CHANGE: Switch from using `jiti` to import entrypoints during the build process by default to `vite-node`.

To continue using `jiti`, add the following to your `wxt.config.ts` file:

```ts
export default defineConfig({
  entrypointLoader: "jiti",
})
```

NOTE: "jiti" is deprecated and will be removed in the next major version, `v0.20.0`.

---

This closes #506