### PR TITLE
fix: Prevent app crashes from parse errors due to incomplete file saves

### DIFF
--- a/packages/i18n/src/module.ts
+++ b/packages/i18n/src/module.ts
@@ -158,7 +158,9 @@ export { type GeneratedI18nStructure }
     if (wxt.config.command === 'serve') {
       wxt.hooks.hookOnce('build:done', () => {
         const watcher = watch(localesDir);
-        watcher.on('change', updateLocalizations);
+        watcher.on('change', (path) => {
+          updateLocalizations(path).catch(wxt.logger.error);
+        });
       });
     }
   },


### PR DESCRIPTION
Editor autosave (triggered by delays or loss of focus) may save **incomplete files** if a user pauses to think or switches tabs, leading to parse failures in `updateLocalizations` during HMR. **Uncaught errors** in `updateLocalizations` then cause the whole app to crash, which is undesirable.

Error handling has now been added to prevent this.

Closes #1115 