### PR TITLE
pref: Tree-shake unrelated code inside `vite-node` entrypoint loader

### DIFF
--- a/packages/wxt/e2e/tests/output-structure.test.ts
+++ b/packages/wxt/e2e/tests/output-structure.test.ts
@@ -280,7 +280,7 @@ describe('Output Directory Structure', () => {
         var _a, _b;
         import { l as logHello, i as initPlugins } from "./chunks/_virtual_wxt-plugins-OjKtWpmY.js";
         function defineBackground(arg) {
-          if (typeof arg === "function") return { main: arg };
+          if (arg == null || typeof arg === "function") return { main: arg };
           return arg;
         }
         const definition = defineBackground({
@@ -366,7 +366,7 @@ describe('Output Directory Structure', () => {
           "use strict";
           var _a, _b;
           function defineBackground(arg) {
-            if (typeof arg === "function") return { main: arg };
+            if (arg == null || typeof arg === "function") return { main: arg };
             return arg;
           }
           function logHello(name) {

--- a/packages/wxt/package.json
+++ b/packages/wxt/package.json
@@ -1,7 +1,7 @@
 {
   "name": "wxt",
   "type": "module",
-  "version": "0.19.1-alpha3",
+  "version": "0.19.0",
   "description": "Next gen framework for developing web extensions",
   "repository": {
     "type": "git",

--- a/packages/wxt/package.json
+++ b/packages/wxt/package.json
@@ -1,7 +1,7 @@
 {
   "name": "wxt",
   "type": "module",
-  "version": "0.19.1-alpha2",
+  "version": "0.19.1-alpha3",
   "description": "Next gen framework for developing web extensions",
   "repository": {
     "type": "git",

--- a/packages/wxt/src/core/builders/vite/plugins/removeEntrypointMainFunction.ts
+++ b/packages/wxt/src/core/builders/vite/plugins/removeEntrypointMainFunction.ts
@@ -17,7 +17,13 @@ export function removeEntrypointMainFunction(
     transform: {
       order: 'pre',
       handler(code, id) {
-        if (id === absPath) return removeMainFunctionCode(code);
+        if (id === absPath) {
+          const newCode = removeMainFunctionCode(code);
+          config.logger.debug('vite-node transformed entrypoint', path);
+          config.logger.debug(`Original:\n---\n${code}\n---`);
+          config.logger.debug(`Transformed:\n---\n${newCode.code}\n---`);
+          return newCode;
+        }
       },
     },
   };

--- a/packages/wxt/src/core/utils/__tests__/transform.test.ts
+++ b/packages/wxt/src/core/utils/__tests__/transform.test.ts
@@ -6,23 +6,28 @@ describe('Transform Utils', () => {
     it.each(['defineBackground', 'defineUnlistedScript'])(
       'should remove the first arrow function argument for %s',
       (def) => {
-        const input = `export default ${def}(() => {
+        const input = `
+          export default ${def}(() => {
             console.log();
-          })`;
-        const expected = `export default ${def}(() => {})`;
+          })
+        `;
+        const expected = `export default ${def}();`;
 
         const actual = removeMainFunctionCode(input).code;
 
         expect(actual).toEqual(expected);
       },
     );
+
     it.each(['defineBackground', 'defineUnlistedScript'])(
       'should remove the first function argument for %s',
       (def) => {
-        const input = `export default ${def}(function () {
+        const input = `
+          export default ${def}(function () {
             console.log();
-          })`;
-        const expected = `export default ${def}(function () {})`;
+          })
+        `;
+        const expected = `export default ${def}();`;
 
         const actual = removeMainFunctionCode(input).code;
 
@@ -35,13 +40,49 @@ describe('Transform Utils', () => {
       'defineContentScript',
       'defineUnlistedScript',
     ])('should remove the main field from %s', (def) => {
-      const input = `export default ${def}({
-        asdf: "asdf",
-        main: () => {},
-      })`;
+      const input = `
+        export default ${def}({
+          asdf: "asdf",
+          main: () => {},
+        })
+      `;
       const expected = `export default ${def}({
   asdf: "asdf"
 })`;
+
+      const actual = removeMainFunctionCode(input).code;
+
+      expect(actual).toEqual(expected);
+    });
+
+    it('should remove unused imports', () => {
+      const input = `
+        import { defineBackground } from "wxt/sandbox"
+        import { test1 } from "somewhere1"
+        import test2 from "somewhere2"
+
+        export default defineBackground(() => {})
+      `;
+      const expected = `import { defineBackground } from "wxt/sandbox"
+
+export default defineBackground();`;
+
+      const actual = removeMainFunctionCode(input).code;
+
+      expect(actual).toEqual(expected);
+    });
+
+    it('should remove explict side-effect imports', () => {
+      const input = `
+        import { defineBackground } from "wxt/sandbox"
+        import "my-polyfill"
+        import "./style.css"
+
+        export default defineBackground(() => {})
+      `;
+      const expected = `import { defineBackground } from "wxt/sandbox"
+
+export default defineBackground();`;
 
       const actual = removeMainFunctionCode(input).code;
 

--- a/packages/wxt/src/core/utils/transform.ts
+++ b/packages/wxt/src/core/utils/transform.ts
@@ -2,8 +2,9 @@ import { ProxifiedModule, parseModule } from 'magicast';
 
 /**
  * Removes any code used at runtime related to an entrypoint's main function.
- * - Removes or clears out `main` function from returned object
- * - TODO: Removes unused imports after main function has been removed to prevent importing runtime modules
+ * 1. Removes or clears out `main` function from returned object
+ * 2. Removes unused imports
+ * 3. Removes value-less, side-effect only imports (like `import "./styles.css"` or `import "webextension-polyfill"`)
  */
 export function removeMainFunctionCode(code: string): {
   code: string;
@@ -11,16 +12,18 @@ export function removeMainFunctionCode(code: string): {
 } {
   const mod = parseModule(code);
   emptyMainFunction(mod);
+  removeUnusedImports(mod);
+  removeSideEffectImports(mod);
   return mod.generate();
 }
 
-function emptyMainFunction(mod: ProxifiedModule) {
+function emptyMainFunction(mod: ProxifiedModule): void {
   if (mod.exports?.default?.$type === 'function-call') {
     if (mod.exports.default.$ast?.arguments?.[0]?.body) {
       // Remove body from function
-      // ex: "fn(() => { ... })" to "fn(() => {})"
-      // ex: "fn(function () { ... })" to "fn(function () {})"
-      mod.exports.default.$ast.arguments[0].body.body = [];
+      // ex: "fn(() => { ... })" to "fn()"
+      // ex: "fn(function () { ... })" to "fn()"
+      delete mod.exports.default.$ast.arguments[0];
     } else if (mod.exports.default.$ast?.arguments?.[0]?.properties) {
       // Remove main field from object
       // ex: "fn({ ..., main: () => {} })" to "fn({ ... })"
@@ -29,5 +32,73 @@ function emptyMainFunction(mod: ProxifiedModule) {
           (prop: any) => prop.key.name !== 'main',
         );
     }
+  }
+}
+
+// TODO: Do a more complex declaration analysis where shadowed variables are detected and ignored.
+// Right now, this code assumes there are no shadowed variables.
+function removeUnusedImports(mod: ProxifiedModule): void {
+  const importSymbols = Object.keys(mod.imports);
+  const usedMap = new Map(importSymbols.map((sym) => [sym, false]));
+
+  const queue: any[] = [getSimpleAstJson(mod.$ast)];
+  for (const item of queue) {
+    if (!item) {
+      continue;
+    } else if (Array.isArray(item)) {
+      queue.push(...item);
+    } else if (item.type === 'ImportDeclaration') {
+      // Exclude looking for identifiers in import statements
+      continue;
+    } else if (item.type === 'Identifier') {
+      // Only track import usages
+      if (usedMap.has(item.name)) usedMap.set(item.name, true);
+    } else if (typeof item === 'object') {
+      queue.push(Object.values(item));
+    }
+  }
+
+  for (const [name, used] of usedMap.entries()) {
+    if (!used) delete mod.imports[name];
+  }
+}
+
+function deleteImportAst(
+  mod: ProxifiedModule,
+  shouldDelete: (node: any) => boolean,
+): void {
+  const importIndexesToDelete: number[] = [];
+  (mod.$ast as any).body.forEach((node: any, index: number) => {
+    if (node.type === 'ImportDeclaration' && shouldDelete(node)) {
+      importIndexesToDelete.push(index);
+    }
+  });
+  importIndexesToDelete.reverse().forEach((i) => {
+    delete (mod.$ast as any).body[i];
+  });
+}
+
+function removeSideEffectImports(mod: ProxifiedModule): void {
+  deleteImportAst(mod, (node) => node.specifiers.length === 0);
+}
+
+/**
+ * Util to get the AST as a simple JSON object, stripping out large objects and file locations to keep it readible
+ */
+function getSimpleAstJson(ast: any): any {
+  if (!ast) {
+    return ast;
+  } else if (Array.isArray(ast)) {
+    return ast.map(getSimpleAstJson);
+  } else if (typeof ast === 'object') {
+    return Object.fromEntries(
+      Object.entries(ast)
+        .filter(
+          ([key, value]) => key !== 'loc' && key !== 'start' && key !== 'end',
+        )
+        .map(([key, value]) => [key, getSimpleAstJson(value)]),
+    );
+  } else {
+    return ast;
   }
 }

--- a/packages/wxt/src/sandbox/define-background.ts
+++ b/packages/wxt/src/sandbox/define-background.ts
@@ -7,6 +7,6 @@ export function defineBackground(
 export function defineBackground(
   arg: (() => void) | BackgroundDefinition,
 ): BackgroundDefinition {
-  if (typeof arg === 'function') return { main: arg };
+  if (arg == null || typeof arg === 'function') return { main: arg };
   return arg;
 }

--- a/packages/wxt/src/sandbox/define-unlisted-script.ts
+++ b/packages/wxt/src/sandbox/define-unlisted-script.ts
@@ -9,6 +9,6 @@ export function defineUnlistedScript(
 export function defineUnlistedScript(
   arg: (() => void) | UnlistedScriptDefinition,
 ): UnlistedScriptDefinition {
-  if (typeof arg === 'function') return { main: arg };
+  if (arg == null || typeof arg === 'function') return { main: arg };
   return arg;
 }


### PR DESCRIPTION
Remove any code from entrypoint file that isn't directly related to returning the options.

https://github.com/wxt-dev/wxt/blob/0c273df271d187640a442d91f25c43a4cb2d7902/packages/wxt/src/core/utils/transform.ts#L3-L18

You can see how the entrypoints are transformed when passing the `--debug` flag: 

```
⚙ vite-node transformed entrypoint /home/aklinker1/Development/github.com/wxt-dev/wxt/packages/wxt-demo/src/entrypoints/background.ts                                                                                                                                    2:54:05 PM
⚙ Original:                                                                                                                                                                                                                                                              2:54:05 PM
---
import messages from '~/public/_locales/en/messages.json';

export default defineBackground({
  // type: 'module',

  main() {
    console.log(browser.runtime.id);
    logId();
    console.log({
      url: import.meta.url,
      browser: import.meta.env.BROWSER,
      chrome: import.meta.env.CHROME,
      firefox: import.meta.env.FIREFOX,
      manifestVersion: import.meta.env.MANIFEST_VERSION,
      messages,
    });

    console.log(useAppConfig());

    // @ts-expect-error: should only accept entrypoints or public assets
    browser.runtime.getURL('/');
    browser.runtime.getURL('/background.js');
    browser.runtime.getURL('/icons/128.png');
    browser.runtime.getURL('/example.html#hash');
    browser.runtime.getURL('/example.html?query=param');
    // @ts-expect-error: should only allow hashes/query params on HTML files
    browser.runtime.getURL('/icon-128.png?query=param');

    // @ts-expect-error: should only accept known message names
    browser.i18n.getMessage('test');
    browser.i18n.getMessage('prompt_for_name');
    browser.i18n.getMessage('hello', 'Aaron');
    browser.i18n.getMessage('bye', ['Aaron']);
    browser.i18n.getMessage('@@extension_id');

    console.log('WXT MODE:', {
      MODE: import.meta.env.MODE,
      DEV: import.meta.env.DEV,
      PROD: import.meta.env.PROD,
    });

    storage.setItem('session:startTime', Date.now());
  },
});

---
⚙ Transformed:                                                                                                                                                                                                                                                           2:54:05 PM
---
export default defineBackground({});
---
...
```