### PR TITLE
fix(web-ext): Correctly pass `browserConsole` option to open devtools in Firefox

### DIFF
--- a/packages/wxt/src/core/runners/web-ext.ts
+++ b/packages/wxt/src/core/runners/web-ext.ts
@@ -35,7 +35,7 @@ export function createWebExtRunner(): ExtensionRunner {
 
       const wxtUserConfig = wxt.config.runnerConfig.config;
       const userConfig = {
-        console: wxtUserConfig?.openConsole,
+        browserConsole: wxtUserConfig?.openConsole,
         devtools: wxtUserConfig?.openDevtools,
         startUrl: wxtUserConfig?.startUrls,
         keepProfileChanges: wxtUserConfig?.keepProfileChanges,


### PR DESCRIPTION
The browser console does not currently open on Firefox, because wxt is passing the wrong property to web-ext. The property is called `browserConsole` but wxt was passing `console`. 

See https://github.com/mozilla/web-ext/blob/master/src/cmd/run.js#L25