### PR TITLE
docs: Added "ZenGram" to the homepage

### DIFF
--- a/docs/.vitepress/components/UsingWxtSection.vue
+++ b/docs/.vitepress/components/UsingWxtSection.vue
@@ -61,6 +61,7 @@ const chromeExtensionIds = [
   'eihpmapodnppeemkhkbhikmggfojdkjd', // Cursorful - Screen Recorder with Auto Zoom
   'hjjkgbibknbahijglkffklflidncplkn', // Show IP – Live View of Website IPs for Developers
   'ilbikcehnpkmldojkcmlldkoelofnbde', // Strong Password Generator
+  'ocllfkhcdopiafndigclebelbecaiocp', // ZenGram: Mindful Instagram, Your Way
 ];
 
 const { data, err, isLoading } = useListExtensionDetails(chromeExtensionIds);


### PR DESCRIPTION
ZenGram is a Chrome/Firefox extension that selectively blocks elements of Instagram Web. it's proudly built with WXT, and I'd like to add it as a part of the WXT homepage :)

it's also open-source under MIT, at https://github.com/abhigyantrips/ZenGram.