### PR TITLE
fix: catch crash in dev server (fixes #1297)

### DIFF
--- a/packages/wxt/src/core/create-server.ts
+++ b/packages/wxt/src/core/create-server.ts
@@ -219,9 +219,9 @@ function createFileReloader(server: WxtDevServer) {
           .join(', ')}`,
       );
 
-      // Rebuild entrypoints on change
-      const allEntrypoints = await findEntrypoints();
       try {
+        // Rebuild entrypoints on change
+        const allEntrypoints = await findEntrypoints();
         const { output: newOutput } = await rebuild(
           allEntrypoints,
           // TODO: this excludes new entrypoints, so they're not built until the dev command is restarted


### PR DESCRIPTION
Fixes #1297.
Catch exception in `findEntrypoints` when reloading changed files in dev server.

### Overview

This fixes a problem where the dev server would crash on syntax errors when reloading changed files. The crash occurs due to an exception in the Babel parser which is invoked for finding the entrypoints. The fix is moving the call to findEntrypoints to the try block, where an exception would be caught - just like the rest of the reload logic.
<!-- Describe your changes and why you made them -->

### Manual Testing

I have a project which would crash every few minutes while editing in VSCode. After the fix the crashes are gone and the reload works.
<!-- Describe how to test your changes to make sure the PR works as intended -->

### Related Issue

This PR closes #1297
