### PR TITLE
docs: fix typo in introduction page

### DIFF
--- a/docs/guide/introduction.md
+++ b/docs/guide/introduction.md
@@ -5,7 +5,7 @@ WXT is a modern, open-source framework for building web extensions. Inspired by 
 - Provide an awesome [DX](https://about.gitlab.com/topics/devops/what-is-developer-experience/)
 - Provide first-class support for all major browsers
 
-Check out the [comparison](/guide/resources/compare) to see how WXT compares to other tools for building web extnesions.
+Check out the [comparison](/guide/resources/compare) to see how WXT compares to other tools for building web extensions.
 
 ## Prerequisites
 


### PR DESCRIPTION
fixes a small typo in [introduction page](https://wxt.dev/guide/introduction.html#:~:text=for%20building%20web-,extnesions,-.)