### PR TITLE
fix: Correctly remove child elements with integrated UI remove

### DIFF
--- a/packages/wxt/src/client/content-scripts/ui/index.ts
+++ b/packages/wxt/src/client/content-scripts/ui/index.ts
@@ -34,6 +34,7 @@ export function createIntegratedUi<TMounted>(
   };
   const remove = () => {
     options.onRemove?.(mounted);
+    wrapper.replaceChildren();
     wrapper.remove();
     mounted = undefined;
   };


### PR DESCRIPTION
fix #1218

Empty the child elements when removing. ref: https://developer.mozilla.org/en-US/docs/Web/API/Element/replaceChildren