### PR TITLE
chore: add more metadata for npm

### DIFF
--- a/packages/auto-icons/package.json
+++ b/packages/auto-icons/package.json
@@ -1,5 +1,28 @@
 {
   "name": "@wxt-dev/auto-icons",
+  "description": "WXT module for automatically generating extension icons in different sizes",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/wxt-dev/wxt/tree/main/packages/auto-icons"
+  },
+  "homepage": "https://wxt.dev",
+  "keywords": [
+    "wxt",
+    "module",
+    "icons",
+    "manifest"
+  ],
+  "author": {
+    "name": "Florian Metz",
+    "email": "me@timeraa.dev"
+  },
+  "contributors": [
+    {
+      "name": "Aaron Klinker",
+      "email": "aaronklinker1+wxt@gmail.com"
+    }
+  ],
+  "license": "MIT",
   "version": "1.0.1",
   "type": "module",
   "module": "./dist/index.mjs",

--- a/packages/auto-icons/package.json
+++ b/packages/auto-icons/package.json
@@ -3,9 +3,10 @@
   "description": "WXT module for automatically generating extension icons in different sizes",
   "repository": {
     "type": "git",
-    "url": "https://github.com/wxt-dev/wxt/tree/main/packages/auto-icons"
+    "url": "git+https://github.com/wxt-dev/wxt.git",
+    "directory": "packages/auto-icons"
   },
-  "homepage": "https://wxt.dev",
+  "homepage": "https://github.com/wxt-dev/wxt/blob/main/packages/auto-icons/README.md",
   "keywords": [
     "wxt",
     "module",

--- a/packages/module-react/package.json
+++ b/packages/module-react/package.json
@@ -1,5 +1,21 @@
 {
   "name": "@wxt-dev/module-react",
+  "description": "WXT module to enable React support",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/wxt-dev/wxt/tree/main/packages/module-react"
+  },
+  "homepage": "https://wxt.dev",
+  "keywords": [
+    "wxt",
+    "module",
+    "react"
+  ],
+  "author": {
+    "name": "Aaron Klinker",
+    "email": "aaronklinker1+wxt@gmail.com"
+  },
+  "license": "MIT",
   "version": "1.1.0",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/packages/module-react/package.json
+++ b/packages/module-react/package.json
@@ -3,9 +3,10 @@
   "description": "WXT module to enable React support",
   "repository": {
     "type": "git",
-    "url": "https://github.com/wxt-dev/wxt/tree/main/packages/module-react"
+    "url": "git+https://github.com/wxt-dev/wxt.git",
+    "directory": "packages/module-react"
   },
-  "homepage": "https://wxt.dev",
+  "homepage": "https://github.com/wxt-dev/wxt/blob/main/packages/module-react/README.md",
   "keywords": [
     "wxt",
     "module",

--- a/packages/module-solid/package.json
+++ b/packages/module-solid/package.json
@@ -1,5 +1,21 @@
 {
   "name": "@wxt-dev/module-solid",
+  "description": "WXT module to enable SolidJS support",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/wxt-dev/wxt/tree/main/packages/module-solid"
+  },
+  "homepage": "https://wxt.dev",
+  "keywords": [
+    "wxt",
+    "module",
+    "solidjs"
+  ],
+  "author": {
+    "name": "Aaron Klinker",
+    "email": "aaronklinker1+wxt@gmail.com"
+  },
+  "license": "MIT",
   "version": "1.1.1",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/packages/module-solid/package.json
+++ b/packages/module-solid/package.json
@@ -3,9 +3,10 @@
   "description": "WXT module to enable SolidJS support",
   "repository": {
     "type": "git",
-    "url": "https://github.com/wxt-dev/wxt/tree/main/packages/module-solid"
+    "url": "git+https://github.com/wxt-dev/wxt.git",
+    "directory": "packages/module-solid"
   },
-  "homepage": "https://wxt.dev",
+  "homepage": "https://github.com/wxt-dev/wxt/blob/main/packages/module-solid/README.md",
   "keywords": [
     "wxt",
     "module",

--- a/packages/module-svelte/package.json
+++ b/packages/module-svelte/package.json
@@ -1,5 +1,21 @@
 {
   "name": "@wxt-dev/module-svelte",
+  "description": "WXT module to enable Svelte support",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/wxt-dev/wxt/tree/main/packages/module-svelte"
+  },
+  "homepage": "https://wxt.dev",
+  "keywords": [
+    "wxt",
+    "module",
+    "svelte"
+  ],
+  "author": {
+    "name": "Aaron Klinker",
+    "email": "aaronklinker1+wxt@gmail.com"
+  },
+  "license": "MIT",
   "version": "1.0.0",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/packages/module-svelte/package.json
+++ b/packages/module-svelte/package.json
@@ -3,9 +3,10 @@
   "description": "WXT module to enable Svelte support",
   "repository": {
     "type": "git",
-    "url": "https://github.com/wxt-dev/wxt/tree/main/packages/module-svelte"
+    "url": "git+https://github.com/wxt-dev/wxt.git",
+    "directory": "packages/module-svelte"
   },
-  "homepage": "https://wxt.dev",
+  "homepage": "https://github.com/wxt-dev/wxt/blob/main/packages/module-svelte/README.md",
   "keywords": [
     "wxt",
     "module",

--- a/packages/module-vue/package.json
+++ b/packages/module-vue/package.json
@@ -3,9 +3,10 @@
   "description": "WXT module to enable Vue support",
   "repository": {
     "type": "git",
-    "url": "https://github.com/wxt-dev/wxt/tree/main/packages/module-vue"
+    "url": "git+https://github.com/wxt-dev/wxt.git",
+    "directory": "packages/module-vue"
   },
-  "homepage": "https://wxt.dev",
+  "homepage": "https://github.com/wxt-dev/wxt/blob/main/packages/module-vue/README.md",
   "keywords": [
     "wxt",
     "module",

--- a/packages/module-vue/package.json
+++ b/packages/module-vue/package.json
@@ -1,5 +1,21 @@
 {
   "name": "@wxt-dev/module-vue",
+  "description": "WXT module to enable Vue support",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/wxt-dev/wxt/tree/main/packages/module-vue"
+  },
+  "homepage": "https://wxt.dev",
+  "keywords": [
+    "wxt",
+    "module",
+    "vue"
+  ],
+  "author": {
+    "name": "Aaron Klinker",
+    "email": "aaronklinker1+wxt@gmail.com"
+  },
+  "license": "MIT",
   "version": "1.0.0",
   "type": "module",
   "main": "./dist/index.cjs",


### PR DESCRIPTION
This PR adds more metadata to make the modules more complete in terms of "required" data that's shown on npm, perhaps we should add more metadata @aklinker1?