### PR TITLE
docs: fix incorrect syntax for MatchPattern

### DIFF
--- a/docs/guide/essentials/content-scripts.md
+++ b/docs/guide/essentials/content-scripts.md
@@ -602,7 +602,7 @@ export default defineContentScript({
   matches: ['*://*.youtube.com/*'],
   main(ctx) {
     ctx.addEventListener(window, 'wxt:locationchange', ({ newUrl }) => {
-      if (watchPattern.matches(newUrl)) mainWatch(ctx);
+      if (watchPattern.includes(newUrl)) mainWatch(ctx);
     });
   },
 });


### PR DESCRIPTION
## Context
Fix incorrect syntax for MatchPattern. Because MatchPattern doesn't have a 'matches' function