### PR TITLE
fix: #1005 fixed, by updating type-definations to getItem method.

### DIFF
--- a/packages/wxt/src/storage.ts
+++ b/packages/wxt/src/storage.ts
@@ -461,7 +461,10 @@ export interface WxtStorage {
    * @example
    * await storage.getItem<number>("local:installDate");
    */
-  getItem<T>(key: StorageItemKey, opts?: GetItemOptions<T>): Promise<T | null>;
+  getItem<T, O extends GetItemOptions<T> = GetItemOptions<T>>(
+    key: StorageItemKey,
+    opts?: O,
+  ): Promise<O extends { fallback: infer F } ? F : T | null>;
   /**
    * Get multiple items from storage. The return order is guaranteed to be the same as the order
    * requested.


### PR DESCRIPTION
## Changes
Updated the `getItem` function to check if the fallback parameter is provided. If it is, the function will return a non-null type.
