### PR TITLE
fix: Prevent changing dev server port when reloading config

### DIFF
--- a/packages/wxt/e2e/tests/dev.test.ts
+++ b/packages/wxt/e2e/tests/dev.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect } from 'vitest';
+import { TestProject } from '../utils';
+
+describe('Dev Mode', () => {
+  it('should not change ports when restarting the server', async () => {
+    const project = new TestProject();
+    project.addFile(
+      'entrypoints/background.ts',
+      'export default defineBackground(() => {})',
+    );
+
+    const server = await project.startServer({
+      runner: {
+        disabled: true,
+      },
+    });
+    const initialPort = server.port;
+    await server.restart();
+    const finalPort = server.port;
+    await server.stop();
+
+    expect(finalPort).toBe(initialPort);
+  });
+});

--- a/packages/wxt/src/core/wxt.ts
+++ b/packages/wxt/src/core/wxt.ts
@@ -38,11 +38,11 @@ export async function registerWxt(
     async reloadConfig() {
       // Prevent changing the server port when resolving config multiple times
       // get-port-please doesn't always return the same port if it was recently closed.
-      if (wxt.config.dev.server?.port) {
-        inlineConfig.dev ??= {};
-        inlineConfig.dev.server ??= {};
-        inlineConfig.dev.server.port = wxt.config.dev.server.port;
-      }
+      // if (wxt.config.dev.server?.port) {
+      //   inlineConfig.dev ??= {};
+      //   inlineConfig.dev.server ??= {};
+      //   inlineConfig.dev.server.port = wxt.config.dev.server.port;
+      // }
 
       wxt.config = await resolveConfig(inlineConfig, command);
       await wxt.hooks.callHook('config:resolved', wxt);

--- a/packages/wxt/src/core/wxt.ts
+++ b/packages/wxt/src/core/wxt.ts
@@ -38,11 +38,11 @@ export async function registerWxt(
     async reloadConfig() {
       // Prevent changing the server port when resolving config multiple times
       // get-port-please doesn't always return the same port if it was recently closed.
-      // if (wxt.config.dev.server?.port) {
-      //   inlineConfig.dev ??= {};
-      //   inlineConfig.dev.server ??= {};
-      //   inlineConfig.dev.server.port = wxt.config.dev.server.port;
-      // }
+      if (wxt.config.dev.server?.port) {
+        inlineConfig.dev ??= {};
+        inlineConfig.dev.server ??= {};
+        inlineConfig.dev.server.port = wxt.config.dev.server.port;
+      }
 
       wxt.config = await resolveConfig(inlineConfig, command);
       await wxt.hooks.callHook('config:resolved', wxt);

--- a/packages/wxt/src/core/wxt.ts
+++ b/packages/wxt/src/core/wxt.ts
@@ -36,6 +36,14 @@ export async function registerWxt(
       return config.logger;
     },
     async reloadConfig() {
+      // Prevent changing the server port when resolving config multiple times
+      // get-port-please doesn't always return the same port if it was recently closed.
+      if (wxt.config.dev.server?.port) {
+        inlineConfig.dev ??= {};
+        inlineConfig.dev.server ??= {};
+        inlineConfig.dev.server.port = wxt.config.dev.server.port;
+      }
+
       wxt.config = await resolveConfig(inlineConfig, command);
       await wxt.hooks.callHook('config:resolved', wxt);
     },


### PR DESCRIPTION
This closes #1239 