### PR TITLE
fix: Svelte production errors and warnings on resolve conditions

### DIFF
--- a/packages/module-svelte/src/index.ts
+++ b/packages/module-svelte/src/index.ts
@@ -22,7 +22,7 @@ export default defineWxtModule<SvelteModuleOptions>({
         }),
       ],
       resolve: {
-        conditions: mode === 'development' ? ['browser'] : [],
+        conditions: ['browser', mode],
       },
     }));
 


### PR DESCRIPTION
This closes #1274. For svelte, `resolve.conditions` needs to be `"browser"` for both dev and production builds. Additionally, the mode, usually "development" or "production", needs to be passed in the conditions to prevent [`esm-env`](https://www.npmjs.com/package/esm-env) from complaining.