### PR TITLE
fix!: Remove invalid options argument

### DIFF
--- a/packages/i18n/src/__tests__/index.test.ts
+++ b/packages/i18n/src/__tests__/index.test.ts
@@ -27,7 +27,7 @@ describe('createI18n', () => {
 
     expect(actual).toBe(expectedValue);
     expect(getMessageMock).toBeCalledTimes(1);
-    expect(getMessageMock).toBeCalledWith(expectedKey, undefined);
+    expect(getMessageMock).toBeCalledWith(expectedKey);
   });
 
   it.each([
@@ -54,13 +54,13 @@ describe('createI18n', () => {
 
       expect(actual).toBe(expected);
       expect(getMessageMock).toBeCalledTimes(1);
-      expect(getMessageMock).toBeCalledWith(key, [String(count)], undefined);
+      expect(getMessageMock).toBeCalledWith(key, [String(count)]);
     },
   );
 
   it('should allow overriding the plural substitutions', () => {
     const i18n = createI18n();
     i18n.t('key', 3, ['custom']);
-    expect(getMessageMock).toBeCalledWith('key', ['custom'], undefined);
+    expect(getMessageMock).toBeCalledWith('key', ['custom']);
   });
 });

--- a/packages/i18n/src/__tests__/index.test.ts
+++ b/packages/i18n/src/__tests__/index.test.ts
@@ -1,6 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { createI18n } from '../index';
-import { GetMessageOptions } from '../types';
 
 const getMessageMock = vi.fn();
 
@@ -63,20 +62,5 @@ describe('createI18n', () => {
     const i18n = createI18n();
     i18n.t('key', 3, ['custom']);
     expect(getMessageMock).toBeCalledWith('key', ['custom'], undefined);
-  });
-
-  it('should pass options into browser.i18n.getMessage', () => {
-    const i18n = createI18n();
-    const options: GetMessageOptions = {
-      escapeLt: true,
-    };
-
-    i18n.t('key', options);
-    i18n.t('key', [''], options);
-    i18n.t('key', 1, options);
-    i18n.t('key', 1, [''], options);
-    getMessageMock.mock.calls.forEach((call) => {
-      expect(call.pop()).toEqual(options);
-    });
   });
 });

--- a/packages/i18n/src/__tests__/types.test.ts
+++ b/packages/i18n/src/__tests__/types.test.ts
@@ -22,13 +22,9 @@ describe('I18n Types', () => {
     describe('t', () => {
       it('should allow passing any combination of arguments', () => {
         i18n.t('any');
-        i18n.t('any', { escapeLt: true });
         i18n.t('any', ['one']);
-        i18n.t('any', ['one'], { escapeLt: true });
         i18n.t('any', ['one', 'two']);
-        i18n.t('any', ['one', 'two'], { escapeLt: true });
         i18n.t('any', n, ['one', 'two']);
-        i18n.t('any', n, ['one', 'two'], { escapeLt: true });
       });
     });
   });
