### PR TITLE
fix: Reduce extension environment footprint

### DIFF
--- a/packages/wxt/src/core/builders/vite/index.ts
+++ b/packages/wxt/src/core/builders/vite/index.ts
@@ -24,6 +24,7 @@ import { importEntrypointFile } from '../../utils/building';
 import { ViteNodeServer } from 'vite-node/server';
 import { ViteNodeRunner } from 'vite-node/client';
 import { installSourcemapsSupport } from 'vite-node/source-map';
+import { createExtensionEnvironment } from '../../utils/environments';
 
 export async function createViteBuilder(
   wxtConfig: ResolvedConfig,
@@ -263,7 +264,8 @@ export async function createViteBuilder(
               return node.resolveId(id, importer);
             },
           });
-          const res = await runner.executeFile(path);
+          const env = createExtensionEnvironment();
+          const res = await env.run(() => runner.executeFile(path));
           await server.close();
           return res.default;
         }

--- a/packages/wxt/src/core/utils/building/find-entrypoints.ts
+++ b/packages/wxt/src/core/utils/building/find-entrypoints.ts
@@ -28,7 +28,6 @@ import { VIRTUAL_NOOP_BACKGROUND_MODULE_ID } from '../../utils/constants';
 import { CSS_EXTENSIONS_PATTERN } from '../../utils/paths';
 import pc from 'picocolors';
 import { wxt } from '../../wxt';
-import { createExtensionEnvironment } from '../environments';
 
 /**
  * Return entrypoints and their configuration by looking through the project's files.
@@ -83,50 +82,47 @@ export async function findEntrypoints(): Promise<Entrypoint[]> {
 
   // Import entrypoints to get their config
   let hasBackground = false;
-  const env = createExtensionEnvironment();
-  const entrypoints: Entrypoint[] = await env.run(() =>
-    Promise.all(
-      entrypointInfos.map(async (info): Promise<Entrypoint> => {
-        const { type } = info;
-        switch (type) {
-          case 'popup':
-            return await getPopupEntrypoint(info);
-          case 'sidepanel':
-            return await getSidepanelEntrypoint(info);
-          case 'options':
-            return await getOptionsEntrypoint(info);
-          case 'background':
-            hasBackground = true;
-            return await getBackgroundEntrypoint(info);
-          case 'content-script':
-            return await getContentScriptEntrypoint(info);
-          case 'unlisted-page':
-            return await getUnlistedPageEntrypoint(info);
-          case 'unlisted-script':
-            return await getUnlistedScriptEntrypoint(info);
-          case 'content-script-style':
-            return {
-              ...info,
-              type,
-              outputDir: resolve(wxt.config.outDir, CONTENT_SCRIPT_OUT_DIR),
-              options: {
-                include: undefined,
-                exclude: undefined,
-              },
-            };
-          default:
-            return {
-              ...info,
-              type,
-              outputDir: wxt.config.outDir,
-              options: {
-                include: undefined,
-                exclude: undefined,
-              },
-            };
-        }
-      }),
-    ),
+  const entrypoints: Entrypoint[] = await Promise.all(
+    entrypointInfos.map(async (info): Promise<Entrypoint> => {
+      const { type } = info;
+      switch (type) {
+        case 'popup':
+          return await getPopupEntrypoint(info);
+        case 'sidepanel':
+          return await getSidepanelEntrypoint(info);
+        case 'options':
+          return await getOptionsEntrypoint(info);
+        case 'background':
+          hasBackground = true;
+          return await getBackgroundEntrypoint(info);
+        case 'content-script':
+          return await getContentScriptEntrypoint(info);
+        case 'unlisted-page':
+          return await getUnlistedPageEntrypoint(info);
+        case 'unlisted-script':
+          return await getUnlistedScriptEntrypoint(info);
+        case 'content-script-style':
+          return {
+            ...info,
+            type,
+            outputDir: resolve(wxt.config.outDir, CONTENT_SCRIPT_OUT_DIR),
+            options: {
+              include: undefined,
+              exclude: undefined,
+            },
+          };
+        default:
+          return {
+            ...info,
+            type,
+            outputDir: wxt.config.outDir,
+            options: {
+              include: undefined,
+              exclude: undefined,
+            },
+          };
+      }
+    }),
   );
 
   if (wxt.config.command === 'serve' && !hasBackground) {

--- a/packages/wxt/src/core/utils/building/import-entrypoint.ts
+++ b/packages/wxt/src/core/utils/building/import-entrypoint.ts
@@ -7,6 +7,7 @@ import { normalizePath } from '../../utils/paths';
 import { TransformOptions, transformSync } from 'esbuild';
 import { fileURLToPath } from 'node:url';
 import { wxt } from '../../wxt';
+import { createExtensionEnvironment } from '../environments';
 
 /**
  * Get the value from the default export of a `path`.
@@ -20,7 +21,7 @@ import { wxt } from '../../wxt';
  * This prevents resolving imports of imports, speeding things up and preventing "xxx is not
  * defined" errors.
  *
- * Downside is that code cannot be executed outside of the main fucntion for the entrypoint,
+ * Downside is that code cannot be executed outside of the main function for the entrypoint,
  * otherwise you will see "xxx is not defined" errors for any imports used outside of main function.
  */
 export async function importEntrypointFile<T>(path: string): Promise<T> {
@@ -89,7 +90,8 @@ export async function importEntrypointFile<T>(path: string): Promise<T> {
   );
 
   try {
-    const res = await jiti(path);
+    const env = createExtensionEnvironment();
+    const res = await env.run<any>(() => jiti(path));
     return res.default;
   } catch (err) {
     const filePath = relative(wxt.config.root, path);


### PR DESCRIPTION
This fixes #931. This fixes #1227.

Before, the extension environment polyfills were setup before creating the vite dev server. This was creating a `document` global that shouldn't exist when the dev-server is spinning up. Instead, the environment has been moved to have as small of a impact as possible - just when the entrypoint files are imported.