### PR TITLE
fix: Exclude skipped entrypoints from manifest

### DIFF
--- a/packages/wxt/src/core/utils/__tests__/manifest.test.ts
+++ b/packages/wxt/src/core/utils/__tests__/manifest.test.ts
@@ -44,6 +44,7 @@ describe('Manifest Utils', () => {
             defaultTitle: 'Default Iitle',
           },
           outputDir: outDir,
+          skipped: false,
         });
 
       it('should include an action for mv3', async () => {
@@ -209,6 +210,7 @@ describe('Manifest Utils', () => {
           chromeStyle: true,
           browserStyle: true,
         },
+        skipped: false,
       });
 
       it('should include a options_ui and chrome_style for chrome', async () => {
@@ -265,6 +267,7 @@ describe('Manifest Utils', () => {
           persistent: true,
           type: 'module',
         },
+        skipped: false,
       });
 
       describe('MV3', () => {
@@ -368,7 +371,7 @@ describe('Manifest Utils', () => {
 
     describe('icons', () => {
       it('should auto-discover icons with the correct name', async () => {
-        const entrypoints = fakeArray(fakeEntrypoint);
+        const entrypoints = fakeArray(() => fakeEntrypoint({ skipped: false }));
         const buildOutput = fakeBuildOutput({
           publicAssets: [
             { type: 'asset', fileName: 'icon-16.png' },
@@ -396,7 +399,7 @@ describe('Manifest Utils', () => {
       });
 
       it('should return undefined when no icons are found', async () => {
-        const entrypoints = fakeArray(fakeEntrypoint);
+        const entrypoints = fakeArray(() => fakeEntrypoint({ skipped: false }));
         const buildOutput = fakeBuildOutput({
           publicAssets: [
             { type: 'asset', fileName: 'logo.png' },
@@ -413,7 +416,7 @@ describe('Manifest Utils', () => {
       });
 
       it('should allow icons to be overwritten from the wxt.config.ts file', async () => {
-        const entrypoints = fakeArray(fakeEntrypoint);
+        const entrypoints = fakeArray(() => fakeEntrypoint({ skipped: false }));
         const buildOutput = fakeBuildOutput({
           publicAssets: [
             { type: 'asset', fileName: 'icon-16.png' },
@@ -837,6 +840,7 @@ describe('Manifest Utils', () => {
             options: {
               registration: 'runtime',
             },
+            skipped: false,
           });
 
           const entrypoints = [cs];
@@ -902,6 +906,7 @@ describe('Manifest Utils', () => {
         async (browser) => {
           const sidepanel = fakeSidepanelEntrypoint({
             outputDir: outDir,
+            skipped: false,
           });
           const buildOutput = fakeBuildOutput();
 
@@ -934,6 +939,7 @@ describe('Manifest Utils', () => {
         async (browser) => {
           const sidepanel = fakeSidepanelEntrypoint({
             outputDir: outDir,
+            skipped: false,
           });
           const buildOutput = fakeBuildOutput();
 
@@ -1616,6 +1622,29 @@ describe('Manifest Utils', () => {
 
         expect(actual.content_security_policy).toEqual(expectedCsp);
       });
+    });
+
+    it('should not add skipped entrypoints to manifest', async () => {
+      const popup = fakePopupEntrypoint({ skipped: true });
+      const content = fakeContentScriptEntrypoint({ skipped: true });
+      const sidePanel = fakeSidepanelEntrypoint({ skipped: true });
+      const buildOutput = fakeBuildOutput();
+
+      setFakeWxt({
+        config: {
+          command: 'build',
+          manifestVersion: 3,
+        },
+      });
+
+      const { manifest } = await generateManifest(
+        [popup, content, sidePanel],
+        buildOutput,
+      );
+
+      expect(manifest.action).toBeUndefined();
+      expect(manifest.sidebar_action).toBeUndefined();
+      expect(manifest.content_scripts).toBeUndefined();
     });
   });
 

--- a/packages/wxt/src/core/utils/manifest.ts
+++ b/packages/wxt/src/core/utils/manifest.ts
@@ -47,9 +47,11 @@ export async function writeManifest(
  * Generates the manifest based on the config and entrypoints.
  */
 export async function generateManifest(
-  entrypoints: Entrypoint[],
+  _entrypoints: Entrypoint[],
   buildOutput: Omit<BuildOutput, 'manifest'>,
 ): Promise<{ manifest: Manifest.WebExtensionManifest; warnings: any[][] }> {
+  const entrypoints = _entrypoints.filter((entry) => !entry.skipped);
+
   const warnings: any[][] = [];
   const pkg = await getPackageJson();
 

--- a/packages/wxt/src/core/utils/testing/fake-objects.ts
+++ b/packages/wxt/src/core/utils/testing/fake-objects.ts
@@ -22,6 +22,7 @@ import {
   UserManifest,
   Wxt,
   SidepanelEntrypoint,
+  BaseEntrypoint,
 } from '../../../types';
 import { mock } from 'vitest-mock-extended';
 import { vi } from 'vitest';
@@ -50,7 +51,7 @@ export function fakeDir(root = process.cwd()): string {
   return resolve(root, faker.string.alphanumeric());
 }
 
-export const fakeEntrypoint = () =>
+export const fakeEntrypoint = (options?: DeepPartial<BaseEntrypoint>) =>
   faker.helpers.arrayElement([
     fakePopupEntrypoint,
     fakeGenericEntrypoint,
@@ -58,7 +59,7 @@ export const fakeEntrypoint = () =>
     fakeBackgroundEntrypoint,
     fakeContentScriptEntrypoint,
     fakeUnlistedScriptEntrypoint,
-  ])();
+  ])(options);
 
 export const fakeContentScriptEntrypoint =
   fakeObjectCreator<ContentScriptEntrypoint>(() => ({


### PR DESCRIPTION
In one of my personal extensions, noticed that skipped entrypoints where making it into the manifest. This PR removes them.