### PR TITLE
docs: Add react language ID to README

### DIFF
--- a/packages/i18n/README.md
+++ b/packages/i18n/README.md
@@ -354,6 +354,7 @@ You'll need to configure it the extension so it knows where your localization fi
 # You can check available language ids here: https://code.visualstudio.com/docs/languages/identifiers
 languageIds:
   - typescript
+  - typescriptreact
 
 # Look for t("...")
 usageMatchRegex:


### PR DESCRIPTION
Add typescriptreact as part of the I18n Ally Extension's languageIds as most translations occur in .tsx code.

This allows the translation to be displayed in tsx properly.