### PR TITLE
perf: Ignore output directories in all `vite.watcher`

### DIFF
--- a/packages/wxt/src/core/builders/vite/index.ts
+++ b/packages/wxt/src/core/builders/vite/index.ts
@@ -59,6 +59,11 @@ export async function createViteBuilder(
       config.build.sourcemap = 'inline';
     }
 
+    config.server ??= {};
+    config.server.watch = {
+      ignored: [`${wxtConfig.outBaseDir}/**`, `${wxtConfig.wxtDir}/**`],
+    };
+
     config.plugins ??= [];
     config.plugins.push(
       wxtPlugins.download(wxtConfig),
@@ -287,9 +292,6 @@ export async function createViteBuilder(
           strictPort: true,
           host: info.hostname,
           origin: info.origin,
-          watch: {
-            ignored: [`${wxtConfig.outBaseDir}/**`, `${wxtConfig.wxtDir}/**`],
-          },
         },
       };
       const baseConfig = await getBaseConfig();


### PR DESCRIPTION
From my research on https://github.com/wxt-dev/wxt/discussions/866#discussioncomment-10373242. Add the watcher config to the base config. This will make it ignored on `importEntrypoint`'s vite server. The performance is slightly more stable because vite is internally handled by the watcher.