### PR TITLE
fix!: Remove `transformManfiest` option

### DIFF
--- a/packages/wxt/src/core/resolve-config.ts
+++ b/packages/wxt/src/core/resolve-config.ts
@@ -193,7 +193,6 @@ export async function resolveConfig(
     typesDir,
     wxtDir,
     zip: resolveZipConfig(root, browser, outBaseDir, mergedConfig),
-    transformManifest: mergedConfig.transformManifest,
     analysis: resolveAnalysisConfig(root, mergedConfig),
     userConfigMetadata: userConfigMetadata ?? {},
     alias,
@@ -242,12 +241,6 @@ async function mergeInlineConfig(
     return defu(inline, user);
   };
 
-  // Merge transformManifest option
-  const transformManifest: InlineConfig['transformManifest'] = (manifest) => {
-    userConfig.transformManifest?.(manifest);
-    inlineConfig.transformManifest?.(manifest);
-  };
-
   const merged = defu(inlineConfig, userConfig);
 
   // Builders
@@ -260,7 +253,6 @@ async function mergeInlineConfig(
   return {
     ...merged,
     // Custom merge values
-    transformManifest,
     imports,
     manifest,
     ...builderConfig,

--- a/packages/wxt/src/core/utils/__tests__/manifest.test.ts
+++ b/packages/wxt/src/core/utils/__tests__/manifest.test.ts
@@ -1107,31 +1107,6 @@ describe('Manifest Utils', () => {
       });
     });
 
-    describe('transformManifest option', () => {
-      it("should call the transformManifest option after the manifest is generated, but before it's returned", async () => {
-        const entrypoints: Entrypoint[] = [];
-        const buildOutput = fakeBuildOutput();
-        const newAuthor = 'Custom Author';
-        setFakeWxt({
-          config: {
-            transformManifest(manifest: any) {
-              manifest.author = newAuthor;
-            },
-          },
-        });
-        const expected = {
-          author: newAuthor,
-        };
-
-        const { manifest: actual } = await generateManifest(
-          entrypoints,
-          buildOutput,
-        );
-
-        expect(actual).toMatchObject(expected);
-      });
-    });
-
     describe('version', () => {
       it.each(['chrome', 'safari', 'edge'] as const)(
         'should include version and version_name as is on %s',

--- a/packages/wxt/src/core/utils/manifest.ts
+++ b/packages/wxt/src/core/utils/manifest.ts
@@ -107,8 +107,6 @@ export async function generateManifest(
   if (wxt.config.command === 'serve') addDevModeCsp(manifest);
   if (wxt.config.command === 'serve') addDevModePermissions(manifest);
 
-  // TODO: Remove in v1
-  wxt.config.transformManifest?.(manifest);
   await wxt.hooks.callHook('build:manifestGenerated', wxt, manifest);
 
   if (wxt.config.manifestVersion === 2) {

--- a/packages/wxt/src/core/utils/testing/fake-objects.ts
+++ b/packages/wxt/src/core/utils/testing/fake-objects.ts
@@ -292,7 +292,6 @@ export const fakeResolvedConfig = fakeObjectCreator<ResolvedConfig>(() => {
       compressionLevel: 9,
       zipSources: false,
     },
-    transformManifest: () => {},
     userConfigMetadata: {},
     alias: {},
     experimental: {},

--- a/packages/wxt/src/types.ts
+++ b/packages/wxt/src/types.ts
@@ -252,26 +252,6 @@ export interface InlineConfig {
      */
     compressionLevel?: 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9;
   };
-
-  /**
-   * @deprecated Use `hooks.build.manifestGenerated` to modify your manifest instead. This option
-   *             will be removed in v1.0
-   *
-   * Transform the final manifest before it's written to the file system. Edit the `manifest`
-   * parameter directly, do not return a new object. Return values are ignored.
-   *
-   * @example
-   * defineConfig({
-   *   // Add a CSS-only content script.
-   *   transformManifest(manifest) {
-   *     manifest.content_scripts.push({
-   *       matches: ["*://google.com/*"],
-   *       css: ["content-scripts/some-example.css"],
-   *     });
-   *   }
-   * })
-   */
-  transformManifest?: (manifest: chrome.runtime.Manifest) => void;
   analysis?: {
     /**
      * Explicitly include bundle analysis when running `wxt build`. This can be overridden by the
@@ -1293,10 +1273,6 @@ export interface ResolvedConfig {
      */
     zipSources: boolean;
   };
-  /**
-   * @deprecated Use `build:manifestGenerated` hook instead.
-   */
-  transformManifest?: (manifest: chrome.runtime.Manifest) => void;
   analysis: {
     enabled: boolean;
     open: boolean;


### PR DESCRIPTION
BREAKING CHANGE: Remove deprecated option, `transformManifest`. Use the [`build:manifestGenerated` hook](https://wxt.dev/api/reference/wxt/interfaces/WxtHooks.html#build-manifestgenerated) to transform the manifest instead.

```diff
// wxt.config.ts
export default defineConfig({
- transformManifest(manifest) {
-   // ...
- },
+ hooks: {
+   build:manifestGenerated: (_, manifest) =>  {
+     // ...
+   },
+ },
});
```