### PR TITLE
fix: Update `vite` dependency range to support v6

### DIFF
--- a/packages/wxt/package.json
+++ b/packages/wxt/package.json
@@ -122,7 +122,7 @@
     "publish-browser-extension": "^2.2.2",
     "scule": "^1.3.0",
     "unimport": "^3.13.1",
-    "vite": "^5.4.11",
+    "vite": "^5.0.0 || ^6.0.0",
     "vite-node": "^2.1.4",
     "web-ext-run": "^0.2.1",
     "webextension-polyfill": "^0.12.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -451,7 +451,7 @@ importers:
         specifier: ^3.13.1
         version: 3.13.1(rollup@4.24.0)(webpack-sources@3.2.3)
       vite:
-        specifier: ^5.4.11
+        specifier: ^5.0.0 || ^6.0.0
         version: 5.4.11(@types/node@20.17.6)(sass@1.80.7)
       vite-node:
         specifier: ^2.1.4


### PR DESCRIPTION
Apart of #1214, everything seems in order. Vanilla template works in dev mode and production builds with no errors or warnings.

Plugins haven't updated their peer dependencies yet, so it's hard to test on full projects. Will let people open issues if it doesn't work for them.