### PR TITLE
fix: Don't default to dev mode for production builds when using `vite-node` loader

### DIFF
--- a/packages/wxt/src/core/wxt.ts
+++ b/packages/wxt/src/core/wxt.ts
@@ -27,6 +27,10 @@ export async function registerWxt(
   inlineConfig: InlineConfig = {},
   getServer?: (config: ResolvedConfig) => Promise<WxtDevServer>,
 ): Promise<void> {
+  // Default NODE_ENV environment variable before other packages, like vite, do it
+  // See https://github.com/wxt-dev/wxt/issues/873#issuecomment-2254555523
+  process.env.NODE_ENV ??= command === 'serve' ? 'development' : 'production';
+
   const hooks = createHooks<WxtHooks>();
   const config = await resolveConfig(inlineConfig, command);
   const server = await getServer?.(config);


### PR DESCRIPTION
This closes https://github.com/wxt-dev/wxt/issues/873.

This does cause `vite-node`'s dev server to run in different modes when doing `wxt` vs `wxt build`, but I don't expect that to cause any problems.