### PR TITLE
chore(package): set type to "module" for Svelte template

### DIFF
--- a/templates/svelte/package.json
+++ b/templates/svelte/package.json
@@ -3,6 +3,7 @@
   "description": "manifest.json description",
   "private": true,
   "version": "0.0.0",
+  "type": "module",
   "scripts": {
     "dev": "wxt",
     "dev:firefox": "wxt -b firefox",


### PR DESCRIPTION
When adding shadcn-svelte, I discovered that the template project's type was not set to "module," causing errors when using "export default" in postcss.js. Since ESM is now widely popular, shouldn't setting "type: module" by default be fine?