### PR TITLE
fix: respect `inlineConfig.mode` when setting NODE_ENV

### DIFF
--- a/packages/wxt/src/core/wxt.ts
+++ b/packages/wxt/src/core/wxt.ts
@@ -21,7 +21,8 @@ export async function registerWxt(
 ): Promise<void> {
   // Default NODE_ENV environment variable before other packages, like vite, do it
   // See https://github.com/wxt-dev/wxt/issues/873#issuecomment-2254555523
-  process.env.NODE_ENV ??= command === 'serve' ? 'development' : 'production';
+  process.env.NODE_ENV ??=
+    inlineConfig.mode ?? (command === 'serve' ? 'development' : 'production');
 
   const hooks = createHooks<WxtHooks>();
   const config = await resolveConfig(inlineConfig, command);


### PR DESCRIPTION
### Overview

<!-- Describe your changes and why you made them -->
I think this fix is self-explanatory, but let me know if you need clarification.

### Manual Testing

<!-- Describe how to test your changes to make sure the PR works as intended -->
1. Add an expression that uses `import.meta.env.DEV` (or a statement wrapped with an `if (import.meta.env.DEV)` condition)

2. Build with `pnpm build --mode=development`

3. Notice how, without this PR, `import.meta.env.DEV` unexpectedly resolves to false.

