### PR TITLE
chore: Resolve version regression issues related to optional peer deps.

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "test:coverage": "pnpm -r --sequential run test:coverage",
     "prepare": "simple-git-hooks",
     "prepublish": "pnpm -s build",
+    "postinstall": "pnpm i --resolution-only",
     "docs:gen": "typedoc --options docs/typedoc.json",
     "docs:dev": "pnpm -s docs:gen && vitepress dev docs",
     "docs:build": "pnpm -s docs:gen && vitepress build docs",


### PR DESCRIPTION
related: #908

With simple solution. 

If want an advanced solution to this problem, we can have the renovate-bot do `lockfilemaintenance`, but at the cost of having a bot.