### PR TITLE
docs: fix wrong anchor to "Environment Variables"

### DIFF
--- a/docs/guide/essentials/project-structure.md
+++ b/docs/guide/essentials/project-structure.md
@@ -35,7 +35,7 @@ Here's a brief summary of each of these files and directories:
 - `hooks/`: Auto-imported by default, contains hooks for React and Solid
 - `public/`: Contains any files you want to copy into the output folder as-is, without being processed by WXT
 - `utils/`: Auto-imported by default, contains generic utilities used throughout your project
-- `.env`: Contains [Environment Variables](/guide/essentials/config/runtime#environment-variables)
+- `.env`: Contains [Environment Variables](/guide/essentials/config/environment-variables)
 - `.env.publish`: Contains Environment Variables for [publishing](/guide/essentials/publishing)
 - `app.config.ts`: Contains [Runtime Config](/guide/essentials/config/runtime)
 - `package.json`: The standard file used by your package manager


### PR DESCRIPTION
As for now, when you click on the "Environment Variables" anchor on the
https://wxt.dev/guide/essentials/project-structure.html
doc page it will redirect you to
https://wxt.dev/guide/essentials/config/runtime.html#environment-variables

Notice the "#environment-variables" which might be a deprecated anchor for this doc.

This Pull-Request will correct the redirect to the actual "Environment Variables" doc page.