### PR TITLE
fix: Ensure TSConfig paths start with `../` or  `./` so they are valid

### DIFF
--- a/packages/wxt/e2e/tests/typescript-project.test.ts
+++ b/packages/wxt/e2e/tests/typescript-project.test.ts
@@ -379,6 +379,22 @@ describe('TypeScript Project', () => {
     `);
   });
 
+  it('should start path aliases with "./" for paths inside the .wxt dir', async () => {
+    const project = new TestProject();
+    project.addFile('src/entrypoints/unlisted.html', '<html></html>');
+    project.setConfigFileConfig({
+      srcDir: 'src',
+      alias: {
+        example: '.wxt/example.ts',
+      },
+    });
+
+    await project.prepare();
+
+    const output = await project.serializeFile('.wxt/tsconfig.json');
+    expect(output).toContain('./example.ts');
+  });
+
   // TODO: Once a module has been published, use it here for testing - local files are never added to the .wxt/wxt.d.ts file
   it.todo(
     'should add modules from NPM to the TS project if they have a configKey',

--- a/packages/wxt/src/core/utils/building/generate-wxt-dir.ts
+++ b/packages/wxt/src/core/utils/building/generate-wxt-dir.ts
@@ -240,7 +240,7 @@ async function getTsConfigEntry(): Promise<WxtDirFileEntry> {
   };
   const paths = Object.entries(wxt.config.alias)
     .flatMap(([alias, absolutePath]) => {
-      let aliasPath = getTsconfigPath(absolutePath);
+      const aliasPath = getTsconfigPath(absolutePath);
       return [
         `      "${alias}": ["${aliasPath}"]`,
         `      "${alias}/*": ["${aliasPath}/*"]`,

--- a/packages/wxt/src/core/utils/building/generate-wxt-dir.ts
+++ b/packages/wxt/src/core/utils/building/generate-wxt-dir.ts
@@ -233,10 +233,14 @@ function getMainDeclarationEntry(references: WxtDirEntry[]): WxtDirFileEntry {
 
 async function getTsConfigEntry(): Promise<WxtDirFileEntry> {
   const dir = wxt.config.wxtDir;
-  const getTsconfigPath = (path: string) => normalizePath(relative(dir, path));
+  const getTsconfigPath = (path: string) => {
+    const res = normalizePath(relative(dir, path));
+    if (res.startsWith('.') || res.startsWith('/')) return res;
+    return './' + res;
+  };
   const paths = Object.entries(wxt.config.alias)
     .flatMap(([alias, absolutePath]) => {
-      const aliasPath = getTsconfigPath(absolutePath);
+      let aliasPath = getTsconfigPath(absolutePath);
       return [
         `      "${alias}": ["${aliasPath}"]`,
         `      "${alias}/*": ["${aliasPath}/*"]`,


### PR DESCRIPTION
If you added an alias to a file in the `.wxt` directory, it wouldn't start with `./path/to/file`, it would start with `path/to/file`. TS requires files start with "./" or "../", so that's what this PR does.