### PR TITLE
docs: Add missing web_accessible_resources to `injectScript` example

### DIFF
--- a/docs/guide/essentials/content-scripts.md
+++ b/docs/guide/essentials/content-scripts.md
@@ -566,6 +566,20 @@ export default defineContentScript({
 });
 ```
 
+```json
+export default defineConfig({
+  manifest: {
+    // ...
+    web_accessible_resources: [
+      {
+        resources: ["example-main-world.js"],
+        matches: ["*://*/*"],
+      }
+    ]
+  }
+});
+```
+
 `injectScript` works by creating a `script` element on the page pointing to your script. This loads the script into the page's context so it runs in the main world.
 
 `injectScript` returns a promise, that when resolved, means the script has been evaluated by the browser and you can start communicating with it.


### PR DESCRIPTION
According to the documentation for injectScript(), it requires web_accessible_resources to be defined in the manifest file
(here https://github.com/wxt-dev/wxt/blob/main/packages/wxt/src/client/inject-script.ts#L16).
 However, this is missing from the current documentation. I have added the missing details.

P.S. I also verified that the script does not run without defining web_accessible_resources.