### PR TITLE
fix: fix config manifest type

### DIFF
--- a/packages/wxt/src/types.ts
+++ b/packages/wxt/src/types.ts
@@ -839,7 +839,9 @@ export type UserManifest = {
     | 'manifest_version'
     | 'options_page'
     | 'options_ui'
+    | 'permissions'
     | 'sandbox'
+    | 'web_accessible_resources'
     ? never
     : key]?: chrome.runtime.ManifestV3[key];
 } & {
@@ -869,6 +871,13 @@ export type UserManifest = {
       strict_max_version?: string;
     };
   };
+  permissions?: (
+    | chrome.runtime.ManifestPermissions
+    | (string & Record<never, never>)
+  )[];
+  web_accessible_resources?:
+    | string[]
+    | chrome.runtime.ManifestV3['web_accessible_resources'];
 };
 
 export type UserManifestFn = (

--- a/packages/wxt/src/types.ts
+++ b/packages/wxt/src/types.ts
@@ -830,9 +830,8 @@ export type ResolvedPerBrowserOptions<T, TOmitted extends keyof T = never> = {
  * Manifest customization available in the `wxt.config.ts` file. You cannot configure entrypoints
  * here, they are configured inline.
  */
-export type UserManifest = Partial<
-  Omit<
-    chrome.runtime.ManifestV3,
+export type UserManifest = {
+  [key in keyof chrome.runtime.ManifestV3 as key extends
     | 'action'
     | 'background'
     | 'chrome_url_overrides'
@@ -841,8 +840,9 @@ export type UserManifest = Partial<
     | 'options_page'
     | 'options_ui'
     | 'sandbox'
-  >
-> & {
+    ? never
+    : key]?: chrome.runtime.ManifestV3[key];
+} & {
   // Add any Browser-specific or MV2 properties that WXT supports here
   action?: chrome.runtime.ManifestV3['action'] & {
     browser_style?: boolean;


### PR DESCRIPTION
This PR fixes types from #969

Because Chrome's manifest types have an index signature `[key: string]: any`, `Omit<chrome.runtime.ManifestV3, ...>` becomes

```ts
{
  [x: string]: any;
  [x: number]: any;
}
```

and only the added properties remain in `UserManifest`