### PR TITLE
fix: web globals not defined when importing entrypoints

### DIFF
--- a/packages/wxt-demo/src/entrypoints/main-world.content.ts
+++ b/packages/wxt-demo/src/entrypoints/main-world.content.ts
@@ -1,7 +1,3 @@
-console.log(globalThis);
-
-console.log(document);
-
 export default defineContentScript({
   matches: ['*://*/*'],
   world: 'MAIN',

--- a/packages/wxt-demo/src/entrypoints/main-world.content.ts
+++ b/packages/wxt-demo/src/entrypoints/main-world.content.ts
@@ -1,3 +1,7 @@
+console.log(globalThis);
+
+console.log(document);
+
 export default defineContentScript({
   matches: ['*://*/*'],
   world: 'MAIN',

--- a/packages/wxt/e2e/tests/remote-code.test.ts
+++ b/packages/wxt/e2e/tests/remote-code.test.ts
@@ -3,7 +3,7 @@ import { TestProject } from '../utils';
 
 describe('Remote Code', () => {
   it('should download "url:*" modules and include them in the final bundle', async () => {
-    const url = 'https://code.jquery.com/jquery-3.7.1.slim.min.js';
+    const url = 'https://cdn.jsdelivr.net/npm/lodash@4.17.21/lodash.min.js';
     const project = new TestProject();
     project.addFile(
       'entrypoints/popup.ts',
@@ -16,7 +16,7 @@ describe('Remote Code', () => {
     const output = await project.serializeFile('.output/chrome-mv3/popup.js');
     expect(output).toContain(
       // Some text that will hopefully be in future versions of this script
-      'jQuery v3.7.1',
+      'lodash.com',
     );
     expect(output).not.toContain(url);
     expect(

--- a/packages/wxt/package.json
+++ b/packages/wxt/package.json
@@ -1,7 +1,7 @@
 {
   "name": "wxt",
   "type": "module",
-  "version": "0.19.0",
+  "version": "0.19.1-alpha1",
   "description": "Next gen framework for developing web extensions",
   "repository": {
     "type": "git",

--- a/packages/wxt/package.json
+++ b/packages/wxt/package.json
@@ -1,7 +1,7 @@
 {
   "name": "wxt",
   "type": "module",
-  "version": "0.19.1-alpha1",
+  "version": "0.19.1-alpha2",
   "description": "Next gen framework for developing web extensions",
   "repository": {
     "type": "git",

--- a/packages/wxt/src/core/builders/vite/index.ts
+++ b/packages/wxt/src/core/builders/vite/index.ts
@@ -24,7 +24,6 @@ import { importEntrypointFile } from '../../utils/building';
 import { ViteNodeServer } from 'vite-node/server';
 import { ViteNodeRunner } from 'vite-node/client';
 import { installSourcemapsSupport } from 'vite-node/source-map';
-import { createExtensionEnvironment } from '../../utils/environments';
 
 export async function createViteBuilder(
   wxtConfig: ResolvedConfig,

--- a/packages/wxt/src/core/builders/vite/index.ts
+++ b/packages/wxt/src/core/builders/vite/index.ts
@@ -24,6 +24,7 @@ import { importEntrypointFile } from '../../utils/building';
 import { ViteNodeServer } from 'vite-node/server';
 import { ViteNodeRunner } from 'vite-node/client';
 import { installSourcemapsSupport } from 'vite-node/source-map';
+import { createExtensionEnvironment } from '../../utils/environments';
 
 export async function createViteBuilder(
   wxtConfig: ResolvedConfig,
@@ -230,10 +231,7 @@ export async function createViteBuilder(
           baseConfig.optimizeDeps.noDiscovery = true;
           baseConfig.optimizeDeps.include = [];
           const envConfig: vite.InlineConfig = {
-            plugins: [
-              wxtPlugins.extensionApiMock(wxtConfig),
-              wxtPlugins.removeEntrypointMainFunction(wxtConfig, path),
-            ],
+            plugins: [wxtPlugins.removeEntrypointMainFunction(wxtConfig, path)],
           };
           const config = vite.mergeConfig(baseConfig, envConfig);
           const server = await vite.createServer(config);

--- a/packages/wxt/src/core/builders/vite/plugins/removeEntrypointMainFunction.ts
+++ b/packages/wxt/src/core/builders/vite/plugins/removeEntrypointMainFunction.ts
@@ -14,8 +14,11 @@ export function removeEntrypointMainFunction(
   const absPath = normalizePath(resolve(config.root, path));
   return {
     name: 'wxt:remove-entrypoint-main-function',
-    transform(code, id) {
-      if (id === absPath) return removeMainFunctionCode(code);
+    transform: {
+      order: 'pre',
+      handler(code, id) {
+        if (id === absPath) return removeMainFunctionCode(code);
+      },
     },
   };
 }

--- a/packages/wxt/src/core/utils/environments/browser-environment.ts
+++ b/packages/wxt/src/core/utils/environments/browser-environment.ts
@@ -1,0 +1,21 @@
+import { parseHTML } from 'linkedom';
+import { createEnvironment, Environment, EnvGlobals } from './environment';
+
+export function createBrowserEnvironment(): Environment {
+  return createEnvironment(getBrowserEnvironmentGlobals);
+}
+
+export function getBrowserEnvironmentGlobals(): EnvGlobals {
+  const { window, document, global } = parseHTML(`
+    <html>
+      <head></head>
+      <body></body>
+    </html>
+  `);
+  return {
+    ...global,
+    window,
+    document,
+    self: global,
+  };
+}

--- a/packages/wxt/src/core/utils/environments/environment.ts
+++ b/packages/wxt/src/core/utils/environments/environment.ts
@@ -1,0 +1,51 @@
+export interface Environment {
+  setup: () => () => void;
+  run: <T>(fn: () => Promise<T>) => Promise<T>;
+}
+
+export function createEnvironment(getGlobals: () => EnvGlobals): Environment {
+  const setup = () => {
+    console.log('SETUP');
+    const envGlobals = getGlobals();
+    const ogGlobals = getOgGlobals(envGlobals);
+    applyGlobals(envGlobals);
+
+    return () => {
+      applyGlobals(ogGlobals);
+      console.log('TEARDOWN');
+    };
+  };
+  const run = async (fn: () => any) => {
+    const teardown = setup();
+    try {
+      return await fn();
+    } finally {
+      teardown();
+    }
+  };
+  return {
+    setup,
+    run,
+  };
+}
+
+export type EnvGlobals = Record<string, any>;
+
+export function getOgGlobals(envGlobals: EnvGlobals): EnvGlobals {
+  return Object.keys(envGlobals).reduce<typeof envGlobals>((acc, key) => {
+    // @ts-expect-error: Untyped key on globalThis
+    acc[key] = globalThis[key];
+    return acc;
+  }, {});
+}
+
+export function applyGlobals(globals: EnvGlobals): void {
+  Object.entries(globals).forEach(([key, envValue]) => {
+    try {
+      // @ts-expect-error: Untyped key on globalThis
+      globalThis[key] = envValue;
+    } catch (err) {
+      // ignore any globals that can't be set
+    }
+  });
+}

--- a/packages/wxt/src/core/utils/environments/environment.ts
+++ b/packages/wxt/src/core/utils/environments/environment.ts
@@ -5,14 +5,12 @@ export interface Environment {
 
 export function createEnvironment(getGlobals: () => EnvGlobals): Environment {
   const setup = () => {
-    console.log('SETUP');
     const envGlobals = getGlobals();
     const ogGlobals = getOgGlobals(envGlobals);
     applyGlobals(envGlobals);
 
     return () => {
       applyGlobals(ogGlobals);
-      console.log('TEARDOWN');
     };
   };
   const run = async (fn: () => any) => {

--- a/packages/wxt/src/core/utils/environments/extension-environment.ts
+++ b/packages/wxt/src/core/utils/environments/extension-environment.ts
@@ -1,0 +1,15 @@
+import { fakeBrowser } from '@webext-core/fake-browser';
+import { getBrowserEnvironmentGlobals } from './browser-environment';
+import { createEnvironment, Environment } from './environment';
+
+export function createExtensionEnvironment(): Environment {
+  return createEnvironment(getExtensionEnvironmentGlobals);
+}
+
+export function getExtensionEnvironmentGlobals() {
+  return {
+    ...getBrowserEnvironmentGlobals(),
+    chrome: fakeBrowser,
+    browser: fakeBrowser,
+  };
+}

--- a/packages/wxt/src/core/utils/environments/index.ts
+++ b/packages/wxt/src/core/utils/environments/index.ts
@@ -1,0 +1,2 @@
+export * from './browser-environment';
+export * from './extension-environment';


### PR DESCRIPTION
This closes #864 . It introduces the concept of an "environment". There are two environments:

- browser environment: Just contains web globals like `window` or `document`
- extension environment: browser environment + `chrome` and `browser` globals.

WXT spins up the extension environment when importing entrypoints.