### PR TITLE
docs: Add missing bracket in example

### DIFF
--- a/docs/guide/essentials/content-scripts.md
+++ b/docs/guide/essentials/content-scripts.md
@@ -80,16 +80,16 @@ To create a standalone content script that only includes a CSS file:
    // wxt.config.ts
    export default defineConfig({
      hooks: {
-       "build:manifestGenerated": (wxt, manifest) => {
+       'build:manifestGenerated': (wxt, manifest) => {
          manifest.content_scripts ??= [];
          manifest.content_scripts.push({
            // Build extension once to see where your CSS get's written to
-           css: ["content-scripts/example.css"],
-           matches: ["*://*/*"]
-         )
-       }
-     }
-   })
+           css: ['content-scripts/example.css'],
+           matches: ['*://*/*'],
+         });
+       },
+     },
+   });
    ```
 
 ## UI


### PR DESCRIPTION
As shown in the picture, a bracket is missing, quickly submit a PR to fix it.

<img width="530" alt="image" src="https://github.com/user-attachments/assets/00c00ef0-7d09-4562-ad1a-8228ec303c53" />
