### PR TITLE
[UPDATE] error friendly messages for null and undefined values

### DIFF
--- a/packages/i18n/src/__tests__/build.test.ts
+++ b/packages/i18n/src/__tests__/build.test.ts
@@ -161,4 +161,17 @@ describe('Built Tools', () => {
     );
     expect(mockWriteFile).toBeCalledWith('output.d.ts', expectedDts, 'utf8');
   });
+
+  it('should throw an error if messages file contains null or undefined', async () => {
+    const invalidFileContent = stringifyYAML({
+      simple: 'example',
+      invalidField: null,
+    });
+
+    mockReadFile.mockResolvedValue(invalidFileContent);
+
+    await expect(parseMessagesFile('invalid.yml')).rejects.toThrowError(
+      'Messages file should not contain `null` (found at "invalidField")',
+    );
+  });
 });

--- a/packages/i18n/src/build.ts
+++ b/packages/i18n/src/build.ts
@@ -166,6 +166,11 @@ function _parseMessagesObject(
       ];
     }
     case 'object':
+      if ([null, undefined].includes(object)) {
+        throw new Error(
+          `While parsing the @wxt-dev/i18n package has found that one of the values in one of your translation files is null or undefined. You may have wanted this value to be transalted from the original please test as necessary`,
+        );
+      }
       if (Array.isArray(object))
         return object.flatMap((item, i) =>
           _parseMessagesObject(path.concat(String(i)), item, depth + 1),

--- a/packages/i18n/src/build.ts
+++ b/packages/i18n/src/build.ts
@@ -168,7 +168,7 @@ function _parseMessagesObject(
     case 'object':
       if ([null, undefined].includes(object)) {
         throw new Error(
-          `While parsing the @wxt-dev/i18n package has found that one of the values in one of your translation files is null or undefined. You may have wanted this value to be transalted from the original please test as necessary`,
+          `Messages file should not contain \`${object}\` (found at "${path.join('.')}")`,
         );
       }
       if (Array.isArray(object))


### PR DESCRIPTION
You may run your i18n files through ai and ai may not be perfect it may introduce undefined or null values this changes gives more human friendly output for the developer to more easily fix the problem