### PR TITLE
fix: correct `dev.reloadCommand` restriction to consider only commands with suggested keys

### DIFF
--- a/packages/wxt/src/core/utils/manifest.ts
+++ b/packages/wxt/src/core/utils/manifest.ts
@@ -91,7 +91,7 @@ export async function generateManifest(
       ).length >= 4
     ) {
       warnings.push([
-        "Extension already has 4 registered suggested key commands, WXT's reload command is disabled",
+        "Extension already has 4 registered commands with suggested keys, WXT's reload command is disabled",
       ]);
     } else {
       manifest.commands ??= {};

--- a/packages/wxt/src/core/utils/manifest.ts
+++ b/packages/wxt/src/core/utils/manifest.ts
@@ -82,9 +82,16 @@ export async function generateManifest(
 
   // Add reload command in dev mode
   if (wxt.config.command === 'serve' && wxt.config.dev.reloadCommand) {
-    if (manifest.commands && Object.keys(manifest.commands).length >= 4) {
+    if (
+      manifest.commands &&
+      // If the following limit is exceeded, Chrome will fail to load the extension.
+      // Error: "Too many commands specified for 'commands': The maximum is 4."
+      Object.values(manifest.commands).filter(
+        (command) => command.suggested_key,
+      ).length >= 4
+    ) {
       warnings.push([
-        "Extension already has 4 registered commands, WXT's reload command is disabled",
+        "Extension already has 4 registered suggested key commands, WXT's reload command is disabled",
       ]);
     } else {
       manifest.commands ??= {};

--- a/packages/wxt/src/core/utils/testing/fake-objects.ts
+++ b/packages/wxt/src/core/utils/testing/fake-objects.ts
@@ -4,7 +4,7 @@
 import { resolve } from 'path';
 import { faker } from '@faker-js/faker';
 import merge from 'lodash.merge';
-import { Commands, type Manifest } from 'wxt/browser';
+import type { Manifest } from 'wxt/browser';
 import {
   FsCache,
   ResolvedConfig,
@@ -355,13 +355,18 @@ export const fakeBuildStepOutput = fakeObjectCreator<BuildStepOutput>(() => ({
   entrypoints: fakeArray(fakeEntrypoint),
 }));
 
-export const fakeManifestCommand = fakeObjectCreator<Commands.Command>(() => ({
-  description: faker.string.sample(),
-  shortcut: `${faker.helpers.arrayElement(['ctrl', 'alt'])}+${faker.number.int({
-    min: 0,
-    max: 9,
-  })}`,
-}));
+export const fakeManifestCommand =
+  fakeObjectCreator<Manifest.WebExtensionManifestCommandsType>(() => ({
+    description: faker.string.sample(),
+    suggested_key: {
+      default: `${faker.helpers.arrayElement(['ctrl', 'alt'])}+${faker.number.int(
+        {
+          min: 0,
+          max: 9,
+        },
+      )}`,
+    },
+  }));
 
 export const fakeDevServer = fakeObjectCreator<WxtDevServer>(() => ({
   hostname: 'localhost',


### PR DESCRIPTION
Closed https://github.com/wxt-dev/wxt/issues/1202

This limitation only exists in Chrome. I tried to load 10 suggested keys in Firefox MV2 and no error occurred.