### PR TITLE
feat!: Reset inherited styles inside shadow root

### DIFF
--- a/packages/wxt/src/utils/content-script-ui/shadow-root.ts
+++ b/packages/wxt/src/utils/content-script-ui/shadow-root.ts
@@ -19,7 +19,14 @@ export async function createShadowRootUi<TMounted>(
   ctx: ContentScriptContext,
   options: ShadowRootContentScriptUiOptions<TMounted>,
 ): Promise<ShadowRootContentScriptUi<TMounted>> {
-  const css = [options.css ?? ''];
+  const css: string[] = [];
+
+  if (!options.inheritStyles) {
+    css.push(`/* WXT Shadow Root Reset */ body{all:initial;}`);
+  }
+  if (options.css) {
+    css.push(options.css);
+  }
   if (ctx.options?.cssInjectionMode === 'ui') {
     const entryCss = await loadCss();
     // Replace :root selectors with :host since we're in a shadow root
@@ -53,7 +60,7 @@ export async function createShadowRootUi<TMounted>(
   const remove = () => {
     // Cleanup mounted state
     options.onRemove?.(mounted);
-    // Detatch shadow root from DOM
+    // Detach shadow root from DOM
     shadowHost.remove();
     // Remove children from uiContainer
     while (uiContainer.lastChild)

--- a/packages/wxt/src/utils/content-script-ui/types.ts
+++ b/packages/wxt/src/utils/content-script-ui/types.ts
@@ -127,6 +127,21 @@ export type ShadowRootContentScriptUiOptions<TMounted> =
      */
     isolateEvents?: boolean | string[];
     /**
+     * By default, WXT adds `all: initial` to the shadow root before the rest of
+     * your CSS. This resets any inheritable CSS styles that
+     * [normally pierce the Shadow DOM](https://open-wc.org/guides/knowledge/styling/styles-piercing-shadow-dom/).
+     *
+     * WXT resets everything but:
+     * - **`rem` Units**: they continue to scale based off the webpage's HTML `font-size`.
+     * - **CSS Variables/Custom Properties**: CSS variables defined outside the shadow root can be accessed inside it.
+     * - **`@font-face` Definitions**: Fonts defined outside the shadow root can be used inside it.
+     *
+     * To disable this behavior and inherit styles from the webpage, set `inheritStyles: true`.
+     *
+     * @default false
+     */
+    inheritStyles?: boolean;
+    /**
      * Callback executed when mounting the UI. This function should create and append the UI to the
      * `uiContainer` element. It is called every time `ui.mount()` is called.
      *


### PR DESCRIPTION
BREAKING CHANGE: Before, if you use `createShadowRootUi`, some styles set on the webpage's `html` element would effect your UI in the shadow root. By default, WXT now applies a CSS reset to prevent your UI from inheriting any styles from the webpage.

Double check that your `createShadowRootUI` UIs are styled properly. If not:

- Continue inheriting styles like before by passing `inheritStyles: true`:
   ```diff
   const ui = await createShadowRootUi({
   + inheritStyles: true,
     // ...
   })
   ```
- Remove any manual resets for styles that were effecting your UI. For example:
   ```diff
   /* entrypoints/reddit.content/styles.css */
   - body {
   -   /* Override Reddit's default "hidden" visibility */
   -   visibility: visible !important;
   - }
   ```

This is a fairly low-impact breaking change. If you needed this reset, you were probably already doing it yourself and this will have no effect. If you didn't need to reset any styles, this shouldn't have any effect.

---

This closes #1195.