### PR TITLE
chore: Update Svelte template to Svelte 5

### DIFF
--- a/templates/svelte/src/entrypoints/popup/main.ts
+++ b/templates/svelte/src/entrypoints/popup/main.ts
@@ -1,11 +1,9 @@
-import { mount } from 'svelte'
+import { mount } from 'svelte';
 import App from './App.svelte';
 import './app.css';
 
-const app = mount(App,
-  {
-    target: document.getElementById("app")
-  }
-);
+const app = mount(App, {
+  target: document.getElementById('app'),
+});
 
 export default app;

--- a/templates/svelte/src/entrypoints/popup/main.ts
+++ b/templates/svelte/src/entrypoints/popup/main.ts
@@ -3,7 +3,7 @@ import App from './App.svelte';
 import './app.css';
 
 const app = mount(App, {
-  target: document.getElementById('app'),
+  target: document.getElementById('app')!,
 });
 
 export default app;

--- a/templates/svelte/src/entrypoints/popup/main.ts
+++ b/templates/svelte/src/entrypoints/popup/main.ts
@@ -1,8 +1,11 @@
-import './app.css';
+import { mount } from 'svelte'
 import App from './App.svelte';
+import './app.css';
 
-const app = new App({
-  target: document.getElementById('app')!,
-});
+const app = mount(App,
+  {
+    target: document.getElementById("app")
+  }
+);
 
 export default app;


### PR DESCRIPTION
using `new App()` no longer works in Svelte 5. I updated the example template to Svelte 5. Though there is still a type error which can be fixed using this. But I just reckoned the code would've been too complicated.

```ts
const target = document.getElementById("app");
let app;
if (target) {
  app = mount(App, { target });
} else {
  throw new Error("Target element not found");
}
```

I found this after finding where it doesn't work. This is actually my first time using wxt so I took a while for it as I really want to use Svelte.