### PR TITLE
fix: Ensure content scripts are registered immediately in dev mode

### DIFF
--- a/packages/wxt/src/core/create-server.ts
+++ b/packages/wxt/src/core/create-server.ts
@@ -97,14 +97,16 @@ async function createServerInternal(): Promise<WxtDevServer> {
       wxt.logger.success(`Started dev server @ ${server.origin}`);
       await wxt.hooks.callHook('server:started', wxt, server);
 
-      await buildAndOpenBrowser();
-
-      // Register content scripts for the first time after the background starts up since they're not
-      // listed in the manifest
+      // Register content scripts for the first time after the background starts
+      // up since they're not listed in the manifest.
+      // Add listener before opening the browser to guarentee it is present when
+      // the extension sends back the initialization message.
       server.ws.on('wxt:background-initialized', () => {
         if (server.currentOutput == null) return;
         reloadContentScripts(server.currentOutput.steps, server);
       });
+
+      await buildAndOpenBrowser();
 
       // Listen for file changes and reload different parts of the extension accordingly
       const reloadOnChange = createFileReloader(server);


### PR DESCRIPTION
This closes #1252. Reorder things so the init event listener up is added before the browser is opened. Seems like Chome on Arch/Linux starts up the service worker before the `buildAndOpenBrowser()` promise resolves.