### PR TITLE
fix(types): Don't report type errors when using string templates with `browser.i18n.getMessage`

### DIFF
--- a/packages/wxt/e2e/tests/typescript-project.test.ts
+++ b/packages/wxt/e2e/tests/typescript-project.test.ts
@@ -126,92 +126,95 @@ describe('TypeScript Project', () => {
         export interface WxtI18n extends I18n.Static {
           /**
            * The extension or app ID; you might use this string to construct URLs for resources inside the extension. Even unlocalized extensions can use this message.
-      Note: You can't use this message in a manifest file.
-           *
+           * Note: You can't use this message in a manifest file.
+           * 
            * "<browser.runtime.id>"
            */
-          getMessage(
+      getMessage(
             messageName: "@@extension_id",
             substitutions?: string | string[],
             options?: GetMessageOptions,
           ): string;
           /**
-           * No message description.
-           *
            * "<browser.i18n.getUiLocale()>"
            */
-          getMessage(
+      getMessage(
             messageName: "@@ui_locale",
             substitutions?: string | string[],
             options?: GetMessageOptions,
           ): string;
           /**
            * The text direction for the current locale, either "ltr" for left-to-right languages such as English or "rtl" for right-to-left languages such as Japanese.
-           *
+           * 
            * "<ltr|rtl>"
            */
-          getMessage(
+      getMessage(
             messageName: "@@bidi_dir",
             substitutions?: string | string[],
             options?: GetMessageOptions,
           ): string;
           /**
            * If the @@bidi_dir is "ltr", then this is "rtl"; otherwise, it's "ltr".
-           *
+           * 
            * "<rtl|ltr>"
            */
-          getMessage(
+      getMessage(
             messageName: "@@bidi_reversed_dir",
             substitutions?: string | string[],
             options?: GetMessageOptions,
           ): string;
           /**
            * If the @@bidi_dir is "ltr", then this is "left"; otherwise, it's "right".
-           *
+           * 
            * "<left|right>"
            */
-          getMessage(
+      getMessage(
             messageName: "@@bidi_start_edge",
             substitutions?: string | string[],
             options?: GetMessageOptions,
           ): string;
           /**
            * If the @@bidi_dir is "ltr", then this is "right"; otherwise, it's "left".
-           *
+           * 
            * "<right|left>"
            */
-          getMessage(
+      getMessage(
             messageName: "@@bidi_end_edge",
             substitutions?: string | string[],
             options?: GetMessageOptions,
           ): string;
           /**
            * Ask for the user's name
-           *
+           * 
            * "What's your name?"
            */
-          getMessage(
+      getMessage(
             messageName: "prompt_for_name",
             substitutions?: string | string[],
             options?: GetMessageOptions,
           ): string;
           /**
            * Greet the user
-           *
+           * 
            * "Hello, $USER$"
            */
-          getMessage(
+      getMessage(
             messageName: "hello",
             substitutions?: string | string[],
             options?: GetMessageOptions,
           ): string;
           /**
            * Say goodbye to the user
-           *
+           * 
            * "Goodbye, $USER$. Come back to $OUR_SITE$ soon!"
            */
-          getMessage(
+      getMessage(
             messageName: "bye",
+            substitutions?: string | string[],
+            options?: GetMessageOptions,
+          ): string;
+      getMessage(
+            messageName: "@@extension_id" | "@@ui_locale" | "@@bidi_dir" | "@@bidi_reversed_dir" | "@@bidi_start_edge" | "@@bidi_end_edge" | "prompt_for_name" | "hello" | "bye",
             substitutions?: string | string[],
             options?: GetMessageOptions,
           ): string;

--- a/packages/wxt/e2e/tests/typescript-project.test.ts
+++ b/packages/wxt/e2e/tests/typescript-project.test.ts
@@ -130,7 +130,7 @@ describe('TypeScript Project', () => {
            *
            * "<browser.runtime.id>"
            */
-      getMessage(
+          getMessage(
             messageName: "@@extension_id",
             substitutions?: string | string[],
             options?: GetMessageOptions,
@@ -138,7 +138,7 @@ describe('TypeScript Project', () => {
           /**
            * "<browser.i18n.getUiLocale()>"
            */
-      getMessage(
+          getMessage(
             messageName: "@@ui_locale",
             substitutions?: string | string[],
             options?: GetMessageOptions,
@@ -148,7 +148,7 @@ describe('TypeScript Project', () => {
            *
            * "<ltr|rtl>"
            */
-      getMessage(
+          getMessage(
             messageName: "@@bidi_dir",
             substitutions?: string | string[],
             options?: GetMessageOptions,
@@ -158,7 +158,7 @@ describe('TypeScript Project', () => {
            *
            * "<rtl|ltr>"
            */
-      getMessage(
+          getMessage(
             messageName: "@@bidi_reversed_dir",
             substitutions?: string | string[],
             options?: GetMessageOptions,
@@ -168,7 +168,7 @@ describe('TypeScript Project', () => {
            *
            * "<left|right>"
            */
-      getMessage(
+          getMessage(
             messageName: "@@bidi_start_edge",
             substitutions?: string | string[],
             options?: GetMessageOptions,
@@ -178,7 +178,7 @@ describe('TypeScript Project', () => {
            *
            * "<right|left>"
            */
-      getMessage(
+          getMessage(
             messageName: "@@bidi_end_edge",
             substitutions?: string | string[],
             options?: GetMessageOptions,
@@ -188,7 +188,7 @@ describe('TypeScript Project', () => {
            *
            * "What's your name?"
            */
-      getMessage(
+          getMessage(
             messageName: "prompt_for_name",
             substitutions?: string | string[],
             options?: GetMessageOptions,
@@ -198,7 +198,7 @@ describe('TypeScript Project', () => {
            *
            * "Hello, $USER$"
            */
-      getMessage(
+          getMessage(
             messageName: "hello",
             substitutions?: string | string[],
             options?: GetMessageOptions,
@@ -208,7 +208,7 @@ describe('TypeScript Project', () => {
            *
            * "Goodbye, $USER$. Come back to $OUR_SITE$ soon!"
            */
-      getMessage(
+          getMessage(
             messageName: "bye",
             substitutions?: string | string[],
             options?: GetMessageOptions,

--- a/packages/wxt/e2e/tests/typescript-project.test.ts
+++ b/packages/wxt/e2e/tests/typescript-project.test.ts
@@ -127,7 +127,7 @@ describe('TypeScript Project', () => {
           /**
            * The extension or app ID; you might use this string to construct URLs for resources inside the extension. Even unlocalized extensions can use this message.
            * Note: You can't use this message in a manifest file.
-           * 
+           *
            * "<browser.runtime.id>"
            */
       getMessage(
@@ -145,7 +145,7 @@ describe('TypeScript Project', () => {
           ): string;
           /**
            * The text direction for the current locale, either "ltr" for left-to-right languages such as English or "rtl" for right-to-left languages such as Japanese.
-           * 
+           *
            * "<ltr|rtl>"
            */
       getMessage(
@@ -155,7 +155,7 @@ describe('TypeScript Project', () => {
           ): string;
           /**
            * If the @@bidi_dir is "ltr", then this is "rtl"; otherwise, it's "ltr".
-           * 
+           *
            * "<rtl|ltr>"
            */
       getMessage(
@@ -165,7 +165,7 @@ describe('TypeScript Project', () => {
           ): string;
           /**
            * If the @@bidi_dir is "ltr", then this is "left"; otherwise, it's "right".
-           * 
+           *
            * "<left|right>"
            */
       getMessage(
@@ -175,7 +175,7 @@ describe('TypeScript Project', () => {
           ): string;
           /**
            * If the @@bidi_dir is "ltr", then this is "right"; otherwise, it's "left".
-           * 
+           *
            * "<right|left>"
            */
       getMessage(
@@ -185,7 +185,7 @@ describe('TypeScript Project', () => {
           ): string;
           /**
            * Ask for the user's name
-           * 
+           *
            * "What's your name?"
            */
       getMessage(
@@ -195,7 +195,7 @@ describe('TypeScript Project', () => {
           ): string;
           /**
            * Greet the user
-           * 
+           *
            * "Hello, $USER$"
            */
       getMessage(
@@ -205,7 +205,7 @@ describe('TypeScript Project', () => {
           ): string;
           /**
            * Say goodbye to the user
-           * 
+           *
            * "Goodbye, $USER$. Come back to $OUR_SITE$ soon!"
            */
       getMessage(

--- a/packages/wxt/e2e/tests/typescript-project.test.ts
+++ b/packages/wxt/e2e/tests/typescript-project.test.ts
@@ -213,7 +213,7 @@ describe('TypeScript Project', () => {
             substitutions?: string | string[],
             options?: GetMessageOptions,
           ): string;
-      getMessage(
+          getMessage(
             messageName: "@@extension_id" | "@@ui_locale" | "@@bidi_dir" | "@@bidi_reversed_dir" | "@@bidi_start_edge" | "@@bidi_end_edge" | "prompt_for_name" | "hello" | "bye",
             substitutions?: string | string[],
             options?: GetMessageOptions,

--- a/packages/wxt/src/core/utils/building/generate-wxt-dir.ts
+++ b/packages/wxt/src/core/utils/building/generate-wxt-dir.ts
@@ -164,7 +164,7 @@ declare module "wxt/browser" {
     const comment =
       commentLines.length > 0
         ? `    /**\n${commentLines.map((line) => `     * ${line}`.trimEnd()).join('\n')}\n     */\n`
-        : '';
+        : '    ';
     return `${comment}getMessage(
       messageName: ${keyType},
       substitutions?: string | string[],

--- a/packages/wxt/src/core/utils/building/generate-wxt-dir.ts
+++ b/packages/wxt/src/core/utils/building/generate-wxt-dir.ts
@@ -163,7 +163,7 @@ declare module "wxt/browser" {
     }
     const comment =
       commentLines.length > 0
-        ? `/**\n${commentLines.map((line) => `     * ${line}`.trimEnd()).join('\n')}\n     */\n`
+        ? `/**\n${commentLines.map((line) => `     * ${line}`.trimEnd()).join('\n')}\n     */\n    `
         : '';
     return `    ${comment}getMessage(
       messageName: ${keyType},

--- a/packages/wxt/src/core/utils/building/generate-wxt-dir.ts
+++ b/packages/wxt/src/core/utils/building/generate-wxt-dir.ts
@@ -163,7 +163,7 @@ declare module "wxt/browser" {
     }
     const comment =
       commentLines.length > 0
-        ? `    /**\n${commentLines.map((line) => `     * ${line}`).join('\n')}\n     */\n`
+        ? `    /**\n${commentLines.map((line) => `     * ${line}`.trimEnd()).join('\n')}\n     */\n`
         : '';
     return `${comment}getMessage(
       messageName: ${keyType},

--- a/packages/wxt/src/core/utils/building/generate-wxt-dir.ts
+++ b/packages/wxt/src/core/utils/building/generate-wxt-dir.ts
@@ -163,9 +163,9 @@ declare module "wxt/browser" {
     }
     const comment =
       commentLines.length > 0
-        ? `    /**\n${commentLines.map((line) => `     * ${line}`.trimEnd()).join('\n')}\n     */\n`
-        : '    ';
-    return `${comment}getMessage(
+        ? `/**\n${commentLines.map((line) => `     * ${line}`.trimEnd()).join('\n')}\n     */\n`
+        : '';
+    return `    ${comment}getMessage(
       messageName: ${keyType},
       substitutions?: string | string[],
       options?: GetMessageOptions,


### PR DESCRIPTION
This fixes: https://discord.com/channels/1212416027611365476/1272982191764144248/1272982191764144248

> I inspected the generated types and it's a bunch of function overloads where `messageName` is basically a literal string that can be passed through as argument to `.getMessage()`. It's nice for development and auto-completion, but it doesn't allow me to pass a template string with an argument that is typed correctly.
> 
> It allows me to write it as:
> ```ts
> browser.i18n.getMessage('mode_upscale')
> ```
> 
> Also this works:
> ```ts
> const myMode = 'upscale'
> browser.i18n.getMessage(`mode_${myMode}`)
> ```
> 
> But this does not (on type level):
> ```ts
> const modeOptions = modes.map((mode) => ({
>   label: browser.i18n.getMessage(`mode_${mode}`),
> }))
> ```
> 
> Am I doing something wrong?