### PR TITLE
feat: Use `@types/chrome` for config manifest type

### DIFF
--- a/packages/wxt/e2e/tests/user-config.test.ts
+++ b/packages/wxt/e2e/tests/user-config.test.ts
@@ -74,6 +74,7 @@ describe('User Config', () => {
     );
 
     await project.build({
+      // Specifically setting an invalid field for the test - it should show up in the snapshot
       manifest: ({ manifestVersion, command }) => ({
         example_customization: [String(manifestVersion), command],
       }),

--- a/packages/wxt/e2e/tests/user-config.test.ts
+++ b/packages/wxt/e2e/tests/user-config.test.ts
@@ -74,7 +74,6 @@ describe('User Config', () => {
     );
 
     await project.build({
-      // @ts-expect-error: Specifically setting an invalid field for the test - it should show up in the snapshot
       manifest: ({ manifestVersion, command }) => ({
         example_customization: [String(manifestVersion), command],
       }),

--- a/packages/wxt/package.json
+++ b/packages/wxt/package.json
@@ -81,6 +81,7 @@
     "prepack": "pnpm build"
   },
   "dependencies": {
+    "@types/chrome": "^0.0.269",
     "@aklinker1/rollup-plugin-visualizer": "5.12.0",
     "@types/webextension-polyfill": "^0.10.7",
     "@webext-core/fake-browser": "^1.3.1",
@@ -128,7 +129,6 @@
   "devDependencies": {
     "@aklinker1/check": "^1.4.5",
     "@faker-js/faker": "^8.4.1",
-    "@types/chrome": "^0.0.269",
     "@types/fs-extra": "^11.0.4",
     "@types/lodash.merge": "^4.6.9",
     "@types/natural-compare": "^1.4.3",
@@ -146,9 +146,6 @@
     "unbuild": "^2.0.0",
     "vitest": "^2.0.4",
     "vitest-plugin-random-seed": "^1.1.0"
-  },
-  "peerDependencies": {
-    "@types/chrome": "*"
   },
   "peerDependenciesMeta": {
     "@types/chrome": {

--- a/packages/wxt/src/types.ts
+++ b/packages/wxt/src/types.ts
@@ -832,7 +832,7 @@ export type ResolvedPerBrowserOptions<T, TOmitted extends keyof T = never> = {
  */
 export type UserManifest = Partial<
   Omit<
-    Manifest.WebExtensionManifest,
+    chrome.runtime.ManifestV3,
     | 'background'
     | 'chrome_url_overrides'
     | 'devtools_page'

--- a/packages/wxt/src/types.ts
+++ b/packages/wxt/src/types.ts
@@ -833,6 +833,7 @@ export type ResolvedPerBrowserOptions<T, TOmitted extends keyof T = never> = {
 export type UserManifest = Partial<
   Omit<
     chrome.runtime.ManifestV3,
+    | 'action'
     | 'background'
     | 'chrome_url_overrides'
     | 'devtools_page'
@@ -841,7 +842,34 @@ export type UserManifest = Partial<
     | 'options_ui'
     | 'sandbox'
   >
->;
+> & {
+  // Add any Browser-specific or MV2 properties that WXT supports here
+  action?: chrome.runtime.ManifestV3['action'] & {
+    browser_style?: boolean;
+  };
+  browser_action?: chrome.runtime.ManifestV2['browser_action'] & {
+    browser_style?: boolean;
+  };
+  page_action?: chrome.runtime.ManifestV2['page_action'] & {
+    browser_style?: boolean;
+  };
+  browser_specific_settings?: {
+    gecko?: {
+      id?: string;
+      strict_min_version?: string;
+      strict_max_version?: string;
+      update_url?: string;
+    };
+    gecko_android?: {
+      strict_min_version?: string;
+      strict_max_version?: string;
+    };
+    safari?: {
+      strict_min_version?: string;
+      strict_max_version?: string;
+    };
+  };
+};
 
 export type UserManifestFn = (
   env: ConfigEnv,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -266,6 +266,9 @@ importers:
       '@aklinker1/rollup-plugin-visualizer':
         specifier: 5.12.0
         version: 5.12.0(rollup@4.19.0)
+      '@types/chrome':
+        specifier: ^0.0.269
+        version: 0.0.269
       '@types/webextension-polyfill':
         specifier: ^0.10.7
         version: 0.10.7
@@ -399,9 +402,6 @@ importers:
       '@faker-js/faker':
         specifier: ^8.4.1
         version: 8.4.1
-      '@types/chrome':
-        specifier: ^0.0.269
-        version: 0.0.269
       '@types/fs-extra':
         specifier: ^11.0.4
         version: 11.0.4


### PR DESCRIPTION
This closes #521

Properties like `key`, which were missing before, are now typed properly.

I am NOT marking this as a breaking change because the only change is to types... the runtime behavior hasn't changed. If this breaks peoples types, I'll fix them by adding custom typings.