### PR TITLE
docs: Fix unocss readme

### DIFF
--- a/packages/unocss/README.md
+++ b/packages/unocss/README.md
@@ -38,8 +38,8 @@ The module can be configured via the `unocss` config:
 export default defineConfig({
   modules: ['@wxt-dev/unocss'],
   unocss: {
-    // Exclude unocss apply for popup/main.ts and background
-    excludeEntrypoints: ['popup/main.ts', 'background'],
+    // Exclude unocss from running for the background
+    excludeEntrypoints: ['background'],
   },
 });
 ```

--- a/packages/unocss/README.md
+++ b/packages/unocss/README.md
@@ -38,10 +38,10 @@ The module can be configured via the `unocss` config:
 export default defineConfig({
   modules: ['@wxt-dev/unocss'],
   unocss: {
-    // Will only apply unocss for popup/main.ts
-    entrypoints: ['popup/main.ts'],
+    // Exclude unocss apply for popup/main.ts and background
+    excludeEntrypoints: ['popup/main.ts', 'background'],
   },
 });
 ```
 
-Options have JSDocs available in your editor, or you can read them in the source code: [`UnoCSSOptions`](https://github.com/wxt-dev/wxt/blob/main/packages/auto-icons/src/index.ts).
+Options have JSDocs available in your editor, or you can read them in the source code: [`UnoCSSOptions`](https://github.com/wxt-dev/wxt/blob/main/packages/unocss/src/index.ts).


### PR DESCRIPTION
This PR does:

1. Add option `excludeEntrypoints` examples and cleanup `entrypoints`'s, cause there is no option `entrypoints`
2. Fix `UnoCSSOptions` link url