### PR TITLE
docs: Add "Youtube Live Chat Fullscreen" to homepage

### DIFF
--- a/docs/.vitepress/components/UsingWxtSection.vue
+++ b/docs/.vitepress/components/UsingWxtSection.vue
@@ -65,6 +65,7 @@ const chromeExtensionIds = [
   'odffpjnpocjfcaclnenaaaddghkgijdb', // Blync: Preview Links, Selection Search, AI Assistant
   'kofbbilhmnkcmibjbioafflgmpkbnmme', // HTML to Markdown - Convert webpages to markdown
   'boecmgggeigllcdocgioijmleimjbfkg', // Walmart WFS Profit Calculator
+  'dlnjcbkmomenmieechnmgglgcljhoepd', // Youtube Live Chat Fullscreen
 ];
 
 const { data, err, isLoading } = useListExtensionDetails(chromeExtensionIds);


### PR DESCRIPTION
Add "Youtube Live Chat Fullscreen" to homepage
[github link](https://github.com/daichan132/Youtube-Live-Chat-Fullscreen)
[chrome extension link](https://chromewebstore.google.com/detail/youtube-live-chat-fullscr/dlnjcbkmomenmieechnmgglgcljhoepd)