### PR TITLE
docs: Add "social-media-copilot" to homepage

### DIFF
--- a/docs/.vitepress/components/UsingWxtSection.vue
+++ b/docs/.vitepress/components/UsingWxtSection.vue
@@ -40,6 +40,7 @@ const chromeExtensionIds = [
   'fonflmjnjbkigocpoommgmhljdpljain', // NiceTab - https://github.com/web-dahuyou/NiceTab
   'fcffekbnfcfdemeekijbbmgmkognnmkd', // Draftly for LinkedIn
   'nkndldfehcidpejfkokbeghpnlbppdmo', // YouTube Summarized - Summarize any YouTube video
+  'dbichmdlbjdeplpkhcejgkakobjbjalc', // 社媒助手 - https://github.com/iszhouhua/social-media-copilot
 ];
 
 const { data, err, isLoading } = useListExtensionDetails(chromeExtensionIds);


### PR DESCRIPTION
Add the new plugin "社媒助手" developed based on wxt。

chrome webstore: https://chromewebstore.google.com/detail/dbichmdlbjdeplpkhcejgkakobjbjalc

github: https://github.com/iszhouhua/social-media-copilot