### PR TITLE
feat(config): Add `outDirTemplate` for customizing output directory structure

### DIFF
--- a/packages/wxt/e2e/tests/user-config.test.ts
+++ b/packages/wxt/e2e/tests/user-config.test.ts
@@ -130,4 +130,31 @@ describe('User Config', () => {
       await project.fileExists('.custom-output/chrome-mv3/background.js'),
     ).toBe(true);
   });
+
+  it('should respect outDirTemplate', async () => {
+    const project = new TestProject();
+    project.setConfigFileConfig({
+      srcDir: 'src',
+      outDirTemplate:
+        'test-{{browser}}-mv{{manifestVersion}}-{{mode}}{{modeSuffix}}-{{command}}',
+    });
+    project.addFile(
+      'src/entrypoints/background.ts',
+      `export default defineBackground(
+        () => console.log('Hello background'),
+      );`,
+    );
+
+    await project.build();
+
+    expect(
+      await project.fileExists('.output/test-chrome-mv3-production-build'),
+    ).toBe(true);
+
+    await project.build({ mode: 'development' });
+
+    expect(
+      await project.fileExists('.output/test-chrome-mv3-development-dev-build'),
+    ).toBe(true);
+  });
 });

--- a/packages/wxt/src/core/resolve-config.ts
+++ b/packages/wxt/src/core/resolve-config.ts
@@ -99,17 +99,17 @@ export async function resolveConfig(
   let outDirTemplate =
     mergedConfig.outDirTemplate ?? `${browser}-mv${manifestVersion}`;
   //* Resolve all variables in the template
-  outDirTemplate = outDirTemplate.replace('{{browser}}', browser);
-  outDirTemplate = outDirTemplate.replace(
+  outDirTemplate = outDirTemplate.replaceAll('{{browser}}', browser);
+  outDirTemplate = outDirTemplate.replaceAll(
     '{{manifestVersion}}',
     manifestVersion.toString(),
   );
-  outDirTemplate = outDirTemplate.replace(
+  outDirTemplate = outDirTemplate.replaceAll(
     '{{modeSuffix}}',
     `${mode === 'production' ? '' : mode === 'development' ? '-dev' : '-${mode}'}`,
   );
-  outDirTemplate = outDirTemplate.replace('{{mode}}', mode);
-  outDirTemplate = outDirTemplate.replace('{{command}}', command);
+  outDirTemplate = outDirTemplate.replaceAll('{{mode}}', mode);
+  outDirTemplate = outDirTemplate.replaceAll('{{command}}', command);
 
   const outDir = path.resolve(outBaseDir, outDirTemplate);
   const reloadCommand = mergedConfig.dev?.reloadCommand ?? 'Alt+R';

--- a/packages/wxt/src/core/resolve-config.ts
+++ b/packages/wxt/src/core/resolve-config.ts
@@ -96,20 +96,17 @@ export async function resolveConfig(
   const publicDir = path.resolve(srcDir, mergedConfig.publicDir ?? 'public');
   const typesDir = path.resolve(wxtDir, 'types');
   const outBaseDir = path.resolve(root, mergedConfig.outDir ?? '.output');
-  let outDirTemplate =
-    mergedConfig.outDirTemplate ?? `${browser}-mv${manifestVersion}`;
-  //* Resolve all variables in the template
-  outDirTemplate = outDirTemplate.replaceAll('{{browser}}', browser);
-  outDirTemplate = outDirTemplate.replaceAll(
-    '{{manifestVersion}}',
-    manifestVersion.toString(),
-  );
-  outDirTemplate = outDirTemplate.replaceAll(
-    '{{modeSuffix}}',
-    `${mode === 'production' ? '' : mode === 'development' ? '-dev' : '-${mode}'}`,
-  );
-  outDirTemplate = outDirTemplate.replaceAll('{{mode}}', mode);
-  outDirTemplate = outDirTemplate.replaceAll('{{command}}', command);
+  const modeSuffixes: Record<string, string | undefined> = {
+    production: "",
+    development: "-dev",
+  };
+  const outDirTemplate = (mergedConfig.outDirTemplate ?? `${browser}-mv${manifestVersion}`)
+    // Resolve all variables in the template
+    .replaceAll('{{browser}}', browser)
+    .replaceAll('{{manifestVersion}}', manifestVersion.toString())
+    .replaceAll('{{modeSuffix}}', `-${modeSuffixes[mode] ?? mode}`)
+    .replaceAll('{{mode}}', mode)
+    .replaceAll('{{command}}', command);
 
   const outDir = path.resolve(outBaseDir, outDirTemplate);
   const reloadCommand = mergedConfig.dev?.reloadCommand ?? 'Alt+R';

--- a/packages/wxt/src/core/resolve-config.ts
+++ b/packages/wxt/src/core/resolve-config.ts
@@ -96,7 +96,22 @@ export async function resolveConfig(
   const publicDir = path.resolve(srcDir, mergedConfig.publicDir ?? 'public');
   const typesDir = path.resolve(wxtDir, 'types');
   const outBaseDir = path.resolve(root, mergedConfig.outDir ?? '.output');
-  const outDir = path.resolve(outBaseDir, `${browser}-mv${manifestVersion}`);
+  let outDirTemplate =
+    mergedConfig.outDirTemplate ?? `${browser}-mv${manifestVersion}`;
+  //* Resolve all variables in the template
+  outDirTemplate = outDirTemplate.replace('{{browser}}', browser);
+  outDirTemplate = outDirTemplate.replace(
+    '{{manifestVersion}}',
+    manifestVersion.toString(),
+  );
+  outDirTemplate = outDirTemplate.replace(
+    '{{modeSuffix}}',
+    `${mode === 'production' ? '' : mode === 'development' ? '-dev' : '-${mode}'}`,
+  );
+  outDirTemplate = outDirTemplate.replace('{{mode}}', mode);
+  outDirTemplate = outDirTemplate.replace('{{command}}', command);
+
+  const outDir = path.resolve(outBaseDir, outDirTemplate);
   const reloadCommand = mergedConfig.dev?.reloadCommand ?? 'Alt+R';
 
   const runnerConfig = await loadConfig<ExtensionRunnerConfig>({

--- a/packages/wxt/src/core/resolve-config.ts
+++ b/packages/wxt/src/core/resolve-config.ts
@@ -97,14 +97,16 @@ export async function resolveConfig(
   const typesDir = path.resolve(wxtDir, 'types');
   const outBaseDir = path.resolve(root, mergedConfig.outDir ?? '.output');
   const modeSuffixes: Record<string, string | undefined> = {
-    production: "",
-    development: "-dev",
+    production: '',
+    development: '-dev',
   };
-  const outDirTemplate = (mergedConfig.outDirTemplate ?? `${browser}-mv${manifestVersion}`)
+  const outDirTemplate = (
+    mergedConfig.outDirTemplate ?? `${browser}-mv${manifestVersion}`
+  )
     // Resolve all variables in the template
     .replaceAll('{{browser}}', browser)
     .replaceAll('{{manifestVersion}}', manifestVersion.toString())
-    .replaceAll('{{modeSuffix}}', `-${modeSuffixes[mode] ?? mode}`)
+    .replaceAll('{{modeSuffix}}', modeSuffixes[mode] ?? `-${mode}`)
     .replaceAll('{{mode}}', mode)
     .replaceAll('{{command}}', command);
 

--- a/packages/wxt/src/types.ts
+++ b/packages/wxt/src/types.ts
@@ -54,6 +54,19 @@ export interface InlineConfig {
    */
   outDir?: string;
   /**
+   * Template string for customizing the output directory structure.
+   * Available variables:
+   * - {{browser}}: The target browser (e.g., 'chrome', 'firefox')
+   * - {{manifestVersion}}: The manifest version (e.g., 2 or 3)
+   * - {{mode}}: The build mode (e.g., 'development', 'production')
+   * - {{modeSuffix}}: A suffix based on the mode ('-dev' for development, '' for production)
+   * - {{command}}: The WXT command being run (e.g., 'build', 'serve')
+   *
+   * @example ".output/{{browser}}-mv{{manifestVersion}}{{modeSuffix}}"
+   * @default `{{browser}}-mv{{manifestVersion}}`
+   */
+  outDirTemplate?: string;
+  /**
    * > Only available when using the JS API. Not available in `wxt.config.ts` files
    *
    * Path to `wxt.config.ts` file or `false` to disable config file discovery.

--- a/packages/wxt/src/types.ts
+++ b/packages/wxt/src/types.ts
@@ -56,14 +56,14 @@ export interface InlineConfig {
   /**
    * Template string for customizing the output directory structure.
    * Available variables:
-   * - {{browser}}: The target browser (e.g., 'chrome', 'firefox')
-   * - {{manifestVersion}}: The manifest version (e.g., 2 or 3)
-   * - {{mode}}: The build mode (e.g., 'development', 'production')
-   * - {{modeSuffix}}: A suffix based on the mode ('-dev' for development, '' for production)
-   * - {{command}}: The WXT command being run (e.g., 'build', 'serve')
+   * - <span v-pre>`{{browser}}`</span>: The target browser (e.g., 'chrome', 'firefox')
+   * - <span v-pre>`{{manifestVersion}}`</span>: The manifest version (e.g., 2 or 3)
+   * - <span v-pre>`{{mode}}`</span>: The build mode (e.g., 'development', 'production')
+   * - <span v-pre>`{{modeSuffix}}`</span>: A suffix based on the mode ('-dev' for development, '' for production)
+   * - <span v-pre>`{{command}}`</span>: The WXT command being run (e.g., 'build', 'serve')
    *
    * @example "{{browser}}-mv{{manifestVersion}}{{modeSuffix}}"
-   * @default `{{browser}}-mv{{manifestVersion}}`
+   * @default <span v-pre>`"{{browser}}-mv{{manifestVersion}}"`</span>
    */
   outDirTemplate?: string;
   /**
@@ -75,7 +75,7 @@ export interface InlineConfig {
    */
   configFile?: string | false;
   /**
-   * Set to `true` to show debug logs. Overriden by the command line `--debug` option.
+   * Set to `true` to show debug logs. Overridden by the command line `--debug` option.
    *
    * @default false
    */
@@ -1247,7 +1247,7 @@ export interface Wxt {
    */
   pm: WxtPackageManager;
   /**
-   * If the dev server was started, it will be availble.
+   * If the dev server was started, it will be available.
    */
   server?: WxtDevServer;
   /**

--- a/packages/wxt/src/types.ts
+++ b/packages/wxt/src/types.ts
@@ -62,7 +62,7 @@ export interface InlineConfig {
    * - {{modeSuffix}}: A suffix based on the mode ('-dev' for development, '' for production)
    * - {{command}}: The WXT command being run (e.g., 'build', 'serve')
    *
-   * @example ".output/{{browser}}-mv{{manifestVersion}}{{modeSuffix}}"
+   * @example "{{browser}}-mv{{manifestVersion}}{{modeSuffix}}"
    * @default `{{browser}}-mv{{manifestVersion}}`
    */
   outDirTemplate?: string;


### PR DESCRIPTION
Closes #1069

This pull request introduces a new feature to allow customization of the output directory structure using a template string. The main changes include adding a new configuration option, updating the build logic to respect this new option, and adding tests to ensure the feature works as expected.

### New Feature: Customizable Output Directory Structure

* [`packages/wxt/src/types.ts`](diffhunk://#diff-d28c2725d1b8ea5238aee0b3d8e6c8aabdee0772ea03a560fcfe685561727f0cR56-R68): Added a new configuration option `outDirTemplate` to the `InlineConfig` interface, allowing users to define a template string for the output directory. This template can include variables such as `{{browser}}`, `{{manifestVersion}}`, `{{mode}}`, `{{modeSuffix}}`, and `{{command}}`.

* [`packages/wxt/src/core/resolve-config.ts`](diffhunk://#diff-ff0465c3a486d3ba187204149a25fc8f632c44d65da356dc04c0f2b268a71506L99-R114): Updated the `resolveConfig` function to process the `outDirTemplate` configuration option. The function now replaces the template variables with their actual values to determine the output directory path.

### Tests

* [`packages/wxt/e2e/tests/user-config.test.ts`](diffhunk://#diff-e72c055b1a82197dfebfc720e61c18602afc25b880f3fb2e6db184e1a6c23718R133-R159): Added a new test case to verify that the `outDirTemplate` configuration is respected during the build process. The test checks that the output directory matches the expected structure based on the template.