### PR TITLE
docs: fix colored-diff in es-modules.md

### DIFF
--- a/docs/guide/essentials/es-modules.md
+++ b/docs/guide/essentials/es-modules.md
@@ -20,7 +20,7 @@ In your background script, set `type: "module"`:
 
 ```ts
 export default defineBackground({
-  type: 'module', // !code ++
+  type: 'module', // [!code ++]
   main() {
     // ...
   },


### PR DESCRIPTION
https://vitepress.dev/guide/markdown#colored-diffs-in-code-blocks

![image](https://github.com/user-attachments/assets/e2766b93-75c3-43d0-99e5-80f62e826380)
