### PR TITLE
fix: Support `registration: "runtime"` for MV2

### DIFF
--- a/packages/wxt/src/core/utils/__tests__/manifest.test.ts
+++ b/packages/wxt/src/core/utils/__tests__/manifest.test.ts
@@ -836,30 +836,6 @@ describe('Manifest Utils', () => {
       });
 
       describe('registration', () => {
-        it('should throw an error when registration=runtime for MV2', async () => {
-          const cs: ContentScriptEntrypoint = fakeContentScriptEntrypoint({
-            options: {
-              registration: 'runtime',
-            },
-            skipped: false,
-          });
-
-          const entrypoints = [cs];
-          const buildOutput: Omit<BuildOutput, 'manifest'> = {
-            publicAssets: [],
-            steps: [{ entrypoints: cs, chunks: [] }],
-          };
-          setFakeWxt({
-            config: {
-              manifestVersion: 2,
-            },
-          });
-
-          await expect(
-            generateManifest(entrypoints, buildOutput),
-          ).rejects.toThrowError();
-        });
-
         it('should add host_permissions instead of content_scripts when registration=runtime', async () => {
           const cs: ContentScriptEntrypoint = {
             type: 'content-script',

--- a/packages/wxt/src/core/utils/manifest.ts
+++ b/packages/wxt/src/core/utils/manifest.ts
@@ -412,14 +412,6 @@ function addEntrypoints(
       const runtimeContentScripts = contentScripts.filter(
         (cs) => cs.options.registration === 'runtime',
       );
-      if (
-        runtimeContentScripts.length > 0 &&
-        wxt.config.manifestVersion === 2
-      ) {
-        throw Error(
-          'Cannot use `registration: "runtime"` with MV2 content scripts, it is a MV3-only feature.',
-        );
-      }
       runtimeContentScripts.forEach((script) => {
         script.options.matches?.forEach((matchPattern) => {
           addHostPermission(manifest, matchPattern);


### PR DESCRIPTION
### Overview

Allow scripts to not register with manifest.json for MV2


### Manual Testing

add scripts to not register with manifest.json for MV2. now it builds successfully.

### Related Issue

<!-- If this PR is related to an issue, please link it here -->

This PR closes #1428
