### PR TITLE
fix: Properly detect and reload changed files when using Vite's `?suffix` imports

### DIFF
--- a/packages/wxt-demo/src/entrypoints/ui.content/index.ts
+++ b/packages/wxt-demo/src/entrypoints/ui.content/index.ts
@@ -1,11 +1,16 @@
 import 'uno.css';
 import './style.css';
+import manualStyle from './manual-style.css?inline';
 
 export default defineContentScript({
   matches: ['https://*.duckduckgo.com/*'],
   cssInjectionMode: 'ui',
 
   async main(ctx) {
+    const style = document.createElement('style');
+    style.textContent = manualStyle;
+    document.head.append(style);
+
     const ui = await createShadowRootUi(ctx, {
       name: 'demo-ui',
       position: 'inline',

--- a/packages/wxt-demo/src/entrypoints/ui.content/manual-style.css
+++ b/packages/wxt-demo/src/entrypoints/ui.content/manual-style.css
@@ -1,0 +1,4 @@
+body {
+  padding: 2rem;
+  background-color: blanchedalmond;
+}


### PR DESCRIPTION
### Overview

This PR for the #1062. The user modified file path has no suffix, and the moduleIds path written in the import syntax has a suffix. So it was unmatched and dev server no-changes.

I've changed the code style a bit. If you don't like it, please modify it to your liking.

### Manual Testing

1. cd wxt-demo && pnpm dev
2. edit & save `src/entrypoints/ui.content/manual-style.css`
3. check reload and apply new styles.

### Related Issue

This PR closes #1062
