### PR TITLE
fix: Respect `configOrPath` for dev server

### DIFF
--- a/packages/unocss/src/index.ts
+++ b/packages/unocss/src/index.ts
@@ -28,7 +28,7 @@ export default defineWxtModule<UnoCSSOptions>({
     }
 
     wxt.hooks.hook('vite:devServer:extendConfig', (config) => {
-      config.plugins?.push(UnoCSS());
+      config.plugins?.push(UnoCSS(resolvedOptions.configOrPath));
     });
 
     wxt.hooks.hook('vite:build:extendConfig', async (entries, config) => {


### PR DESCRIPTION
CC @Timeraa . We forgot to add the parameter to the first plugin instance. Already have it for the other a couple of lines down.