### PR TITLE
feat: Add `storage.clear`

### DIFF
--- a/packages/storage/src/__tests__/index.test.ts
+++ b/packages/storage/src/__tests__/index.test.ts
@@ -491,16 +491,13 @@ describe('Storage Utils', () => {
 
       describe('clear', () => {
         it('should remove all items', async () => {
-          const item1 = storage.defineItem(`${storageArea}:one`);
-          const item2 = storage.defineItem(`${storageArea}:two`);
           await fakeBrowser.storage[storageArea].set({
             one: 1,
             two: 2,
           });
 
           await storage.clear(storageArea);
-          expect(await item1.getValue()).toBeNull();
-          expect(await item2.getValue()).toBeNull();
+          expect(await fakeBrowser.storage[storageArea].get()).toEqual({});
         });
       });
 

--- a/packages/storage/src/__tests__/index.test.ts
+++ b/packages/storage/src/__tests__/index.test.ts
@@ -489,6 +489,21 @@ describe('Storage Utils', () => {
         });
       });
 
+      describe('clear', () => {
+        it('should remove all items', async () => {
+          const item1 = storage.defineItem(`${storageArea}:one`);
+          const item2 = storage.defineItem(`${storageArea}:two`);
+          await fakeBrowser.storage[storageArea].set({
+            one: 1,
+            two: 2,
+          });
+
+          await storage.clear(storageArea);
+          expect(await item1.getValue()).toBeNull();
+          expect(await item2.getValue()).toBeNull();
+        });
+      });
+
       describe('removeMeta', () => {
         it('should remove all metadata', async () => {
           await fakeBrowser.storage[storageArea].set({ count$: { v: 4 } });

--- a/packages/storage/src/index.ts
+++ b/packages/storage/src/index.ts
@@ -683,7 +683,7 @@ export interface WxtStorage {
   ): Promise<void>;
 
   /**
-   * Removes all items from storage.
+   * Removes all items from the provided storage area.
    */
   clear(base: StorageArea): Promise<void>;
 

--- a/packages/storage/src/index.ts
+++ b/packages/storage/src/index.ts
@@ -326,6 +326,10 @@ function createStorage(): WxtStorage {
         }),
       );
     },
+    clear: async (base) => {
+      const driver = getDriver(base);
+      await driver.clear();
+    },
     removeMeta: async (key, properties) => {
       const { driver, driverKey } = resolveKey(key);
       await removeMeta(driver, driverKey, properties);
@@ -534,6 +538,9 @@ function createDriver(storageArea: StorageArea): WxtStorageDriver {
     removeItems: async (keys) => {
       await getStorageArea().remove(keys);
     },
+    clear: async () => {
+      await getStorageArea().clear();
+    },
     snapshot: async () => {
       return await getStorageArea().get();
     },
@@ -674,6 +681,12 @@ export interface WxtStorage {
       | { item: WxtStorageItem<any, any>; options?: RemoveItemOptions }
     >,
   ): Promise<void>;
+
+  /**
+   * Removes all items from storage.
+   */
+  clear(base: StorageArea): Promise<void>;
+
   /**
    * Remove the entire metadata for a key, or specific properties by name.
    *
@@ -730,6 +743,7 @@ interface WxtStorageDriver {
   setItems(values: Array<{ key: string; value: any }>): Promise<void>;
   removeItem(key: string): Promise<void>;
   removeItems(keys: string[]): Promise<void>;
+  clear(): Promise<void>;
   snapshot(): Promise<Record<string, unknown>>;
   restoreSnapshot(data: Record<string, unknown>): Promise<void>;
   watch<T>(key: string, cb: WatchCallback<T | null>): Unwatch;


### PR DESCRIPTION
Though it is easy to call browser.storage.clear() to clear all the items, I guess it is needed to support clear in wxt storage. So I add this method.