### PR TITLE
fix: duplicate `BuildOutput.publicAssets`

### DIFF
--- a/packages/wxt/src/core/utils/building/rebuild.ts
+++ b/packages/wxt/src/core/utils/building/rebuild.ts
@@ -47,14 +47,16 @@ export async function rebuild(
   const newOutput = await buildEntrypoints(entrypointGroups, spinner);
   const mergedOutput: Omit<BuildOutput, 'manifest'> = {
     steps: [...existingOutput.steps, ...newOutput.steps],
-    publicAssets: [...existingOutput.publicAssets, ...newOutput.publicAssets],
+    // Do not merge existing because all publicAssets copied everytime
+    publicAssets: newOutput.publicAssets,
   };
 
   const { manifest: newManifest, warnings: manifestWarnings } =
     await generateManifest(allEntrypoints, mergedOutput);
+
   const finalOutput: BuildOutput = {
     manifest: newManifest,
-    ...newOutput,
+    ...mergedOutput,
   };
 
   // Write manifest
@@ -64,14 +66,7 @@ export async function rebuild(
   spinner.clear().stop();
 
   return {
-    output: {
-      manifest: newManifest,
-      steps: [...existingOutput.steps, ...finalOutput.steps],
-      publicAssets: [
-        ...existingOutput.publicAssets,
-        ...finalOutput.publicAssets,
-      ],
-    },
+    output: finalOutput,
     manifest: newManifest,
     warnings: manifestWarnings,
   };


### PR DESCRIPTION
I was logging about the #938 and noticed this.

The `BuildOutput.publicAssets` is increasing with each rebuild. `publicAssets` should not need to be merged like `BuildOutput.steps` because the current implementation is making copies.

### BEFORE

```sh
[12:12:06] WXT 0.19.8
[12:12:07] ✔ Started dev server @ http://localhost:3000
[12:12:07] ℹ Pre-rendering chrome-mv3 for development with Vite 5.3.5
[12:12:08] ✔ Built extension in 812 ms
  ├─ .output/chrome-mv3/manifest.json               1.04 kB  
  ├─ .output/chrome-mv3/popup.html                  636 B    
  ├─ .output/chrome-mv3/background.js               126.73 kB
  ├─ .output/chrome-mv3/chunks/popup-BxzUToPe.js    8.16 kB  
  ├─ .output/chrome-mv3/content-scripts/content.js  133.94 kB
  ├─ .output/chrome-mv3/icon/128.png                3.07 kB  
  ├─ .output/chrome-mv3/icon/16.png                 559 B    
  ├─ .output/chrome-mv3/icon/32.png                 916 B    
  ├─ .output/chrome-mv3/icon/48.png                 1.33 kB  
  ├─ .output/chrome-mv3/icon/96.png                 2.37 kB  
  └─ .output/chrome-mv3/wxt.svg                     1.07 kB  
Σ Total size: 279.83 kB                                              
[12:12:09] ✔ Opened browser in 1.379 s
server.currentOutput {
  manifest: {
    manifest_version: 3,
    name: 'wxt-starter',
    description: 'manifest.json description',
    version: '0.0.0',
    short_name: undefined,
    icons: {
      '16': 'icon/16.png',
      '32': 'icon/32.png',
      '48': 'icon/48.png',
      '96': 'icon/96.png',
      '128': 'icon/128.png'
    },
    commands: { 'wxt:reload-extension': [Object] },
    version_name: undefined,
    background: { type: undefined, service_worker: 'background.js' },
    action: {
      default_title: 'Default Popup Title',
      default_popup: 'popup.html'
    },
    host_permissions: [ '*://*.google.com/*', 'http://localhost/*' ],
    content_security_policy: {
      extension_pages: "script-src 'self' 'wasm-unsafe-eval' http://localhost:3000; object-src 'self';",
      sandbox: "script-src 'self' 'unsafe-inline' 'unsafe-eval' http://localhost:3000; sandbox allow-scripts allow-forms allow-popups allow-modals; child-src 'self';"
    },
    permissions: [ 'tabs', 'scripting' ]
  },
  steps: [
    { entrypoints: [Object], chunks: [Array] },
    { entrypoints: [Object], chunks: [Array] },
    { entrypoints: [Array], chunks: [Array] }
  ],
  publicAssets: [
    { type: 'asset', fileName: 'manifest.json' },
    { type: 'asset', fileName: 'wxt.svg' },
    { type: 'asset', fileName: 'icon/128.png' },
    { type: 'asset', fileName: 'icon/16.png' },
    { type: 'asset', fileName: 'icon/32.png' },
    { type: 'asset', fileName: 'icon/48.png' },
    { type: 'asset', fileName: 'icon/96.png' }
  ]
}
[12:12:11] ℹ Changed@: entrypoints/content.ts
[12:12:12] ✔ Reloaded: content
server.currentOutput {
  manifest: {
    manifest_version: 3,
    name: 'wxt-starter',
    description: 'manifest.json description',
    version: '0.0.0',
    short_name: undefined,
    icons: {
      '16': 'icon/16.png',
      '32': 'icon/32.png',
      '48': 'icon/48.png',
      '96': 'icon/96.png',
      '128': 'icon/128.png'
    },
    commands: { 'wxt:reload-extension': [Object] },
    version_name: undefined,
    background: { type: undefined, service_worker: 'background.js' },
    action: {
      default_title: 'Default Popup Title',
      default_popup: 'popup.html'
    },
    host_permissions: [ '*://*.google.com/*', 'http://localhost/*' ],
    content_security_policy: {
      extension_pages: "script-src 'self' 'wasm-unsafe-eval' http://localhost:3000; object-src 'self';",
      sandbox: "script-src 'self' 'unsafe-inline' 'unsafe-eval' http://localhost:3000; sandbox allow-scripts allow-forms allow-popups allow-modals; child-src 'self';"
    },
    permissions: [ 'tabs', 'scripting' ]
  },
  steps: [
    { entrypoints: [Object], chunks: [Array] },
    { entrypoints: [Array], chunks: [Array] },
    { entrypoints: [Object], chunks: [Array] }
  ],
  publicAssets: [
    { type: 'asset', fileName: 'manifest.json' },
    { type: 'asset', fileName: 'wxt.svg' },
    { type: 'asset', fileName: 'icon/128.png' },
    { type: 'asset', fileName: 'icon/16.png' },
    { type: 'asset', fileName: 'icon/32.png' },
    { type: 'asset', fileName: 'icon/48.png' },
    { type: 'asset', fileName: 'icon/96.png' },
    { type: 'asset', fileName: 'manifest.json' },
    { type: 'asset', fileName: 'wxt.svg' },
    { type: 'asset', fileName: 'icon/128.png' },
    { type: 'asset', fileName: 'icon/16.png' },
    { type: 'asset', fileName: 'icon/32.png' },
    { type: 'asset', fileName: 'icon/48.png' },
    { type: 'asset', fileName: 'icon/96.png' }
  ]
}
[12:12:14] ℹ Changed@: entrypoints/content.ts
[12:12:14] ✔ Reloaded: content

```

### AFTER

```sh
[12:11:13] WXT 0.19.8
[12:11:13] ✔ Started dev server @ http://localhost:3000
[12:11:13] ℹ Pre-rendering chrome-mv3 for development with Vite 5.3.5
[12:11:14] ✔ Built extension in 444 ms
  ├─ .output/chrome-mv3/manifest.json               1.04 kB  
  ├─ .output/chrome-mv3/popup.html                  636 B    
  ├─ .output/chrome-mv3/background.js               126.73 kB
  ├─ .output/chrome-mv3/chunks/popup-BxzUToPe.js    8.16 kB  
  ├─ .output/chrome-mv3/content-scripts/content.js  133.94 kB
  ├─ .output/chrome-mv3/icon/128.png                3.07 kB  
  ├─ .output/chrome-mv3/icon/16.png                 559 B    
  ├─ .output/chrome-mv3/icon/32.png                 916 B    
  ├─ .output/chrome-mv3/icon/48.png                 1.33 kB  
  ├─ .output/chrome-mv3/icon/96.png                 2.37 kB  
  └─ .output/chrome-mv3/wxt.svg                     1.07 kB  
Σ Total size: 279.83 kB                                              
[12:11:15] ✔ Opened browser in 1.252 s
server.currentOutput {
  manifest: {
    manifest_version: 3,
    name: 'wxt-starter',
    description: 'manifest.json description',
    version: '0.0.0',
    short_name: undefined,
    icons: {
      '16': 'icon/16.png',
      '32': 'icon/32.png',
      '48': 'icon/48.png',
      '96': 'icon/96.png',
      '128': 'icon/128.png'
    },
    commands: { 'wxt:reload-extension': [Object] },
    version_name: undefined,
    background: { type: undefined, service_worker: 'background.js' },
    action: {
      default_title: 'Default Popup Title',
      default_popup: 'popup.html'
    },
    host_permissions: [ '*://*.google.com/*', 'http://localhost/*' ],
    content_security_policy: {
      extension_pages: "script-src 'self' 'wasm-unsafe-eval' http://localhost:3000; object-src 'self';",
      sandbox: "script-src 'self' 'unsafe-inline' 'unsafe-eval' http://localhost:3000; sandbox allow-scripts allow-forms allow-popups allow-modals; child-src 'self';"
    },
    permissions: [ 'tabs', 'scripting' ]
  },
  steps: [
    { entrypoints: [Object], chunks: [Array] },
    { entrypoints: [Object], chunks: [Array] },
    { entrypoints: [Array], chunks: [Array] }
  ],
  publicAssets: [
    { type: 'asset', fileName: 'manifest.json' },
    { type: 'asset', fileName: 'wxt.svg' },
    { type: 'asset', fileName: 'icon/128.png' },
    { type: 'asset', fileName: 'icon/16.png' },
    { type: 'asset', fileName: 'icon/32.png' },
    { type: 'asset', fileName: 'icon/48.png' },
    { type: 'asset', fileName: 'icon/96.png' }
  ]
}
[12:11:31] ℹ Changed@: entrypoints/content.ts
[12:11:31] ✔ Reloaded: content
server.currentOutput {
  manifest: {
    manifest_version: 3,
    name: 'wxt-starter',
    description: 'manifest.json description',
    version: '0.0.0',
    short_name: undefined,
    icons: {
      '16': 'icon/16.png',
      '32': 'icon/32.png',
      '48': 'icon/48.png',
      '96': 'icon/96.png',
      '128': 'icon/128.png'
    },
    commands: { 'wxt:reload-extension': [Object] },
    version_name: undefined,
    background: { type: undefined, service_worker: 'background.js' },
    action: {
      default_title: 'Default Popup Title',
      default_popup: 'popup.html'
    },
    host_permissions: [ '*://*.google.com/*', 'http://localhost/*' ],
    content_security_policy: {
      extension_pages: "script-src 'self' 'wasm-unsafe-eval' http://localhost:3000; object-src 'self';",
      sandbox: "script-src 'self' 'unsafe-inline' 'unsafe-eval' http://localhost:3000; sandbox allow-scripts allow-forms allow-popups allow-modals; child-src 'self';"
    },
    permissions: [ 'tabs', 'scripting' ]
  },
  steps: [
    { entrypoints: [Object], chunks: [Array] },
    { entrypoints: [Array], chunks: [Array] },
    { entrypoints: [Object], chunks: [Array] }
  ],
  publicAssets: [
    { type: 'asset', fileName: 'manifest.json' },
    { type: 'asset', fileName: 'wxt.svg' },
    { type: 'asset', fileName: 'icon/128.png' },
    { type: 'asset', fileName: 'icon/16.png' },
    { type: 'asset', fileName: 'icon/32.png' },
    { type: 'asset', fileName: 'icon/48.png' },
    { type: 'asset', fileName: 'icon/96.png' }
  ]
}
[12:11:35] ℹ Changed@: entrypoints/content.ts
[12:11:36] ✔ Reloaded: content
```