### PR TITLE
docs: Add "ChatGPT Writer" to homepage

### DIFF
--- a/docs/.vitepress/components/UsingWxtSection.vue
+++ b/docs/.vitepress/components/UsingWxtSection.vue
@@ -42,6 +42,7 @@ const chromeExtensionIds = [
   'nkndldfehcidpejfkokbeghpnlbppdmo', // YouTube Summarized - Summarize any YouTube video
   'dbichmdlbjdeplpkhcejgkakobjbjalc', // 社媒助手 - https://github.com/iszhouhua/social-media-copilot
   'opepfpjeogkbgeigkbepobceinnfmjdd', // Dofollow Links for SEO
+  'pdnenlnelpdomajfejgapbdpmjkfpjkp', // ChatGPT Writer: Use AI on Any Site (GPT-4o, Claude, Gemini, and More)
 ];
 
 const { data, err, isLoading } = useListExtensionDetails(chromeExtensionIds);


### PR DESCRIPTION
We have recently migrated our popular browser extension, ChatGPT Writer (with over 700k downloads), from Plasmo to WXT and would like to showcase it in your portfolio. We also wrote about our migration process, which you can read here: https://chatgptwriter.ai/blog/migrate-plasmo-to-wxt