### PR TITLE
fix: Use directory name when `zip.name` and `package.json#name` are not provided

### DIFF
--- a/packages/wxt/src/core/zip.ts
+++ b/packages/wxt/src/core/zip.ts
@@ -28,7 +28,9 @@ export async function zip(config?: InlineConfig): Promise<string[]> {
 
   const projectName =
     wxt.config.zip.name ??
-    safeFilename((await getPackageJson())?.name || path.dirname(process.cwd()));
+    safeFilename(
+      (await getPackageJson())?.name || path.basename(process.cwd()),
+    );
   const applyTemplate = (template: string): string =>
     template
       .replaceAll('{{name}}', projectName)


### PR DESCRIPTION
Addresses issue found in https://discord.com/channels/1212416027611365476/1290394666860019794/1290546365335605338