### PR TITLE
fix: Add back `ExtensionRunnerConfig` as deprecated

### DIFF
--- a/packages/wxt/src/types.ts
+++ b/packages/wxt/src/types.ts
@@ -907,6 +907,11 @@ export interface ConfigEnv {
 export type WxtCommand = 'build' | 'serve';
 
 /**
+ * @deprecated Use `WebExtConfig` instead.
+ */
+export type ExtensionRunnerConfig = WebExtConfig;
+
+/**
  * Options for how [`web-ext`](https://github.com/mozilla/web-ext) starts the browser.
  */
 export interface WebExtConfig {


### PR DESCRIPTION
Add back a type to prevent a breaking change.