### PR TITLE
fix: Use `config:resolved` hook to update config instead of `ready`

### DIFF
--- a/packages/module-react/modules/react.ts
+++ b/packages/module-react/modules/react.ts
@@ -15,7 +15,7 @@ export default defineWxtModule<ReactModuleOptions>({
     addImportPreset(wxt, 'react');
 
     // Enable auto-imports for JSX files
-    wxt.hooks.hook('ready', (wxt) => {
+    wxt.hook('config:resolved', (wxt) => {
       if (wxt.config.imports === false) return;
 
       wxt.config.imports.dirsScanOptions ??= {};

--- a/packages/module-react/package.json
+++ b/packages/module-react/package.json
@@ -44,7 +44,7 @@
     "prepare": "buildc --deps-only -- wxt prepare"
   },
   "peerDependencies": {
-    "wxt": ">=0.18.6"
+    "wxt": ">=0.19.16"
   },
   "dependencies": {
     "@vitejs/plugin-react": "^4.3.3"

--- a/packages/module-solid/modules/solid.ts
+++ b/packages/module-solid/modules/solid.ts
@@ -18,7 +18,7 @@ export default defineWxtModule<SolidModuleOptions>({
     addImportPreset(wxt, 'solid-js');
 
     // Enable auto-imports for JSX files
-    wxt.hooks.hook('ready', (wxt) => {
+    wxt.hook('config:resolved', (wxt) => {
       if (wxt.config.imports === false) return;
 
       wxt.config.imports.dirsScanOptions ??= {};

--- a/packages/module-solid/package.json
+++ b/packages/module-solid/package.json
@@ -44,7 +44,7 @@
     "prepare": "buildc --deps-only -- wxt prepare"
   },
   "peerDependencies": {
-    "wxt": ">=0.18.6"
+    "wxt": ">=0.19.16"
   },
   "dependencies": {
     "vite-plugin-solid": "^2.10.2"

--- a/packages/module-vue/package.json
+++ b/packages/module-vue/package.json
@@ -42,7 +42,7 @@
     "check": "pnpm build && check"
   },
   "peerDependencies": {
-    "wxt": ">=0.18.6"
+    "wxt": ">=0.19.16"
   },
   "dependencies": {
     "@vitejs/plugin-vue": "^5.2.0"

--- a/packages/module-vue/src/index.ts
+++ b/packages/module-vue/src/index.ts
@@ -19,7 +19,7 @@ export default defineWxtModule<VueModuleOptions>({
     }));
 
     // Enable auto-imports in template files
-    wxt.hooks.hook('ready', (wxt) => {
+    wxt.hook('config:resolved', (wxt) => {
       if (!wxt.config.imports) return;
 
       wxt.config.imports.addons ??= {};

--- a/packages/wxt/src/core/wxt.ts
+++ b/packages/wxt/src/core/wxt.ts
@@ -82,7 +82,7 @@ export async function registerWxt(
     });
   }
 
-  await wxt.hooks.callHook('config:resolved', wxt);
+  await wxt.hooks.callHook('ready', wxt);
   await wxt.hooks.callHook('config:resolved', wxt);
 }
 

--- a/packages/wxt/src/core/wxt.ts
+++ b/packages/wxt/src/core/wxt.ts
@@ -82,7 +82,7 @@ export async function registerWxt(
     });
   }
 
-  await wxt.hooks.callHook('ready', wxt);
+  await wxt.hooks.callHook('config:resolved', wxt);
   await wxt.hooks.callHook('config:resolved', wxt);
 }
 


### PR DESCRIPTION
Follow up to #1177 fixing all the other modules usage of "ready".