### PR TITLE
fix: Modify dev `vite.resolve.conditions` to support Vite 6 + Svelte 5

### DIFF
--- a/packages/module-svelte/src/index.ts
+++ b/packages/module-svelte/src/index.ts
@@ -12,7 +12,7 @@ export default defineWxtModule<SvelteModuleOptions>({
   setup(wxt, options) {
     const { vite } = options ?? {};
 
-    addViteConfig(wxt, () => ({
+    addViteConfig(wxt, ({ mode }) => ({
       plugins: [
         svelte({
           // Using a svelte.config.js file causes a segmentation fault when importing the file
@@ -21,6 +21,9 @@ export default defineWxtModule<SvelteModuleOptions>({
           ...vite,
         }),
       ],
+      resolve: {
+        conditions: mode === 'development' ? ['browser'] : [],
+      },
     }));
 
     addImportPreset(wxt, 'svelte');


### PR DESCRIPTION
See #1228. This fixes an error in dev mode:

<img width="638" alt="Screenshot 2024-12-01 at 9 24 54 AM" src="https://github.com/user-attachments/assets/3376fc12-6771-4a35-b3fd-fc78856fe75b">

