### PR TITLE
fix: Ignore `manifest.manifest_version` option and warn about incorrect usage

### DIFF
--- a/packages/wxt/src/core/utils/__tests__/manifest.test.ts
+++ b/packages/wxt/src/core/utils/__tests__/manifest.test.ts
@@ -21,6 +21,7 @@ import {
   OutputAsset,
 } from '../../../types';
 import { wxt } from '../../wxt';
+import { mock } from 'vitest-mock-extended';
 
 const outDir = '/output';
 const contentScriptOutDir = '/output/content-scripts';
@@ -1645,6 +1646,33 @@ describe('Manifest Utils', () => {
       expect(manifest.action).toBeUndefined();
       expect(manifest.sidebar_action).toBeUndefined();
       expect(manifest.content_scripts).toBeUndefined();
+    });
+
+    describe('manifest_version', () => {
+      it('should ignore and log a warning when someone sets `manifest_version` inside the manifest', async () => {
+        const buildOutput = fakeBuildOutput();
+        const expectedVersion = 2;
+        setFakeWxt({
+          logger: mock(),
+          config: {
+            command: 'build',
+            manifestVersion: expectedVersion,
+            manifest: {
+              manifest_version: 3,
+            },
+          },
+        });
+
+        const { manifest } = await generateManifest([], buildOutput);
+
+        expect(manifest.manifest_version).toBe(expectedVersion);
+        expect(wxt.logger.warn).toBeCalledTimes(1);
+        expect(wxt.logger.warn).toBeCalledWith(
+          expect.stringContaining(
+            '`manifest.manifest_version` config was set, but ignored',
+          ),
+        );
+      });
     });
   });
 

--- a/packages/wxt/src/core/utils/manifest.ts
+++ b/packages/wxt/src/core/utils/manifest.ts
@@ -79,7 +79,7 @@ export async function generateManifest(
   if (userManifest.manifest_version) {
     delete userManifest.manifest_version;
     wxt.logger.warn(
-      '`manifest.manifest_version` config was set, but ignored. To change the target manifest version, use the `manifestVersion` option or the `--mv2`/`mv3` CLI flags.\nSee https://wxt.dev/guide/essentials/target-different-browsers.html#target-a-manifest-version',
+      '`manifest.manifest_version` config was set, but ignored. To change the target manifest version, use the `manifestVersion` option or the `--mv2`/`--mv3` CLI flags.\nSee https://wxt.dev/guide/essentials/target-different-browsers.html#target-a-manifest-version',
     );
   }
 

--- a/packages/wxt/src/core/utils/manifest.ts
+++ b/packages/wxt/src/core/utils/manifest.ts
@@ -76,6 +76,12 @@ export async function generateManifest(
     icons: discoverIcons(buildOutput),
   };
   const userManifest = wxt.config.manifest;
+  if (userManifest.manifest_version) {
+    delete userManifest.manifest_version;
+    wxt.logger.warn(
+      '`manifest.manifest_version` config was set, but ignored. To change the target manifest version, use the `manifestVersion` option or the `--mv2`/`mv3` CLI flags.\nSee https://wxt.dev/guide/essentials/target-different-browsers.html#target-a-manifest-version',
+    );
+  }
 
   let manifest = defu(
     userManifest,


### PR DESCRIPTION
### Overview

`manifest.manifest_version` is not how you configure the target manifest version. This PR ignores the option if set (previously, it overwrote the target `manifest_version`, [as described in the issue](https://github.com/wxt-dev/wxt/issues/1388)) and logs a warning telling you that it is configured wrong.

### Manual Testing

See unit tests. No manual testing required.

### Related Issue

This PR closes #1388.
