### PR TITLE
fix: Exclude entire `import.meta.env` object from content script output

### DIFF
--- a/packages/wxt/src/client/content-scripts/custom-events.ts
+++ b/packages/wxt/src/client/content-scripts/custom-events.ts
@@ -15,12 +15,5 @@ export class WxtLocationChangeEvent extends Event {
  * Returns an event name unique to the extension and content script that's running.
  */
 export function getUniqueEventName(eventName: string): string {
-  // During the build process, import.meta.env is not defined when importing
-  // entrypoints to get their metadata.
-  const entrypointName =
-    typeof import.meta.env === 'undefined'
-      ? 'build'
-      : import.meta.env.ENTRYPOINT;
-
-  return `${browser?.runtime?.id}:${entrypointName}:${eventName}`;
+  return `${browser?.runtime?.id}:${import.meta.env.ENTRYPOINT}:${eventName}`;
 }

--- a/packages/wxt/src/core/utils/building/import-entrypoint.ts
+++ b/packages/wxt/src/core/utils/building/import-entrypoint.ts
@@ -113,7 +113,7 @@ function getEsbuildOptions(opts: JitiTransformOptions): TransformOptions {
     format: 'cjs',
     loader: isJsx ? 'tsx' : 'ts',
     define: {
-      'import.meta.env.ENTRYPOINT': 'build',
+      'import.meta.env.ENTRYPOINT': '"build"',
     },
     ...(isJsx
       ? {

--- a/packages/wxt/src/core/utils/building/import-entrypoint.ts
+++ b/packages/wxt/src/core/utils/building/import-entrypoint.ts
@@ -112,6 +112,9 @@ function getEsbuildOptions(opts: JitiTransformOptions): TransformOptions {
   return {
     format: 'cjs',
     loader: isJsx ? 'tsx' : 'ts',
+    define: {
+      'import.meta.env.ENTRYPOINT': 'build',
+    },
     ...(isJsx
       ? {
           // `h` and `Fragment` are undefined, but that's OK because JSX is never evaluated while


### PR DESCRIPTION
[As mentioned on discord](https://discord.com/channels/1212416027611365476/1224505556346212515/1316157389048778783), content script output unnecessarily includes the entire `import.meta.env` object, including values from your .env file (only ones prefixed with `VITE_` or `WXT_`, which are already included elsewhere in your extension):

<img width="1273" alt="Screenshot 2024-12-10 at 4 58 13 PM" src="https://github.com/user-attachments/assets/c144195d-eac7-478b-976a-315d6b0bbed4">

This PR fixes this. Basically, this happens when you reference `import.meta.env` instead of `import.meta.env.VAR_NAME`.

We were doing this because of the old Jiti import method, which used CJS, and thus `import.meta.env` was undefined. Fixed this by telling Jiti to replace `import.meta.env.XYZ` with the environment variable value instead.