### PR TITLE
feat: automatically disable 'Show warning about Self-XSS when pasing code' in new chrome

### DIFF
--- a/packages/wxt/src/core/runners/web-ext.ts
+++ b/packages/wxt/src/core/runners/web-ext.ts
@@ -50,7 +50,10 @@ export function createWebExtRunner(): ExtensionRunner {
                 wxtUserConfig?.chromiumPref,
                 DEFAULT_CHROMIUM_PREFS,
               ),
-              args: wxtUserConfig?.chromiumArgs,
+              args: [
+                '--unsafely-disable-devtools-self-xss-warnings',
+                ...(wxtUserConfig?.chromiumArgs ?? []),
+              ],
             }),
       };
 


### PR DESCRIPTION
close https://github.com/wxt-dev/wxt/issues/435

Before
<img width="555" alt="image" src="https://github.com/user-attachments/assets/47345102-0aa6-44ec-af39-7bc03eb30730">

After
<img width="544" alt="image" src="https://github.com/user-attachments/assets/08de4a63-19c4-43f5-b088-71297b6093ba">

ref: https://developer.chrome.com/blog/self-xss#can_you_disable_it_for_test_automation