### PR TITLE
Added missing member used in `UserManifest` to define the manifest name.

### DIFF
--- a/packages/wxt/src/types.ts
+++ b/packages/wxt/src/types.ts
@@ -916,6 +916,9 @@ export type UserManifest = {
   web_accessible_resources?:
     | string[]
     | chrome.runtime.ManifestV3['web_accessible_resources'];
+} & {
+  // Defines the manifest name, alternatively derived from "<rootDir>/package.json"
+  name?: string
 };
 
 export type UserManifestFn = (


### PR DESCRIPTION
Hiya!

I was doing cursed things, like setting this project to run via Deno (successfully mind you!) and I came across a smol oversight in the typings, so I patched it up :)

>Added the missing manifest name member when defining the manifest name via the wxt.config.ts manifest option.

Happy to take input if you have any!

Br
Permik