### PR TITLE
chore(repo): add CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,6 @@
+# Set default
+* @aklinker1 @Timeraa
+
+# Creator of specific wxt modules
+packages/auto-icons/ @Timeraa
+packages/unocss/ @Timeraa


### PR DESCRIPTION
This PR adds a CODEOWNERS file first referenced in #1370 as a suggestion. It may also be useful to require a PR review (can be enforced as a rule in the repo settings)