### PR TITLE
fix!: Add suffix to non-production output directories

### DIFF
--- a/packages/wxt/src/core/resolve-config.ts
+++ b/packages/wxt/src/core/resolve-config.ts
@@ -100,13 +100,15 @@ export async function resolveConfig(
     production: '',
     development: '-dev',
   };
+  const modeSuffix = modeSuffixes[mode] ?? `-${mode}`;
   const outDirTemplate = (
-    mergedConfig.outDirTemplate ?? `${browser}-mv${manifestVersion}`
+    mergedConfig.outDirTemplate ??
+    `${browser}-mv${manifestVersion}${modeSuffix}`
   )
     // Resolve all variables in the template
     .replaceAll('{{browser}}', browser)
     .replaceAll('{{manifestVersion}}', manifestVersion.toString())
-    .replaceAll('{{modeSuffix}}', modeSuffixes[mode] ?? `-${mode}`)
+    .replaceAll('{{modeSuffix}}', modeSuffix)
     .replaceAll('{{mode}}', mode)
     .replaceAll('{{command}}', command);
 

--- a/packages/wxt/src/types.ts
+++ b/packages/wxt/src/types.ts
@@ -62,8 +62,8 @@ export interface InlineConfig {
    * - <span v-pre>`{{modeSuffix}}`</span>: A suffix based on the mode ('-dev' for development, '' for production)
    * - <span v-pre>`{{command}}`</span>: The WXT command being run (e.g., 'build', 'serve')
    *
-   * @example "{{browser}}-mv{{manifestVersion}}{{modeSuffix}}"
-   * @default <span v-pre>`"{{browser}}-mv{{manifestVersion}}"`</span>
+   * @example "{{browser}}-mv{{manifestVersion}}"
+   * @default <span v-pre>`"{{browser}}-mv{{manifestVersion}}{{modeSuffix}}"`</span>
    */
   outDirTemplate?: string;
   /**


### PR DESCRIPTION
This is not being merged into `main`, but the `v0.20.0` staging branch.

---

BREAKING CHANGE: The build mode is now apart of the output directory:

- `--mode production` &rarr; `.output/chrome-mv3` (unchanged)
- `--mode development` &rarr;`.output/chrome-mv3-dev` (dev builds are output with the "-dev" suffix)
- `--mode other` &rarr;`.output/chrome-mv3-other` (all other build modes are output with the "-[mode]" suffix)


To revert back to the old behavior and output all builds to the same directory, set the `outDirTemplate` option:

```diff
// wxt.config.ts
export default defineConfig({
+ outDirTemplate: "{{browser}}-mv{{manifestVersion}}",
});
```

⚠️ ***If you use `--user-data-dir` in your runner config***, be aware that [`web-ext` is a little buggy when you change the output directory of an extension](https://github.com/wxt-dev/wxt/issues/1080). If you notice that your code isn't reloading properly after saving a file, uninstall the extension by hand and rerun the dev command.