@@ -46,7 +42,6 @@ describe('I18n Types', () => {
     describe('t', () => {
       it('should only allow passing valid combinations of arguments', () => {
         i18n.t('simple');
-        i18n.t('simple', { escapeLt: true });
         // @ts-expect-error
         i18n.t('simple', []);
         // @ts-expect-error
@@ -55,7 +50,6 @@ describe('I18n Types', () => {
         i18n.t('simple', n);
 
         i18n.t('simpleSub1', ['one']);
-        i18n.t('simpleSub1', ['one'], { escapeLt: true });
         // @ts-expect-error
         i18n.t('simpleSub1');
         // @ts-expect-error
@@ -66,7 +60,6 @@ describe('I18n Types', () => {
         i18n.t('simpleSub1', n);
 
         i18n.t('simpleSub2', ['one', 'two']);
-        i18n.t('simpleSub2', ['one', 'two'], { escapeLt: true });
         // @ts-expect-error
         i18n.t('simpleSub2');
         // @ts-expect-error
@@ -77,7 +70,6 @@ describe('I18n Types', () => {
         i18n.t('simpleSub2', n);
 
         i18n.t('plural', n);
-        i18n.t('plural', n, { escapeLt: true });
         // @ts-expect-error
         i18n.t('plural');
         // @ts-expect-error
@@ -88,10 +80,8 @@ describe('I18n Types', () => {
         i18n.t('plural', n, ['sub']);
 
         i18n.t('pluralSub1', n);
-        i18n.t('pluralSub1', n, { escapeLt: true });
-        i18n.t('pluralSub1', n, undefined, { escapeLt: true });
+        i18n.t('pluralSub1', n, undefined);
         i18n.t('pluralSub1', n, ['one']);
-        i18n.t('pluralSub1', n, ['one'], { escapeLt: true });
         // @ts-expect-error
         i18n.t('pluralSub1');
         // @ts-expect-error
@@ -102,7 +92,6 @@ describe('I18n Types', () => {
         i18n.t('pluralSub1', n, ['one', 'two']);
 
         i18n.t('pluralSub2', n, ['one', 'two']);
-        i18n.t('pluralSub2', n, ['one', 'two'], { escapeLt: true });
         // @ts-expect-error
         i18n.t('pluralSub2');
         // @ts-expect-error

--- a/packages/i18n/src/index.ts
+++ b/packages/i18n/src/index.ts
@@ -6,7 +6,6 @@ import {
   DefaultI18nStructure,
   I18n,
   Substitution,
-  GetMessageOptions,
 } from './types';
 
 export function createI18n<
@@ -16,7 +15,6 @@ export function createI18n<
     // Resolve args
     let sub: Substitution[] | undefined;
     let count: number | undefined;
-    let options: GetMessageOptions | undefined;
     args.forEach((arg, i) => {
       if (arg == null) {
         // ignore nullish args
@@ -24,8 +22,6 @@ export function createI18n<
         count = arg;
       } else if (Array.isArray(arg)) {
         sub = arg;
-      } else if (typeof arg === 'object') {
-        options = arg;
       } else {
         throw Error(
           `Unknown argument at index ${i}. Must be a number for pluralization, substitution array, or options object.`,
@@ -43,18 +39,9 @@ export function createI18n<
     if (sub?.length) {
       // Convert all substitutions to strings
       const stringSubs = sub?.map((sub) => String(sub));
-      message = chrome.i18n.getMessage(
-        key.replaceAll('.', '_'),
-        stringSubs,
-        // @ts-ignore - @types/chrome doesn't type the options object, but it's there
-        options,
-      );
+      message = chrome.i18n.getMessage(key.replaceAll('.', '_'), stringSubs);
     } else {
-      message = chrome.i18n.getMessage(
-        key.replaceAll('.', '_'),
-        // @ts-ignore - @types/chrome doesn't type the options object, but it's there
-        options,
-      );
+      message = chrome.i18n.getMessage(key.replaceAll('.', '_'));
     }
     if (!message) {
       console.warn(`[i18n] Message not found: "${key}"`);

--- a/packages/i18n/src/types.ts
+++ b/packages/i18n/src/types.ts
@@ -29,7 +29,6 @@ export type TFunction<T extends I18nStructure> = {
   <K extends keyof T>(
     // prettier-ignore
     key: K & { [P in keyof T]: T[P] extends { plural: false; substitutions: 0 } ? P : never; }[keyof T],
-    options?: GetMessageOptions,
   ): string;
 
   // Non-plural with substitutions
@@ -39,7 +38,6 @@ export type TFunction<T extends I18nStructure> = {
     substitutions: T[K] extends I18nFeatures
       ? SubstitutionTuple<T[K]['substitutions']>
       : never,
-    options?: GetMessageOptions,
   ): string;
 
   // Plural with 1 substitution
@@ -48,7 +46,6 @@ export type TFunction<T extends I18nStructure> = {
     key: K & { [P in keyof T]: T[P] extends { plural: true; substitutions: 1 } ? P : never; }[keyof T],
     n: number,
     substitutions?: SubstitutionTuple<1>,
-    options?: GetMessageOptions,
   ): string;
 
   // Plural without substitutions
@@ -56,7 +53,6 @@ export type TFunction<T extends I18nStructure> = {
     // prettier-ignore
     key: K & { [P in keyof T]: T[P] extends { plural: true; substitutions: 0 | 1 } ? P : never; }[keyof T],
     n: number,
-    options?: GetMessageOptions,
   ): string;
 
   // Plural with substitutions
@@ -67,7 +63,6 @@ export type TFunction<T extends I18nStructure> = {
     substitutions: T[K] extends I18nFeatures
       ? SubstitutionTuple<T[K]['substitutions']>
       : never,
-    options?: GetMessageOptions,
   ): string;
 };
 
@@ -76,14 +71,5 @@ export interface I18n<T extends DefaultI18nStructure> {
 }
 
 export type Substitution = string | number;
-
-export interface GetMessageOptions {
-  /**
-   * Escape `<` in translation to `&lt;`. This applies only to the message itself, not to the placeholders. Developers might want to use this if the translation is used in an HTML context. Closure Templates used with Closure Compiler generate this automatically.
-   *
-   * See https://developer.chrome.com/docs/extensions/reference/api/i18n#type-getMessage-options
-   */
-  escapeLt?: boolean;
-}
 
 type SubstitutionCount = 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9;


### PR DESCRIPTION
Remove the final `options` argument after the substitutions array. It's documentation without Chrome was minimal, and Firefox errored out when passing it to `browser.i18n.getMessage`.