### PR TITLE
docs: Add "Draftly" to homepage

### DIFF
--- a/docs/.vitepress/components/UsingWxtSection.vue
+++ b/docs/.vitepress/components/UsingWxtSection.vue
@@ -38,6 +38,7 @@ const chromeExtensionIds = [
   'cfkdcideecefncbglkhneoflfnmhoicc', // mindful - stay focused on your goals
   'lnhejcpclabmbgpiiomjbhalblnnbffg', // 1Proompt
   'fonflmjnjbkigocpoommgmhljdpljain', // NiceTab - https://github.com/web-dahuyou/NiceTab
+  'fcffekbnfcfdemeekijbbmgmkognnmkd', // Draftly for LinkedIn
 ];
 
 const { data, err, isLoading } = useListExtensionDetails(chromeExtensionIds);


### PR DESCRIPTION
- draftly for linkedin also uses wxt
- we would like to showcase it in wxt home page.
- https://chromewebstore.google.com/detail/draftly-for-linkedin/fcffekbnfcfdemeekijbbmgmkognnmkd