### PR TITLE
chore(vue-template): remove references to Vetur and TypeScript Vue Plugin (Volar)

### DIFF
--- a/templates/vue/README.md
+++ b/templates/vue/README.md
@@ -4,4 +4,4 @@ This template should help get you started developing with Vue 3 in WXT.
 
 ## Recommended IDE Setup
 
-- [VS Code](https://code.visualstudio.com/) + [Volar](https://marketplace.visualstudio.com/items?itemName=Vue.volar) (and disable Vetur) + [TypeScript Vue Plugin (Volar)](https://marketplace.visualstudio.com/items?itemName=Vue.vscode-typescript-vue-plugin).
+- [VS Code](https://code.visualstudio.com/) + [Volar](https://marketplace.visualstudio.com/items?itemName=Vue.volar).


### PR DESCRIPTION
TypeScript Vue Plugin (Volar) has been deprecated and is no longer required for Vue 3 projects.
Vetur only works with Vue2 and has not been updated for 1 year.

There should be no need to mention them in templates.