### PR TITLE
fix: #943 avoid using ungh, switch to GitHub official REST API

### DIFF
--- a/packages/wxt/src/core/initialize.ts
+++ b/packages/wxt/src/core/initialize.ts
@@ -115,15 +115,13 @@ async function listTemplates(): Promise<Template[]> {
       size: number;
     }>;
 
-    return data
-      .map(({ name, path }) => ({ name, path }))
-      .sort((l, r) => {
-        const lWeight = TEMPLATE_SORT_WEIGHT[l.name] ?? Number.MAX_SAFE_INTEGER;
-        const rWeight = TEMPLATE_SORT_WEIGHT[r.name] ?? Number.MAX_SAFE_INTEGER;
-        const diff = lWeight - rWeight;
-        if (diff !== 0) return diff;
-        return l.name.localeCompare(r.name);
-      });
+    return data.sort((l, r) => {
+      const lWeight = TEMPLATE_SORT_WEIGHT[l.name] ?? Number.MAX_SAFE_INTEGER;
+      const rWeight = TEMPLATE_SORT_WEIGHT[r.name] ?? Number.MAX_SAFE_INTEGER;
+      const diff = lWeight - rWeight;
+      if (diff !== 0) return diff;
+      return l.name.localeCompare(r.name);
+    });
   } catch (err) {
     consola.error(err);
     throw Error(`Failed to load templates`);

--- a/packages/wxt/src/core/initialize.ts
+++ b/packages/wxt/src/core/initialize.ts
@@ -99,49 +99,81 @@ interface Template {
 }
 
 async function listTemplates(): Promise<Template[]> {
-  try {
-    const res = await fetch(
-      'https://api.github.com/repos/wxt-dev/wxt/contents/templates',
-      { headers: { Accept: 'application/vnd.github+json' } },
-    );
-    if (res.status >= 300)
-      throw Error(`Request failed with status ${res.status} ${res.statusText}`);
+  const templates = await listTemplatesUngh().catch((err) => {
+    consola.debug('Failed to load templates via ungh:', err);
+    return listTemplatesGithub();
+  });
+  return templates.sort((l, r) => {
+    const lWeight = TEMPLATE_SORT_WEIGHT[l.name] ?? Number.MAX_SAFE_INTEGER;
+    const rWeight = TEMPLATE_SORT_WEIGHT[r.name] ?? Number.MAX_SAFE_INTEGER;
+    const diff = lWeight - rWeight;
+    if (diff !== 0) return diff;
+    return l.name.localeCompare(r.name);
+  });
+}
 
-    // Schema is Example4 of https://docs.github.com/en/rest/repos/contents?apiVersion=2022-11-28#get-repository-content
-    const data = (await res.json()) as Array<{
-      name: string;
+async function listTemplatesUngh(): Promise<Template[]> {
+  const res = await fetch('https://ungh.cc/repos/wxt-dev/wxt/files/main');
+  if (res.status !== 200)
+    throw Error(
+      `Request failed with status ${res.status} ${res.statusText}: ${await res.text()}`,
+    );
+
+  const data = (await res.json()) as {
+    meta: {
+      sha: string;
+    };
+    files: Array<{
       path: string;
+      mode: string;
       sha: string;
       size: number;
     }>;
-
-    return data.sort((l, r) => {
+  };
+  return data.files
+    .map((item) => item.path.match(/templates\/(.+)\/package\.json/)?.[1])
+    .filter((name) => name != null)
+    .map((name) => ({ name: name!, path: `templates/${name}` }))
+    .sort((l, r) => {
       const lWeight = TEMPLATE_SORT_WEIGHT[l.name] ?? Number.MAX_SAFE_INTEGER;
       const rWeight = TEMPLATE_SORT_WEIGHT[r.name] ?? Number.MAX_SAFE_INTEGER;
       const diff = lWeight - rWeight;
       if (diff !== 0) return diff;
       return l.name.localeCompare(r.name);
     });
-  } catch (err) {
-    consola.error(err);
-    throw Error(`Failed to load templates`);
-  }
+}
+
+async function listTemplatesGithub(): Promise<Template[]> {
+  const res = await fetch(
+    `https://api.github.com/repos/${REPO}/contents/templates`,
+    { headers: { Accept: 'application/vnd.github+json' } },
+  );
+  if (res.status !== 200)
+    throw Error(
+      `Request failed with status ${res.status} ${res.statusText}: ${await res.text()}`,
+    );
+
+  // Schema is Example4 of https://docs.github.com/en/rest/repos/contents?apiVersion=2022-11-28#get-repository-content
+  return (await res.json()) as Array<{
+    name: string;
+    path: string;
+    sha: string;
+    size: number;
+  }>;
 }
 
 async function cloneProject({
   directory,
   template,
-  packageManager,
 }: {
   directory: string;
   template: Template;
-  packageManager: string;
 }) {
   const { default: ora } = await import('ora');
   const spinner = ora('Downloading template').start();
   try {
     // 1. Clone repo
-    await downloadTemplate(`gh:wxt-dev/wxt/${template.path}`, {
+    await downloadTemplate(`gh:${REPO}/${template.path}`, {
       dir: directory,
       force: true,
     });
@@ -176,3 +208,5 @@ const TEMPLATE_SORT_WEIGHT: Record<string, number> = {
   vue: 1,
   react: 2,
 };
+
+const REPO = 'wxt-dev/wxt';

--- a/packages/wxt/src/core/initialize.ts
+++ b/packages/wxt/src/core/initialize.ts
@@ -133,14 +133,7 @@ async function listTemplatesUngh(): Promise<Template[]> {
   return data.files
     .map((item) => item.path.match(/templates\/(.+)\/package\.json/)?.[1])
     .filter((name) => name != null)
-    .map((name) => ({ name: name!, path: `templates/${name}` }))
-    .sort((l, r) => {
-      const lWeight = TEMPLATE_SORT_WEIGHT[l.name] ?? Number.MAX_SAFE_INTEGER;
-      const rWeight = TEMPLATE_SORT_WEIGHT[r.name] ?? Number.MAX_SAFE_INTEGER;
-      const diff = lWeight - rWeight;
-      if (diff !== 0) return diff;
-      return l.name.localeCompare(r.name);
-    });
+    .map((name) => ({ name: name!, path: `templates/${name}` }));
 }
 
 async function listTemplatesGithub(): Promise<Template[]> {

--- a/packages/wxt/src/core/initialize.ts
+++ b/packages/wxt/src/core/initialize.ts
@@ -116,7 +116,7 @@ async function listTemplates(): Promise<Template[]> {
     }>;
 
     return data
-      .map(({ name, path }) => ({ name: name, path }))
+      .map(({ name, path }) => ({ name, path }))
       .sort((l, r) => {
         const lWeight = TEMPLATE_SORT_WEIGHT[l.name] ?? Number.MAX_SAFE_INTEGER;
         const rWeight = TEMPLATE_SORT_WEIGHT[r.name] ?? Number.MAX_SAFE_INTEGER;


### PR DESCRIPTION
fix #943

I think ungh is useful but problematic if the init command depends on a ~~3rd party~~ unofficial API. We don't need to use ungh to get public repository, because don't need a token even with GitHub REST API.

https://docs.github.com/en/rest/repos/contents?apiVersion=2022-11-28#get-repository-content
> This endpoint can be used without authentication or the aforementioned permissions if only public resources are requested.