### PR TITLE
feat: continuous publish using pkg.pr.new

### DIFF
--- a/.github/workflows/pkg.pr.new.yml
+++ b/.github/workflows/pkg.pr.new.yml
@@ -9,22 +9,9 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
-
+    runs-on: ubuntu-22.04
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      - run: corepack enable
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 20
-          cache: 'pnpm'
-
-      - name: Install dependencies
-        run: pnpm install
-
-      - name: Build
-        run: pnpm -r build
-
-      - run: pnpx pkg-pr-new publish './packages/*'
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/setup
+      - run: pnpm buildc all
+      - run: pnpx pkg-pr-new publish --compact './packages/*'

--- a/.github/workflows/pkg.pr.new.yml
+++ b/.github/workflows/pkg.pr.new.yml
@@ -1,5 +1,11 @@
-name: Publish Any Commit
-on: [push, pull_request]
+name: Continuous Publish
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
 
 jobs:
   build:

--- a/.github/workflows/pkg.pr.new.yml
+++ b/.github/workflows/pkg.pr.new.yml
@@ -1,0 +1,24 @@
+name: Publish Any Commit
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - run: corepack enable
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: Build
+        run: pnpm build
+
+      - run: pnpx pkg-pr-new publish './packages/*'

--- a/.github/workflows/pkg.pr.new.yml
+++ b/.github/workflows/pkg.pr.new.yml
@@ -19,6 +19,6 @@ jobs:
         run: pnpm install
 
       - name: Build
-        run: pnpm build
+        run: pnpm -r build
 
       - run: pnpx pkg-pr-new publish './packages/*'


### PR DESCRIPTION
This PR will enable continuous publish wxt packages for every commit & PR on main automatically, instead of publishing it manually using npm command. It would be super easy and fast for testing locally, just update package version pointed to specific commit. It works in my fork, result like this ⬇️

<img width="1005" alt="image" src="https://github.com/user-attachments/assets/7816b7d1-b60b-4fb6-b7c3-02f949b3d145">

All u need to do is [install the Github Application](https://github.com/apps/pkg-pr-new).

Detail see https://github.com/stackblitz-labs/pkg.pr.new
