### PR TITLE
chore(types): Cleanup types in wxt/browser/chrome

### DIFF
--- a/packages/wxt/src/browser/chrome.ts
+++ b/packages/wxt/src/browser/chrome.ts
@@ -1,21 +1,16 @@
 /// <reference types="chrome" />
 /**
- * @module wxt/browser/chrome
- */
-import type { WxtRuntime, WxtI18n } from './index';
-
-/**
  * EXPERIMENTAL
  *
  * Includes the `chrome` API and types when using `extensionApi: 'chrome'`.
  *
  * @module wxt/browser/chrome
  */
+import type { WxtRuntime, WxtI18n } from './index';
 
-export type Chrome = typeof chrome;
-export type WxtBrowser = Omit<Chrome, 'runtime' | 'i18n'> & {
-  runtime: WxtRuntime & Omit<Chrome['runtime'], 'getURL'>;
-  i18n: WxtI18n & Omit<Chrome['i18n'], 'getMessage'>;
+export type WxtBrowser = Omit<typeof chrome, 'runtime' | 'i18n'> & {
+  runtime: WxtRuntime & Omit<(typeof chrome)['runtime'], 'getURL'>;
+  i18n: WxtI18n & Omit<(typeof chrome)['i18n'], 'getMessage'>;
 };
 
 export const browser: WxtBrowser =

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -259,7 +259,7 @@ importers:
     dependencies:
       '@aklinker1/rollup-plugin-visualizer':
         specifier: 5.12.0
-        version: 5.12.0(rollup@3.29.4)
+        version: 5.12.0(rollup@4.19.0)
       '@types/webextension-polyfill':
         specifier: ^0.10.7
         version: 0.10.7
@@ -370,7 +370,7 @@ importers:
         version: 2.1.3
       unimport:
         specifier: ^3.9.1
-        version: 3.9.1(rollup@3.29.4)
+        version: 3.9.1(rollup@4.19.0)
       vite:
         specifier: ^5.3.5
         version: 5.3.5(@types/node@20.14.12)(sass@1.77.8)
@@ -2649,12 +2649,10 @@ packages:
 
   glob@6.0.4:
     resolution: {integrity: sha512-MKZeRNyYZAVVVG1oZeLaWie1uweH40m9AZwIwxyPbTSX4hHrVYSzLg0Ro5Z5R7XKkIX+Cc6oD1rqeDJnwsB8/A==}
-    deprecated: Glob versions prior to v9 are no longer supported
 
   glob@8.1.0:
     resolution: {integrity: sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==}
     engines: {node: '>=12'}
-    deprecated: Glob versions prior to v9 are no longer supported
 
   global-dirs@3.0.1:
     resolution: {integrity: sha512-NBcGGFbBA9s1VzD41QXDG+3++t9Mn5t1FpLdhESY6oKY4gYTFpX4wO3sqGUa0Srjtbfj3szX0RnemmrVRUdULA==}
@@ -2804,7 +2802,6 @@ packages:
 
   inflight@1.0.6:
     resolution: {integrity: sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==}
-    deprecated: This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.
 
   inherits@2.0.4:
     resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
@@ -3968,7 +3965,6 @@ packages:
 
   rimraf@2.4.5:
     resolution: {integrity: sha512-J5xnxTyqaiw06JjMftq7L9ouA448dw/E7dKghkP9WpKNuwmARNNg+Gk8/u5ryb9N/Yo2+z3MCwuqFK/+qPOPfQ==}
-    deprecated: Rimraf versions prior to v4 are no longer supported
     hasBin: true
 
   rollup-plugin-dts@6.1.1:
@@ -4845,14 +4841,14 @@ snapshots:
       citty: 0.1.6
       typescript: 5.5.4
 
-  '@aklinker1/rollup-plugin-visualizer@5.12.0(rollup@3.29.4)':
+  '@aklinker1/rollup-plugin-visualizer@5.12.0(rollup@4.19.0)':
     dependencies:
       open: 8.4.2
       picomatch: 2.3.1
       source-map: 0.7.4
       yargs: 17.7.2
     optionalDependencies:
-      rollup: 3.29.4
+      rollup: 4.19.0
 
   '@algolia/autocomplete-core@1.9.3(@algolia/client-search@4.20.0)(algoliasearch@4.20.0)(search-insights@2.15.0)':
     dependencies:
@@ -5574,6 +5570,14 @@ snapshots:
       picomatch: 2.3.1
     optionalDependencies:
       rollup: 3.29.4
+
+  '@rollup/pluginutils@5.1.0(rollup@4.19.0)':
+    dependencies:
+      '@types/estree': 1.0.5
+      estree-walker: 2.0.2
+      picomatch: 2.3.1
+    optionalDependencies:
+      rollup: 4.19.0
 
   '@rollup/rollup-android-arm-eabi@4.19.0':
     optional: true
@@ -8903,9 +8907,9 @@ snapshots:
 
   undici-types@5.26.5: {}
 
-  unimport@3.9.1(rollup@3.29.4):
+  unimport@3.9.1(rollup@4.19.0):
     dependencies:
-      '@rollup/pluginutils': 5.1.0(rollup@3.29.4)
+      '@rollup/pluginutils': 5.1.0(rollup@4.19.0)
       acorn: 8.12.1
       escape-string-regexp: 5.0.0
       estree-walker: 3.0.3


### PR DESCRIPTION
After this PR, the recommended approach to importing types is this:

###### `extensionApi: "webextension-polyfill"`

```ts
import { Runtime } from 'wxt/browser';

function onMesasge(message: any, sender: Runtime.Sender) {
  // ...
} 
```

###### `extensionApi: "chrome"`

```ts
function onMesasge(message: any, sender: browser.runtime.Sender) {
  // ...
} 
```