### PR TITLE
docs: Add "aesthetic Notion, styled" to homepage

### DIFF
--- a/docs/.vitepress/components/UsingWxtSection.vue
+++ b/docs/.vitepress/components/UsingWxtSection.vue
@@ -59,6 +59,7 @@ const chromeExtensionIds = [
   'macmkmchfoclhpbncclinhjflmdkaoom', // Wandpen - Instantly improve your writing with AI
   'lhmgechokhmdekdpgkkemoeecelcaonm', // YouTube Hider - Remove Comments By Keywords, Usernames & Tools
   'imgheieooppmahcgniieddodaliodeeg', // QA Compass - Record standardized bug reports easily
+  'npgghjedpchajflknnbngajkjkdhncdo', // aesthetic Notion, styled
 ];
 
 const { data, err, isLoading } = useListExtensionDetails(chromeExtensionIds);


### PR DESCRIPTION
Hi,
I want to add _aesthetic Notion, styled_ extension entry.
The [Chrome web store url](https://chromewebstore.google.com/detail/aesthetic/npgghjedpchajflknnbngajkjkdhncdo).

<img src="https://github.com/user-attachments/assets/7e103a84-d9a4-4900-8575-522d6e1b5397" width="300" />

## A quick presentation of this extension: 

Elevate your Notion with this Chrome extension to customize headings and add a unique, aesthetic touch to your digital space.

💥 Make your Notion titles Pop!