### PR TITLE
docs: Fix invalid CSS color

### DIFF
--- a/docs/.vitepress/theme/custom.css
+++ b/docs/.vitepress/theme/custom.css
@@ -3,14 +3,14 @@
   --wxt-c-green-1: #0b8a00;
   --wxt-c-green-2: #096600;
   --wxt-c-green-3: #096600;
-  --wxt-c-green-soft: rgba(#0b8a00 / 0.14);
+  --wxt-c-green-soft: rgba(11, 138, 0, 0.14);
 }
 
 .dark {
   --wxt-c-green-1: #67d45e;
   --wxt-c-green-2: #329929;
   --wxt-c-green-3: #21651b;
-  --wxt-c-green-soft: rgba(#67d45e / 0.14);
+  --wxt-c-green-soft: rgba(103, 212, 94, 0.14);
 }
 
 /* https://github.com/vuejs/vitepress/blob/main/src/client/theme-default/styles/vars.css */


### PR DESCRIPTION
No,` rgba(#0b8a00 / .14)` is not a valid CSS value.

I haved update the vlaue to use RGB value with opacity for easy to update in future.

---

but here is alternative also if you prefer to use hex value with Alpha.

`rgba(#0b8a00 / .14)` to `#0b8a0024`
`rgba(#67d45e / .14)` to `#67d45e24`

Multiply the decimal opacity by 255 (e.g., `0.14 * 255 = 35.7`), approx 36 
Convert the number to a two-digit hex (36 in decimal is 24 in hex).