### PR TITLE
chore: Enable `extensionApi: chrome` in template projects

### DIFF
--- a/packages/wxt/src/types.ts
+++ b/packages/wxt/src/types.ts
@@ -329,7 +329,7 @@ export interface InlineConfig {
    * Which extension API to use.
    *
    * - `"webextension-polyfill"`: Use `browser` and types from [`webextension-polyfill`](https://www.npmjs.com/package/webextension-polyfill).
-   * - `"chrome"` (unstable): Use the regular `chrome` (or `browser` for Firefox/Safari) globals provided by the browser. Types provided by [`@types/chrome`](https://www.npmjs.com/package/@types/chrome), make sure to install the package or types won't work.
+   * - `"chrome"`: Use the regular `chrome` (or `browser` for Firefox/Safari) globals provided by the browser. Types provided by [`@types/chrome`](https://www.npmjs.com/package/@types/chrome).
    *
    * @default "webextension-polyfill"
    * @since 0.19.0

--- a/templates/react/wxt.config.ts
+++ b/templates/react/wxt.config.ts
@@ -2,5 +2,6 @@ import { defineConfig } from 'wxt';
 
 // See https://wxt.dev/api/config.html
 export default defineConfig({
+  extensionApi: 'chrome',
   modules: ['@wxt-dev/module-react'],
 });

--- a/templates/solid/wxt.config.ts
+++ b/templates/solid/wxt.config.ts
@@ -2,5 +2,6 @@ import { defineConfig } from 'wxt';
 
 // See https://wxt.dev/api/config.html
 export default defineConfig({
+  extensionApi: 'chrome',
   modules: ['@wxt-dev/module-solid'],
 });

--- a/templates/svelte/wxt.config.ts
+++ b/templates/svelte/wxt.config.ts
@@ -3,5 +3,6 @@ import { defineConfig } from 'wxt';
 // See https://wxt.dev/api/config.html
 export default defineConfig({
   srcDir: 'src',
+  extensionApi: 'chrome',
   modules: ['@wxt-dev/module-svelte'],
 });

--- a/templates/vanilla/wxt.config.ts
+++ b/templates/vanilla/wxt.config.ts
@@ -1,4 +1,6 @@
 import { defineConfig } from 'wxt';
 
 // See https://wxt.dev/api/config.html
-export default defineConfig({});
+export default defineConfig({
+  extensionApi: 'chrome',
+});

--- a/templates/vue/wxt.config.ts
+++ b/templates/vue/wxt.config.ts
@@ -2,5 +2,6 @@ import { defineConfig } from 'wxt';
 
 // See https://wxt.dev/api/config.html
 export default defineConfig({
+  extensionApi: 'chrome',
   modules: ['@wxt-dev/module-vue'],
 });


### PR DESCRIPTION
Goal here is to onboard more projects onto the API to make sure it works before switching the default for everyone