### PR TITLE
docs: examples reference outDir vs. outputDir

### DIFF
--- a/docs/guide/go-further/reusable-modules.md
+++ b/docs/guide/go-further/reusable-modules.md
@@ -139,7 +139,7 @@ export default defineWxtModule({
       name: 'changelog',
       // Point to the "modules/changelog.html" file
       inputPath: resolve(__dirname, 'changelog.html'),
-      outputDir: wxt.config.outputDir,
+      outputDir: wxt.config.outDir,
       options: {},
     });
   },

--- a/packages/wxt/src/modules.ts
+++ b/packages/wxt/src/modules.ts
@@ -47,7 +47,7 @@ export function defineWxtModule<TOptions extends WxtModuleOptions>(
  *     type: "content-script",
  *     name: "some-name",
  *     inputPath: entrypointPath,
- *     outputDir: wxt.config.outputDir,
+ *     outputDir: wxt.config.outDir,
  *     options: await wxt.builder.importEntrypoint(entrypointPath),
  *   });
  * });


### PR DESCRIPTION
The value `wxt.config.outputDir` doesn't exist. By inspecting `wxt.config` the closest value I found was `outDir`.

This change does not effect any functionality. It's just markdown and comments that generate the docs.