### PR TITLE
fix: Re-initialize WXT modules correctly during development

### DIFF
--- a/packages/wxt-demo/wxt.config.ts
+++ b/packages/wxt-demo/wxt.config.ts
@@ -25,7 +25,7 @@ export default defineConfig({
   },
   example: {
     a: 'a',
-    // @ts-expect-error: c is not defined, this should error out
+    // @ts-expect-error: c is not defined, this should be a type error, but it should show up in the module
     c: 'c',
   },
   unocss: {

--- a/packages/wxt/package.json
+++ b/packages/wxt/package.json
@@ -100,7 +100,7 @@
     "fast-glob": "^3.3.2",
     "filesize": "^10.1.6",
     "fs-extra": "^11.2.0",
-    "get-port": "^7.1.0",
+    "get-port-please": "^3.1.2",
     "giget": "^1.2.3",
     "hookable": "^5.5.3",
     "is-wsl": "^3.1.0",

--- a/packages/wxt/src/core/builders/vite/index.ts
+++ b/packages/wxt/src/core/builders/vite/index.ts
@@ -3,6 +3,7 @@ import {
   BuildStepOutput,
   Entrypoint,
   ResolvedConfig,
+  ServerInfo,
   WxtBuilder,
   WxtBuilderServer,
   WxtDevServer,
@@ -28,7 +29,7 @@ import { installSourcemapsSupport } from 'vite-node/source-map';
 export async function createViteBuilder(
   wxtConfig: ResolvedConfig,
   hooks: Hookable<WxtHooks>,
-  server?: WxtDevServer,
+  getDevServer?: () => WxtDevServer | undefined,
 ): Promise<WxtBuilder> {
   const vite = await import('vite');
 
@@ -65,12 +66,14 @@ export async function createViteBuilder(
       ignored: [`${wxtConfig.outBaseDir}/**`, `${wxtConfig.wxtDir}/**`],
     };
 
+    const devServer = getDevServer?.();
+
     config.plugins ??= [];
     config.plugins.push(
       wxtPlugins.download(wxtConfig),
-      wxtPlugins.devHtmlPrerender(wxtConfig, server),
+      wxtPlugins.devHtmlPrerender(wxtConfig, devServer),
       wxtPlugins.resolveVirtualModules(wxtConfig),
-      wxtPlugins.devServerGlobals(wxtConfig, server),
+      wxtPlugins.devServerGlobals(wxtConfig, devServer),
       wxtPlugins.tsconfigPaths(wxtConfig),
       wxtPlugins.noopBackground(),
       wxtPlugins.globals(wxtConfig),
@@ -193,7 +196,7 @@ export async function createViteBuilder(
   };
 
   /**
-   * Return the basic config for building a sinlge CSS entrypoint in [multi-page mode](https://vitejs.dev/guide/build.html#multi-page-app).
+   * Return the basic config for building a single CSS entrypoint in [multi-page mode](https://vitejs.dev/guide/build.html#multi-page-app).
    */
   const getCssConfig = (entrypoint: Entrypoint): vite.InlineConfig => {
     return {

--- a/packages/wxt/src/core/builders/vite/index.ts
+++ b/packages/wxt/src/core/builders/vite/index.ts
@@ -3,7 +3,6 @@ import {
   BuildStepOutput,
   Entrypoint,
   ResolvedConfig,
-  ServerInfo,
   WxtBuilder,
   WxtBuilderServer,
   WxtDevServer,
@@ -29,7 +28,7 @@ import { installSourcemapsSupport } from 'vite-node/source-map';
 export async function createViteBuilder(
   wxtConfig: ResolvedConfig,
   hooks: Hookable<WxtHooks>,
-  getDevServer?: () => WxtDevServer | undefined,
+  getWxtDevServer?: () => WxtDevServer | undefined,
 ): Promise<WxtBuilder> {
   const vite = await import('vite');
 
@@ -66,14 +65,14 @@ export async function createViteBuilder(
       ignored: [`${wxtConfig.outBaseDir}/**`, `${wxtConfig.wxtDir}/**`],
     };
 
-    const devServer = getDevServer?.();
+    const server = getWxtDevServer?.();
 
     config.plugins ??= [];
     config.plugins.push(
       wxtPlugins.download(wxtConfig),
-      wxtPlugins.devHtmlPrerender(wxtConfig, devServer),
+      wxtPlugins.devHtmlPrerender(wxtConfig, server),
       wxtPlugins.resolveVirtualModules(wxtConfig),
-      wxtPlugins.devServerGlobals(wxtConfig, devServer),
+      wxtPlugins.devServerGlobals(wxtConfig, server),
       wxtPlugins.tsconfigPaths(wxtConfig),
       wxtPlugins.noopBackground(),
       wxtPlugins.globals(wxtConfig),

--- a/packages/wxt/src/core/create-server.ts
+++ b/packages/wxt/src/core/create-server.ts
@@ -46,7 +46,7 @@ export async function createServer(
 }
 
 /**
- * Called during WXT singleton registration when we create the server
+ * Called during WXT singleton registration before initializing WXT modules and hooks.
  */
 async function createServerInternal(
   wxt: Omit<Wxt, 'server'>,

--- a/packages/wxt/src/core/create-server.ts
+++ b/packages/wxt/src/core/create-server.ts
@@ -28,6 +28,7 @@ import {
   getContentScriptJs,
   mapWxtOptionsToRegisteredContentScript,
 } from './utils/content-scripts';
+import { sleep } from './utils/time';
 
 /**
  * Creates a dev server and pre-builds all the files that need to exist before loading the extension.
@@ -119,6 +120,7 @@ async function createServerInternal(
     },
     async restart() {
       await server.stop();
+      await sleep(5000);
       await server.start();
     },
     transformHtml(url, html, originalUrl) {

--- a/packages/wxt/src/core/create-server.ts
+++ b/packages/wxt/src/core/create-server.ts
@@ -43,14 +43,14 @@ import {
 export async function createServer(
   inlineConfig?: InlineConfig,
 ): Promise<WxtDevServer> {
-  await registerWxt('serve', inlineConfig, (wxt) => createServerInternal(wxt));
+  await registerWxt('serve', inlineConfig, createServerInternal);
   return wxt.server!;
 }
 
 /**
  * Called during WXT singleton registration when we create the server
  */
-export async function createServerInternal(
+async function createServerInternal(
   wxt: Omit<Wxt, 'server'>,
 ): Promise<WxtDevServer> {
   const getServerInfo = (): ServerInfo => {

--- a/packages/wxt/src/core/create-server.ts
+++ b/packages/wxt/src/core/create-server.ts
@@ -41,16 +41,14 @@ import {
 export async function createServer(
   inlineConfig?: InlineConfig,
 ): Promise<WxtDevServer> {
-  await registerWxt('serve', inlineConfig, createServerInternal);
-  return wxt.server!;
+  await registerWxt('serve', inlineConfig);
+
+  wxt.server = await createServerInternal();
+
+  return wxt.server;
 }
 
-/**
- * Called during WXT singleton registration before initializing WXT modules and hooks.
- */
-async function createServerInternal(
-  wxt: Omit<Wxt, 'server'>,
-): Promise<WxtDevServer> {
+async function createServerInternal(): Promise<WxtDevServer> {
   const getServerInfo = (): ServerInfo => {
     const { port, hostname } = wxt.config.dev.server!;
     return {

--- a/packages/wxt/src/core/create-server.ts
+++ b/packages/wxt/src/core/create-server.ts
@@ -4,7 +4,6 @@ import {
   EntrypointGroup,
   InlineConfig,
   ServerInfo,
-  Wxt,
   WxtDevServer,
 } from '../types';
 import { getEntrypointBundlePath, isHtmlEntrypoint } from './utils/entrypoints';
@@ -43,9 +42,7 @@ export async function createServer(
 ): Promise<WxtDevServer> {
   await registerWxt('serve', inlineConfig);
 
-  wxt.server = await createServerInternal();
-
-  return wxt.server;
+  return (wxt.server = await createServerInternal());
 }
 
 async function createServerInternal(): Promise<WxtDevServer> {

--- a/packages/wxt/src/core/create-server.ts
+++ b/packages/wxt/src/core/create-server.ts
@@ -28,7 +28,6 @@ import {
   getContentScriptJs,
   mapWxtOptionsToRegisteredContentScript,
 } from './utils/content-scripts';
-import { sleep } from './utils/time';
 
 /**
  * Creates a dev server and pre-builds all the files that need to exist before loading the extension.
@@ -120,7 +119,6 @@ async function createServerInternal(
     },
     async restart() {
       await server.stop();
-      await sleep(5000);
       await server.start();
     },
     transformHtml(url, html, originalUrl) {

--- a/packages/wxt/src/core/create-server.ts
+++ b/packages/wxt/src/core/create-server.ts
@@ -2,9 +2,7 @@ import { debounce } from 'perfect-debounce';
 import {
   BuildStepOutput,
   EntrypointGroup,
-  ExtensionRunner,
   InlineConfig,
-  ResolvedConfig,
   ServerInfo,
   Wxt,
   WxtDevServer,

--- a/packages/wxt/src/core/resolve-config.ts
+++ b/packages/wxt/src/core/resolve-config.ts
@@ -27,7 +27,7 @@ import { builtinModules } from '../builtin-modules';
 import { getEslintVersion } from './utils/eslint';
 import { safeStringToNumber } from './utils/number';
 import { loadEnv } from './utils/env';
-import { getPort } from 'get-port-please';
+import { checkPort, getPort } from 'get-port-please';
 
 /**
  * Given an inline config, discover the config file if necessary, merge the results, resolve any
@@ -138,13 +138,19 @@ export async function resolveConfig(
 
   let devServerConfig: ResolvedConfig['dev']['server'];
   if (command === 'serve') {
+    const hostname = mergedConfig.dev?.server?.hostname ?? 'localhost';
     let port = mergedConfig.dev?.server?.port;
     if (port == null || !isFinite(port)) {
-      port = await getPort({ portRange: [3000, 3010] });
+      port = await getPort({
+        port: 3000,
+        portRange: [3001, 3010],
+        // Passing host required for Mac, unsure of Windows/Linux
+        host: hostname,
+      });
     }
     devServerConfig = {
       port,
-      hostname: mergedConfig.dev?.server?.hostname ?? 'localhost',
+      hostname,
       watchDebounce: safeStringToNumber(process.env.WXT_WATCH_DEBOUNCE) ?? 800,
     };
   }

--- a/packages/wxt/src/core/resolve-config.ts
+++ b/packages/wxt/src/core/resolve-config.ts
@@ -27,6 +27,7 @@ import { builtinModules } from '../builtin-modules';
 import { getEslintVersion } from './utils/eslint';
 import { safeStringToNumber } from './utils/number';
 import { loadEnv } from './utils/env';
+import { getPort } from 'get-port-please';
 
 /**
  * Given an inline config, discover the config file if necessary, merge the results, resolve any
@@ -139,8 +140,7 @@ export async function resolveConfig(
   if (command === 'serve') {
     let port = mergedConfig.dev?.server?.port;
     if (port == null || !isFinite(port)) {
-      const { default: getPort, portNumbers } = await import('get-port');
-      port = await getPort({ port: portNumbers(3000, 3010) });
+      port = await getPort({ portRange: [3000, 3010] });
     }
     devServerConfig = {
       port,

--- a/packages/wxt/src/core/resolve-config.ts
+++ b/packages/wxt/src/core/resolve-config.ts
@@ -27,7 +27,7 @@ import { builtinModules } from '../builtin-modules';
 import { getEslintVersion } from './utils/eslint';
 import { safeStringToNumber } from './utils/number';
 import { loadEnv } from './utils/env';
-import { checkPort, getPort } from 'get-port-please';
+import { getPort } from 'get-port-please';
 
 /**
  * Given an inline config, discover the config file if necessary, merge the results, resolve any

--- a/packages/wxt/src/core/utils/building/__tests__/detect-dev-changes.test.ts
+++ b/packages/wxt/src/core/utils/building/__tests__/detect-dev-changes.test.ts
@@ -71,6 +71,33 @@ describe('Detect Dev Changes', () => {
     });
   });
 
+  describe('modules/*', () => {
+    it("should return 'full-restart' when one of the changed files is in the WXT modules folder", () => {
+      const modulesDir = '/root/modules';
+      setFakeWxt({
+        config: {
+          modulesDir,
+        },
+      });
+      const changes = [
+        '/root/src/public/image.svg',
+        `${modulesDir}/example.ts`,
+      ];
+      const currentOutput: BuildOutput = {
+        manifest: fakeManifest(),
+        publicAssets: [],
+        steps: [],
+      };
+      const expected: DevModeChange = {
+        type: 'full-restart',
+      };
+
+      const actual = detectDevChanges(changes, currentOutput);
+
+      expect(actual).toEqual(expected);
+    });
+  });
+
   describe('web-ext.config.ts', () => {
     it("should return 'browser-restart' when one of the changed files is the config file", () => {
       const runnerFile = '/root/web-ext.config.ts';

--- a/packages/wxt/src/core/utils/building/detect-dev-changes.ts
+++ b/packages/wxt/src/core/utils/building/detect-dev-changes.ts
@@ -26,7 +26,11 @@ import { wxt } from '../../wxt';
  *   - Background script is changed
  *   - Manifest is different
  * - Restart browser
- *   - Config file changed (wxt.config.ts, .env, web-ext.config.ts, etc)
+ *   - web-ext.config.ts (runner config changes)
+ * - Full dev server restart
+ *   - wxt.config.ts (main config file)
+ *   - modules/* (any file related to WXT modules)
+ *   - .env (environment variable changed could effect build)
  */
 export function detectDevChanges(
   changedFiles: string[],
@@ -37,6 +41,11 @@ export function detectDevChanges(
     (file) => file === wxt.config.userConfigMetadata.configFile,
   );
   if (isConfigChange) return { type: 'full-restart' };
+
+  const isWxtModuleChange = some(changedFiles, (file) =>
+    file.startsWith(wxt.config.modulesDir),
+  );
+  if (isWxtModuleChange) return { type: 'full-restart' };
 
   const isRunnerChange = some(
     changedFiles,

--- a/packages/wxt/src/core/wxt.ts
+++ b/packages/wxt/src/core/wxt.ts
@@ -1,6 +1,5 @@
 import {
   InlineConfig,
-  ResolvedConfig,
   Wxt,
   WxtCommand,
   WxtDevServer,
@@ -26,7 +25,7 @@ export let wxt: Wxt;
 export async function registerWxt(
   command: WxtCommand,
   inlineConfig: InlineConfig = {},
-  getServer?: (config: ResolvedConfig) => Promise<WxtDevServer>,
+  getServer?: (wxt: Omit<Wxt, 'server'>) => Promise<WxtDevServer>,
 ): Promise<void> {
   // Default NODE_ENV environment variable before other packages, like vite, do it
   // See https://github.com/wxt-dev/wxt/issues/873#issuecomment-2254555523
@@ -34,8 +33,7 @@ export async function registerWxt(
 
   const hooks = createHooks<WxtHooks>();
   const config = await resolveConfig(inlineConfig, command);
-  const server = await getServer?.(config);
-  const builder = await createViteBuilder(config, hooks, server);
+  const builder = await createViteBuilder(config, hooks, () => wxt.server);
   const pm = await createWxtPackageManager(config.root);
 
   wxt = {
@@ -50,27 +48,26 @@ export async function registerWxt(
     },
     pm,
     builder,
-    server,
+    server: undefined,
   };
+  wxt.server = await getServer?.(wxt);
 
-  // Initialize modules
-  const initModule = async (module: WxtModule<any>) => {
-    if (module.hooks) wxt.hooks.addHooks(module.hooks);
-    await module.setup?.(
-      wxt,
-      // @ts-expect-error: Untyped configKey field
-      module.configKey ? config[module.configKey] : undefined,
-    );
-  };
-  for (const builtinModule of builtinModules) await initModule(builtinModule);
-  for (const userModule of config.userModules) await initModule(userModule);
+  await initWxtModules();
+}
+
+export async function initWxtModules() {
+  // Call setup function
+  for (const mod of builtinModules) await initWxtModule(mod);
+  for (const mod of wxt.config.userModules) await initWxtModule(mod);
 
   // Initialize hooks
-  wxt.hooks.addHooks(config.hooks);
+  wxt.hooks.addHooks(wxt.config.hooks);
+
+  // Print order for debugging
   if (wxt.config.debug) {
     const order = [
       ...builtinModules.map((module) => module.name),
-      ...config.userModules.map((module) =>
+      ...wxt.config.userModules.map((module) =>
         relative(wxt.config.root, module.id),
       ),
       'wxt.config.ts > hooks',
@@ -82,6 +79,22 @@ export async function registerWxt(
   }
 
   await wxt.hooks.callHook('ready', wxt);
+}
+
+async function initWxtModule(module: WxtModule<any>): Promise<void> {
+  if (module.hooks) wxt.hooks.addHooks(module.hooks);
+  await module.setup?.(
+    wxt,
+    // @ts-expect-error: Untyped configKey field
+    module.configKey ? wxt.config[module.configKey] : undefined,
+  );
+}
+
+/**
+ * Unloads WXT modules.
+ */
+export function deinitWxtModules(): void {
+  wxt.hooks.removeAllHooks();
 }
 
 /**

--- a/packages/wxt/src/core/wxt.ts
+++ b/packages/wxt/src/core/wxt.ts
@@ -56,7 +56,7 @@ export async function registerWxt(
 }
 
 export async function initWxtModules() {
-  // Call setup function
+  // Call setup function and add hooks
   for (const mod of builtinModules) await initWxtModule(mod);
   for (const mod of wxt.config.userModules) await initWxtModule(mod);
 

--- a/packages/wxt/src/core/wxt.ts
+++ b/packages/wxt/src/core/wxt.ts
@@ -1,11 +1,4 @@
-import {
-  InlineConfig,
-  Wxt,
-  WxtCommand,
-  WxtDevServer,
-  WxtHooks,
-  WxtModule,
-} from '../types';
+import { InlineConfig, Wxt, WxtCommand, WxtHooks, WxtModule } from '../types';
 import { resolveConfig } from './resolve-config';
 import { createHooks } from 'hookable';
 import { createWxtPackageManager } from './package-managers';

--- a/packages/wxt/src/core/wxt.ts
+++ b/packages/wxt/src/core/wxt.ts
@@ -25,7 +25,6 @@ export let wxt: Wxt;
 export async function registerWxt(
   command: WxtCommand,
   inlineConfig: InlineConfig = {},
-  getServer?: (wxt: Omit<Wxt, 'server'>) => Promise<WxtDevServer>,
 ): Promise<void> {
   // Default NODE_ENV environment variable before other packages, like vite, do it
   // See https://github.com/wxt-dev/wxt/issues/873#issuecomment-2254555523
@@ -50,7 +49,6 @@ export async function registerWxt(
     builder,
     server: undefined,
   };
-  wxt.server = await getServer?.(wxt);
 
   await initWxtModules();
 }

--- a/packages/wxt/src/types.ts
+++ b/packages/wxt/src/types.ts
@@ -1239,7 +1239,7 @@ export interface Wxt {
    */
   logger: Logger;
   /**
-   * Reload config file and update the `config` field with the result.
+   * Reload config file and update `wxt.config` with the result.
    */
   reloadConfig: () => Promise<void>;
   /**

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -329,7 +329,7 @@ importers:
     dependencies:
       '@aklinker1/rollup-plugin-visualizer':
         specifier: 5.12.0
-        version: 5.12.0(rollup@3.29.4)
+        version: 5.12.0(rollup@4.24.0)
       '@types/chrome':
         specifier: ^0.0.280
         version: 0.0.280
@@ -449,7 +449,7 @@ importers:
         version: 1.3.0
       unimport:
         specifier: ^3.13.1
-        version: 3.13.1(rollup@3.29.4)(webpack-sources@3.2.3)
+        version: 3.13.1(rollup@4.24.0)(webpack-sources@3.2.3)
       vite:
         specifier: ^5.4.11
         version: 5.4.11(@types/node@20.17.6)(sass@1.80.7)
@@ -5124,14 +5124,14 @@ snapshots:
       citty: 0.1.6
       typescript: 5.6.3
 
-  '@aklinker1/rollup-plugin-visualizer@5.12.0(rollup@3.29.4)':
+  '@aklinker1/rollup-plugin-visualizer@5.12.0(rollup@4.24.0)':
     dependencies:
       open: 8.4.2
       picomatch: 2.3.1
       source-map: 0.7.4
       yargs: 17.7.2
     optionalDependencies:
-      rollup: 3.29.4
+      rollup: 4.24.0
 
   '@algolia/autocomplete-core@1.9.3(@algolia/client-search@4.20.0)(algoliasearch@4.20.0)(search-insights@2.15.0)':
     dependencies:
@@ -6093,13 +6093,13 @@ snapshots:
     optionalDependencies:
       rollup: 3.29.4
 
-  '@rollup/pluginutils@5.1.2(rollup@3.29.4)':
+  '@rollup/pluginutils@5.1.2(rollup@4.24.0)':
     dependencies:
       '@types/estree': 1.0.5
       estree-walker: 2.0.2
       picomatch: 2.3.1
     optionalDependencies:
-      rollup: 3.29.4
+      rollup: 4.24.0
 
   '@rollup/pluginutils@5.1.3(rollup@4.24.0)':
     dependencies:
@@ -9363,9 +9363,9 @@ snapshots:
 
   undici-types@6.19.8: {}
 
-  unimport@3.13.1(rollup@3.29.4)(webpack-sources@3.2.3):
+  unimport@3.13.1(rollup@4.24.0)(webpack-sources@3.2.3):
     dependencies:
-      '@rollup/pluginutils': 5.1.2(rollup@3.29.4)
+      '@rollup/pluginutils': 5.1.2(rollup@4.24.0)
       acorn: 8.12.1
       escape-string-regexp: 5.0.0
       estree-walker: 3.0.3

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3041,12 +3041,10 @@ packages:
 
   glob@6.0.4:
     resolution: {integrity: sha512-MKZeRNyYZAVVVG1oZeLaWie1uweH40m9AZwIwxyPbTSX4hHrVYSzLg0Ro5Z5R7XKkIX+Cc6oD1rqeDJnwsB8/A==}
-    deprecated: Glob versions prior to v9 are no longer supported
 
   glob@8.1.0:
     resolution: {integrity: sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==}
     engines: {node: '>=12'}
-    deprecated: Glob versions prior to v9 are no longer supported
 
   global-dirs@3.0.1:
     resolution: {integrity: sha512-NBcGGFbBA9s1VzD41QXDG+3++t9Mn5t1FpLdhESY6oKY4gYTFpX4wO3sqGUa0Srjtbfj3szX0RnemmrVRUdULA==}
@@ -3176,7 +3174,6 @@ packages:
 
   inflight@1.0.6:
     resolution: {integrity: sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==}
-    deprecated: This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.
 
   inherits@2.0.4:
     resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
@@ -4286,7 +4283,6 @@ packages:
 
   rimraf@2.4.5:
     resolution: {integrity: sha512-J5xnxTyqaiw06JjMftq7L9ouA448dw/E7dKghkP9WpKNuwmARNNg+Gk8/u5ryb9N/Yo2+z3MCwuqFK/+qPOPfQ==}
-    deprecated: Rimraf versions prior to v4 are no longer supported
     hasBin: true
 
   rollup-plugin-dts@6.1.1:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -329,7 +329,7 @@ importers:
     dependencies:
       '@aklinker1/rollup-plugin-visualizer':
         specifier: 5.12.0
-        version: 5.12.0(rollup@4.24.0)
+        version: 5.12.0(rollup@3.29.4)
       '@types/chrome':
         specifier: ^0.0.280
         version: 0.0.280
@@ -384,9 +384,9 @@ importers:
       fs-extra:
         specifier: ^11.2.0
         version: 11.2.0
-      get-port:
-        specifier: ^7.1.0
-        version: 7.1.0
+      get-port-please:
+        specifier: ^3.1.2
+        version: 3.1.2
       giget:
         specifier: ^1.2.3
         version: 1.2.3
@@ -449,7 +449,7 @@ importers:
         version: 1.3.0
       unimport:
         specifier: ^3.13.1
-        version: 3.13.1(rollup@4.24.0)(webpack-sources@3.2.3)
+        version: 3.13.1(rollup@3.29.4)(webpack-sources@3.2.3)
       vite:
         specifier: ^5.4.11
         version: 5.4.11(@types/node@20.17.6)(sass@1.80.7)
@@ -3006,9 +3006,8 @@ packages:
   get-func-name@2.0.2:
     resolution: {integrity: sha512-8vXOvuE167CtIc3OyItco7N/dpRtBbYOsPsXCz7X/PMnlGjYjSGuZJgM1Y7mmew7BKf9BqvLX2tnOVy1BBUsxQ==}
 
-  get-port@7.1.0:
-    resolution: {integrity: sha512-QB9NKEeDg3xxVwCCwJQ9+xycaz6pBB6iQ76wiWMl1927n0Kir6alPiP+yuiICLLU4jpMe08dXfpebuQppFA2zw==}
-    engines: {node: '>=16'}
+  get-port-please@3.1.2:
+    resolution: {integrity: sha512-Gxc29eLs1fbn6LQ4jSU4vXjlwyZhF5HsGuMAa7gqBP4Rw4yxxltyDUuF5MBclFzDTXO+ACchGQoeela4DSfzdQ==}
 
   get-stream@5.2.0:
     resolution: {integrity: sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==}
@@ -5125,14 +5124,14 @@ snapshots:
       citty: 0.1.6
       typescript: 5.6.3
 
-  '@aklinker1/rollup-plugin-visualizer@5.12.0(rollup@4.24.0)':
+  '@aklinker1/rollup-plugin-visualizer@5.12.0(rollup@3.29.4)':
     dependencies:
       open: 8.4.2
       picomatch: 2.3.1
       source-map: 0.7.4
       yargs: 17.7.2
     optionalDependencies:
-      rollup: 4.24.0
+      rollup: 3.29.4
 
   '@algolia/autocomplete-core@1.9.3(@algolia/client-search@4.20.0)(algoliasearch@4.20.0)(search-insights@2.15.0)':
     dependencies:
@@ -6094,13 +6093,13 @@ snapshots:
     optionalDependencies:
       rollup: 3.29.4
 
-  '@rollup/pluginutils@5.1.2(rollup@4.24.0)':
+  '@rollup/pluginutils@5.1.2(rollup@3.29.4)':
     dependencies:
       '@types/estree': 1.0.5
       estree-walker: 2.0.2
       picomatch: 2.3.1
     optionalDependencies:
-      rollup: 4.24.0
+      rollup: 3.29.4
 
   '@rollup/pluginutils@5.1.3(rollup@4.24.0)':
     dependencies:
@@ -7586,7 +7585,7 @@ snapshots:
 
   get-func-name@2.0.2: {}
 
-  get-port@7.1.0: {}
+  get-port-please@3.1.2: {}
 
   get-stream@5.2.0:
     dependencies:
@@ -9364,9 +9363,9 @@ snapshots:
 
   undici-types@6.19.8: {}
 
-  unimport@3.13.1(rollup@4.24.0)(webpack-sources@3.2.3):
+  unimport@3.13.1(rollup@3.29.4)(webpack-sources@3.2.3):
     dependencies:
-      '@rollup/pluginutils': 5.1.2(rollup@4.24.0)
+      '@rollup/pluginutils': 5.1.2(rollup@3.29.4)
       acorn: 8.12.1
       escape-string-regexp: 5.0.0
       estree-walker: 3.0.3


### PR DESCRIPTION
This close #857, #863, #939.

There were lots of callbacks and dependencies between variables in the `createServer` function... I was able to clean it up apart of this PR! Very happy about that, wasn't sure how I would work around that...

I don't have E2E tests for dev mode, so we'll need to check over this carefully.

### Todo

- [x] Cleanup callback ordering
- [x] Properly call WXT module's setup function when config changes
- [x] Ensure port doesn't change between restarts
- [x] Do a full restart when `modules/*` is saved during development, not just when `wxt.config.ts` is changed
- [x] Make sure it's fixed: #857
- [x] Make sure it's fixed: #863
- [x] Make sure it's fixed: #939

