### PR TITLE
chore: Add funding links to `package.json` files

### DIFF
--- a/packages/i18n/package.json
+++ b/packages/i18n/package.json
@@ -19,6 +19,7 @@
     "email": "aaronklinker1+wxt@gmail.com"
   },
   "license": "MIT",
+  "funding": "https://github.com/sponsors/wxt-dev",
   "scripts": {
     "build": "buildc -- unbuild",
     "check": "buildc --deps-only -- check",

--- a/packages/module-react/package.json
+++ b/packages/module-react/package.json
@@ -17,6 +17,7 @@
     "email": "aaronklinker1+wxt@gmail.com"
   },
   "license": "MIT",
+  "funding": "https://github.com/sponsors/wxt-dev",
   "version": "1.1.3",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/packages/module-solid/package.json
+++ b/packages/module-solid/package.json
@@ -17,6 +17,7 @@
     "email": "aaronklinker1+wxt@gmail.com"
   },
   "license": "MIT",
+  "funding": "https://github.com/sponsors/wxt-dev",
   "version": "1.1.3",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/packages/module-svelte/package.json
+++ b/packages/module-svelte/package.json
@@ -17,6 +17,7 @@
     "email": "aaronklinker1+wxt@gmail.com"
   },
   "license": "MIT",
+  "funding": "https://github.com/sponsors/wxt-dev",
   "version": "2.0.3",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/packages/module-vue/package.json
+++ b/packages/module-vue/package.json
@@ -17,6 +17,7 @@
     "email": "aaronklinker1+wxt@gmail.com"
   },
   "license": "MIT",
+  "funding": "https://github.com/sponsors/wxt-dev",
   "version": "1.0.2",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -23,6 +23,7 @@
     "email": "aaronklinker1+wxt@gmail.com"
   },
   "license": "MIT",
+  "funding": "https://github.com/sponsors/wxt-dev",
   "scripts": {
     "build": "buildc -- unbuild",
     "check": "buildc --deps-only -- check",

--- a/packages/wxt/package.json
+++ b/packages/wxt/package.json
@@ -2,7 +2,7 @@
   "name": "wxt",
   "type": "module",
   "version": "0.19.27",
-  "description": "Next gen framework for developing web extensions",
+  "description": "⚡ Next-gen Web Extension Framework",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/wxt-dev/wxt.git"
@@ -22,6 +22,7 @@
     "email": "aaronklinker1+wxt@gmail.com"
   },
   "license": "MIT",
+  "funding": "https://github.com/sponsors/wxt-dev",
   "files": [
     "bin",
     "dist"


### PR DESCRIPTION
### Overview

* Added funding URL to the following packages:
  - i18n
  - module-react
  - module-solid
  - module-svelte
  - module-vue
  - storage
  - wxt
 
I left out the packages that @Timeraa is authored because I don't know if it should be sponsored or an organization

Your NPM package will have the following button:

<img src="https://github.com/user-attachments/assets/625d8be4-7a08-48a8-ad13-fc2e88ff881a" width="560">



