### PR TITLE
fix: Remove unused top-level functions and variables when loading entrypoints with the `vite-node` loader

### DIFF
--- a/packages/wxt/src/core/utils/__tests__/transform.test.ts
+++ b/packages/wxt/src/core/utils/__tests__/transform.test.ts
@@ -88,5 +88,54 @@ export default defineBackground();`;
 
       expect(actual).toEqual(expected);
     });
+
+    it("should remove any functions delcared outside the main function that aren't used", () => {
+      const input = `
+              function getMatches() {
+                return ["*://*/*"]
+              }
+              function unused1() {}
+              function unused2() {
+                unused1();
+              }
+
+              export default defineContentScript({
+                matches: getMatches(),
+                main: () => {},
+              })
+            `;
+      const expected = `function getMatches() {
+  return ["*://*/*"]
+}
+
+export default defineContentScript({
+  matches: getMatches()
+})`;
+
+      const actual = removeMainFunctionCode(input).code;
+
+      expect(actual).toEqual(expected);
+    });
+
+    it("should remove any variables delcared outside the main function that aren't used", () => {
+      const input = `
+        const unused1 = "a", matches = ["*://*/*"];
+        let unused2 = unused1 + "b";
+
+        export default defineContentScript({
+          matches,
+          main: () => {}
+        })
+      `;
+      const expected = `const matches = ["*://*/*"];
+
+export default defineContentScript({
+  matches
+})`;
+
+      const actual = removeMainFunctionCode(input).code;
+
+      expect(actual).toEqual(expected);
+    });
   });
 });


### PR DESCRIPTION
Basically, tree-shake out any unused functions or variables that were called in the main function of an entrypoint, and nowhere else. Was already doing this with imports, now we're doing it with all top-level declarations.

See tests for examples:

https://github.com/wxt-dev/wxt/blob/26ced9319bb6c0b5ee9419eba3c6ec9f831cb3a8/packages/wxt/src/core/utils/__tests__/transform.test.ts#L121-L134

https://github.com/wxt-dev/wxt/blob/26ced9319bb6c0b5ee9419eba3c6ec9f831cb3a8/packages/wxt/src/core/utils/__tests__/transform.test.ts#L93-L113