### PR TITLE
feat: allow zipping hidden files by listing them explicitly in `includeSources`

### DIFF
--- a/packages/wxt/src/core/zip.ts
+++ b/packages/wxt/src/core/zip.ts
@@ -99,13 +99,11 @@ async function zipDir(
 ): Promise<void> {
   const archive = new JSZip();
   const files = (
-    await glob('**/*', {
+    await glob(['**/*', ...(options?.include || [])], {
       cwd: directory,
       // Ignore node_modules, otherwise this glob step takes forever
       ignore: ['**/node_modules'],
       onlyFiles: true,
-      // TODO: Fix #738
-      // dot: true,
     })
   ).filter((relativePath) => {
     return (


### PR DESCRIPTION
I omitted `dot: true` and didn't touch the default `excludeSources` (mentioned in https://github.com/wxt-dev/wxt/issues/738#issuecomment-2192251866) to avoid filtering all files inside hidden directories (including those in `.git`). For example, in my repo:
- `dot: true` filters 4657 files
- only 1028 files are filtered with this PR

In theory, there should be no difference for the end user - both approaches will not include files inside the hidden directory if only that directory is specified in `includeSources` (i.e. to include all files inside `.hidden-dir`, you should specify `.hidden-dir/**`, not `.hidden-dir`). Perhaps this specific aspect should be mentioned somehow in the `includeSources` JSDoc?