### PR TITLE
fix: Reverse env files priority

### DIFF
--- a/packages/wxt/src/core/utils/env.ts
+++ b/packages/wxt/src/core/utils/env.ts
@@ -5,6 +5,6 @@ import { config } from 'dotenv';
  */
 export function loadEnv(mode: string) {
   return config({
-    path: [`.env`, `.env.local`, `.env.${mode}`, `.env.${mode}.local`],
+    path: [`.env.${mode}.local`, `.env.${mode}`, `.env.local`, `.env`],
   });
 }


### PR DESCRIPTION
Makes environment variables defined in`.env.*` files take precedence over variables defined in `.env` file.

From [`dotenv` docs](https://github.com/motdotla/dotenv?tab=readme-ov-file#path):

> Pass in multiple files as an array, and they will be parsed in order and combined with process.env (or option.processEnv, if set). The first value set for a variable will win, unless the options.override flag is set, in which case the last value set will win. If a value already exists in process.env and the options.override flag is NOT set, no changes will be made to that value.
