### PR TITLE
docs: fix typo `you're` -> `your`

### DIFF
--- a/docs/guide/essentials/config/browser-startup.md
+++ b/docs/guide/essentials/config/browser-startup.md
@@ -74,7 +74,7 @@ export default defineRunnerConfig({
 Now, next time you run the `dev` script, a persistent profile will be created in `.wxt/chrome-data/{profile-name}`. With a persistent profile, you can install devtools extensions to help with development, allow the browser to remember logins, etc, without worrying about the profile being reset the next time you run the `dev` script.
 
 :::tip
-You can use any directory you'd like for `--user-data-dir`, the examples above create a persistent profile for each WXT project. To create a profile for all WXT projects, you can put the `chrome-data` directory inside you're user's home directory.
+You can use any directory you'd like for `--user-data-dir`, the examples above create a persistent profile for each WXT project. To create a profile for all WXT projects, you can put the `chrome-data` directory inside your user's home directory.
 :::
 
 ### Disable Opening Browser


### PR DESCRIPTION
### Overview

Fixing simple typo on the docs (`your` instead of `you're`)
- https://wxt.dev/guide/essentials/config/browser-startup.html#profile-customization

### Manual Testing

[your ](https://www.dictionary.com/browse/your) vs [you're](https://www.dictionary.com/browse/you're)



