### PR TITLE
docs: Correct the type example of `allFrames`

### DIFF
--- a/docs/guide/directory-structure/entrypoints/content-scripts.md
+++ b/docs/guide/directory-structure/entrypoints/content-scripts.md
@@ -24,7 +24,7 @@ export default defineContentScript({
   excludeMatches: undefined | [],
   includeGlobs: undefined | [],
   excludeGlobs: undefined | [],
-  allFrames: undefined | [],
+  allFrames: undefined | true | false,
   runAt: undefined | 'document_start' | 'document_end' | 'document_idle',
   matchAboutBlank: undefined | true | false,
   matchOriginAsFallback: undefined | true | false,


### PR DESCRIPTION
The type of `allFrames` is a boolean, not an array.