### PR TITLE
fix: Typo in sidepanel options (`browse_style` → `browser_style`)

### DIFF
--- a/packages/wxt/src/core/utils/building/find-entrypoints.ts
+++ b/packages/wxt/src/core/utils/building/find-entrypoints.ts
@@ -387,7 +387,7 @@ async function getSidepanelEntrypoint(
   const options = await getHtmlEntrypointOptions<SidepanelEntrypointOptions>(
     info,
     {
-      browserStyle: 'browse_style',
+      browserStyle: 'browser_style',
       exclude: 'exclude',
       include: 'include',
       defaultIcon: 'default_icon',


### PR DESCRIPTION
This fixes https://github.com/wxt-dev/wxt/discussions/913