### PR TITLE
perf: Ignore non-source code from the file watcher

### DIFF
--- a/packages/wxt/src/core/builders/vite/index.ts
+++ b/packages/wxt/src/core/builders/vite/index.ts
@@ -287,7 +287,9 @@ export async function createViteBuilder(
           strictPort: true,
           host: info.hostname,
           origin: info.origin,
-          watch: { ignored: [`${wxtConfig.outBaseDir}/**`] },
+          watch: {
+            ignored: [`${wxtConfig.outBaseDir}/**`, `${wxtConfig.wxtDir}/**`],
+          },
         },
       };
       const baseConfig = await getBaseConfig();

--- a/packages/wxt/src/core/builders/vite/index.ts
+++ b/packages/wxt/src/core/builders/vite/index.ts
@@ -287,6 +287,7 @@ export async function createViteBuilder(
           strictPort: true,
           host: info.hostname,
           origin: info.origin,
+          watch: { ignored: [`${wxtConfig.outBaseDir}/**`] },
         },
       };
       const baseConfig = await getBaseConfig();

--- a/packages/wxt/src/core/create-server.ts
+++ b/packages/wxt/src/core/create-server.ts
@@ -145,8 +145,6 @@ function createFileReloader(server: WxtDevServer) {
   const changeQueue: Array<[string, string]> = [];
 
   return async (event: string, path: string) => {
-    await wxt.reloadConfig();
-
     changeQueue.push([event, path]);
 
     await fileChangedMutex.runExclusive(async () => {
@@ -156,6 +154,8 @@ function createFileReloader(server: WxtDevServer) {
         .splice(0, changeQueue.length)
         .map(([_, file]) => file);
       if (fileChanges.length === 0) return;
+
+      await wxt.reloadConfig();
 
       const changes = detectDevChanges(fileChanges, server.currentOutput);
       if (changes.type === 'no-change') return;

--- a/packages/wxt/src/core/create-server.ts
+++ b/packages/wxt/src/core/create-server.ts
@@ -147,9 +147,6 @@ function createFileReloader(server: WxtDevServer) {
   return async (event: string, path: string) => {
     await wxt.reloadConfig();
 
-    // Here, "path" is a non-normalized path (ie: C:\\users\\... instead of C:/users/...)
-    if (path.startsWith(wxt.config.outBaseDir)) return;
-    if (path.startsWith(wxt.config.wxtDir)) return;
     changeQueue.push([event, path]);
 
     await fileChangedMutex.runExclusive(async () => {


### PR DESCRIPTION
related #866 

I noticed an over-firing of `resolveConfig` due to `reloadOnChange`, so I will fix that.

At first, I thought need to cache the `resolveConfig`, but don't need to cache it now. This change will reduce build time. And I haven't figured out the cause……but after repeating the launch a few times, launch speed also faster. (The 1st launch still a little slow) 🤷 

##### About the repeating launch

1. `cd wxt-demo`
2. `pnpm i` (rebuild the project)
3. run 1st: `node ./node_modules/wxt/bin/wxt.mjs`
    - browser launch duration about 1.3s
4. repeat run 2nd..3rd..: `node ./node_modules/wxt/bin/wxt.mjs`
    - browser launch duration about 600ms
    - decreased
