### PR TITLE
Fix: Remove duplicated css rule from vue template

### DIFF
--- a/templates/vue/entrypoints/popup/style.css
+++ b/templates/vue/entrypoints/popup/style.css
@@ -23,15 +23,6 @@ a:hover {
   color: #535bf2;
 }
 
-a {
-  font-weight: 500;
-  color: #646cff;
-  text-decoration: inherit;
-}
-a:hover {
-  color: #535bf2;
-}
-
 body {
   margin: 0;
   display: flex;


### PR DESCRIPTION
This fix removes some duplicated rules on the style.css file on the Vue template.