### PR TITLE
feat: allow excluding files when zipping

### DIFF
--- a/packages/wxt/src/core/utils/building/resolve-config.ts
+++ b/packages/wxt/src/core/utils/building/resolve-config.ts
@@ -268,6 +268,7 @@ function resolveZipConfig(
     includeSources: [],
     compressionLevel: 9,
     ...mergedConfig.zip,
+    exclude: mergedConfig.zip?.exclude ?? [],
     excludeSources: [
       '**/node_modules',
       // WXT files

--- a/packages/wxt/src/core/utils/testing/fake-objects.ts
+++ b/packages/wxt/src/core/utils/testing/fake-objects.ts
@@ -286,6 +286,7 @@ export const fakeResolvedConfig = fakeObjectCreator<ResolvedConfig>(() => {
       artifactTemplate: '{{name}}-{{version}}.zip',
       includeSources: [],
       excludeSources: [],
+      exclude: [],
       sourcesRoot: fakeDir(),
       sourcesTemplate: '{{name}}-sources.zip',
       name: faker.person.firstName().toLowerCase(),

--- a/packages/wxt/src/core/zip.ts
+++ b/packages/wxt/src/core/zip.ts
@@ -47,7 +47,9 @@ export async function zip(config?: InlineConfig): Promise<string[]> {
 
   const outZipFilename = applyTemplate(wxt.config.zip.artifactTemplate);
   const outZipPath = path.resolve(wxt.config.outBaseDir, outZipFilename);
-  await zipDir(wxt.config.outDir, outZipPath);
+  await zipDir(wxt.config.outDir, outZipPath, {
+    exclude: wxt.config.zip.exclude,
+  });
   zipFiles.push(outZipPath);
 
   // ZIP sources for Firefox

--- a/packages/wxt/src/types.ts
+++ b/packages/wxt/src/types.ts
@@ -182,6 +182,16 @@ export interface InlineConfig {
      */
     excludeSources?: string[];
     /**
+     * [Minimatch](https://www.npmjs.com/package/minimatch) patterns of files to exclude when
+     * zipping the extension.
+     *
+     * @example
+     * [
+     *   "*.map", // Exclude all sourcemaps
+     * ]
+     */
+    exclude?: string[];
+    /**
      * The Firefox review process requires the extension be buildable from source to make reviewing
      * easier. This field allows you to use private packages without exposing your auth tokens.
      *
@@ -1192,6 +1202,7 @@ export interface ResolvedConfig {
     downloadedPackagesDir: string;
     downloadPackages: string[];
     compressionLevel: 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9;
+    exclude: string[];
   };
   /**
    * @deprecated Use `build:manifestGenerated` hook instead.

--- a/packages/wxt/src/types.ts
+++ b/packages/wxt/src/types.ts
@@ -187,7 +187,7 @@ export interface InlineConfig {
      *
      * @example
      * [
-     *   "*.map", // Exclude all sourcemaps
+     *   "**\/*.map", // Exclude all sourcemaps
      * ]
      */
     exclude?: string[];


### PR DESCRIPTION
Allows the user to exclude files when zipping the folder, real world use case for this would be excluding sourcemaps for example when using the sentry plugin you need to have them but when zipping the actual extension I don't want to have them to not "expose" the structure of my codebase.

I didn't add the include option since you can do that using the public folder

I am not quite sure about the JSDoc, had to escape it like this, anyone know a proper fix for that?