### PR TITLE
fix: Add extension ID to event used to invalidate `ContentScriptContext`

### DIFF
--- a/packages/wxt/src/client/content-scripts/content-script-context.ts
+++ b/packages/wxt/src/client/content-scripts/content-script-context.ts
@@ -35,7 +35,9 @@ import { createLocationWatcher } from './location-watcher';
  * ```
  */
 export class ContentScriptContext implements AbortController {
-  private static SCRIPT_STARTED_MESSAGE_TYPE = 'wxt:content-script-started';
+  private static SCRIPT_STARTED_MESSAGE_TYPE = getUniqueEventName(
+    'wxt:content-script-started',
+  );
 
   private isTopFrame = window.self === window.top;
   private abortController: AbortController;


### PR DESCRIPTION
Before, all WXT extensions shared the same event name, meaning if you had multiple installed they would invalidate each other.

Now, the event includes the extension ID, so it only invalidates itself.