### PR TITLE
chore: Cleanup leftover E2E test artifacts 

### DIFF
--- a/packages/wxt/vitest.config.ts
+++ b/packages/wxt/vitest.config.ts
@@ -6,12 +6,12 @@ export default defineConfig({
   test: {
     mockReset: true,
     restoreMocks: true,
-    setupFiles: ['vitest.setup.ts'],
     testTimeout: 120e3,
     coverage: {
       include: ['src/**'],
       exclude: ['**/dist', '**/__tests__', 'src/utils/testing'],
     },
+    globalSetup: ['./vitest.globalSetup.ts'],
   },
   server: {
     watch: {

--- a/packages/wxt/vitest.globalSetup.ts
+++ b/packages/wxt/vitest.globalSetup.ts
@@ -1,27 +1,19 @@
-import { rm } from 'fs/promises';
-import { existsSync } from 'fs';
-import consola from 'consola';
+import { exists, rm } from 'fs-extra';
 
-let teardownHappened = false;
+let setupHappened = false;
 
 export async function setup() {
+  if (setupHappened) {
+    throw new Error('setup called twice');
+  }
+
+  setupHappened = true;
+
   // @ts-expect-error
   globalThis.__ENTRYPOINT__ = 'test';
-}
-
-export async function teardown() {
-  if (teardownHappened) {
-    throw new Error('teardown called twice');
-  }
-  teardownHappened = true;
 
   const e2eDistPath = './e2e/dist/';
-  if (existsSync(e2eDistPath)) {
-    try {
-      await rm(e2eDistPath, { recursive: true, force: true });
-      consola.info(`cleaned up ${e2eDistPath}`);
-    } catch (error) {
-      consola.error(error);
-    }
+  if (await exists(e2eDistPath)) {
+    await rm(e2eDistPath, { recursive: true, force: true });
   }
 }

--- a/packages/wxt/vitest.globalSetup.ts
+++ b/packages/wxt/vitest.globalSetup.ts
@@ -1,0 +1,27 @@
+import { rm } from 'fs/promises';
+import { existsSync } from 'fs';
+import consola from 'consola';
+
+let teardownHappened = false;
+
+export async function setup() {
+  // @ts-expect-error
+  globalThis.__ENTRYPOINT__ = 'test';
+}
+
+export async function teardown() {
+  if (teardownHappened) {
+    throw new Error('teardown called twice');
+  }
+  teardownHappened = true;
+
+  const e2eDistPath = './e2e/dist/';
+  if (existsSync(e2eDistPath)) {
+    try {
+      await rm(e2eDistPath, { recursive: true, force: true });
+      consola.info(`cleaned up ${e2eDistPath}`);
+    } catch (error) {
+      consola.error(error);
+    }
+  }
+}

--- a/packages/wxt/vitest.setup.ts
+++ b/packages/wxt/vitest.setup.ts
@@ -1,2 +1,0 @@
-// @ts-expect-error
-globalThis.__ENTRYPOINT__ = 'test';


### PR DESCRIPTION
Separated from #966 .

Cleanup the `e2e/dist` after all tests.