### PR TITLE
fix: regression on variable expansion in dotenv files

### DIFF
--- a/packages/wxt/package.json
+++ b/packages/wxt/package.json
@@ -98,6 +98,7 @@
     "consola": "^3.2.3",
     "defu": "^6.1.4",
     "dotenv": "^16.4.5",
+    "dotenv-expand": "^12.0.1",
     "esbuild": "^0.21.5",
     "fast-glob": "^3.3.2",
     "filesize": "^10.1.6",

--- a/packages/wxt/src/core/utils/env.ts
+++ b/packages/wxt/src/core/utils/env.ts
@@ -1,21 +1,24 @@
 import { config } from 'dotenv';
+import { expand } from 'dotenv-expand';
 import type { TargetBrowser } from '../../types';
 
 /**
  * Load environment files based on the current mode and browser.
  */
 export function loadEnv(mode: string, browser: TargetBrowser) {
-  return config({
-    // Files on top override files below
-    path: [
-      `.env.${mode}.${browser}.local`,
-      `.env.${mode}.${browser}`,
-      `.env.${browser}.local`,
-      `.env.${browser}`,
-      `.env.${mode}.local`,
-      `.env.${mode}`,
-      `.env.local`,
-      `.env`,
-    ],
-  });
+  return expand(
+    config({
+      // Files on top override files below
+      path: [
+        `.env.${mode}.${browser}.local`,
+        `.env.${mode}.${browser}`,
+        `.env.${browser}.local`,
+        `.env.${browser}`,
+        `.env.${mode}.local`,
+        `.env.${mode}`,
+        `.env.local`,
+        `.env`,
+      ],
+    }),
+  );
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -387,6 +387,9 @@ importers:
       dotenv:
         specifier: ^16.4.5
         version: 16.4.5
+      dotenv-expand:
+        specifier: ^12.0.1
+        version: 12.0.1
       esbuild:
         specifier: ^0.21.5
         version: 0.21.5
@@ -2871,6 +2874,10 @@ packages:
     resolution: {integrity: sha512-tE7ztYzXHIeyvc7N+hR3oi7FIbf/NIjVP9hmAt3yMXzrQ072/fpjGLx2GxNxGxUl5V73MEqYzioOMoVhGMJ5cA==}
     engines: {node: '>=10'}
 
+  dotenv-expand@12.0.1:
+    resolution: {integrity: sha512-LaKRbou8gt0RNID/9RoI+J2rvXsBRPMV7p+ElHlPhcSARbCPDYcYG2s1TIzAfWv4YSgyY5taidWzzs31lNV3yQ==}
+    engines: {node: '>=12'}
+
   dotenv@16.4.5:
     resolution: {integrity: sha512-ZmdL2rui+eB2YwhsWzjInR8LldtZHGDoQ1ugH85ppHKwpUHL7j7rN0Ti9NCnGiQbhaZ11FpR+7ao1dNsmduNUg==}
     engines: {node: '>=12'}
@@ -3117,12 +3124,10 @@ packages:
 
   glob@6.0.4:
     resolution: {integrity: sha512-MKZeRNyYZAVVVG1oZeLaWie1uweH40m9AZwIwxyPbTSX4hHrVYSzLg0Ro5Z5R7XKkIX+Cc6oD1rqeDJnwsB8/A==}
-    deprecated: Glob versions prior to v9 are no longer supported
 
   glob@8.1.0:
     resolution: {integrity: sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==}
     engines: {node: '>=12'}
-    deprecated: Glob versions prior to v9 are no longer supported
 
   global-dirs@3.0.1:
     resolution: {integrity: sha512-NBcGGFbBA9s1VzD41QXDG+3++t9Mn5t1FpLdhESY6oKY4gYTFpX4wO3sqGUa0Srjtbfj3szX0RnemmrVRUdULA==}
@@ -3263,7 +3268,6 @@ packages:
 
   inflight@1.0.6:
     resolution: {integrity: sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==}
-    deprecated: This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.
 
   inherits@2.0.4:
     resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
@@ -4391,7 +4395,6 @@ packages:
 
   rimraf@2.4.5:
     resolution: {integrity: sha512-J5xnxTyqaiw06JjMftq7L9ouA448dw/E7dKghkP9WpKNuwmARNNg+Gk8/u5ryb9N/Yo2+z3MCwuqFK/+qPOPfQ==}
-    deprecated: Rimraf versions prior to v4 are no longer supported
     hasBin: true
 
   rollup-plugin-dts@6.1.1:
@@ -7501,6 +7504,10 @@ snapshots:
   dot-prop@6.0.1:
     dependencies:
       is-obj: 2.0.0
+
+  dotenv-expand@12.0.1:
+    dependencies:
+      dotenv: 16.4.5
 
   dotenv@16.4.5: {}
 


### PR DESCRIPTION
### Overview

[PR #978](https://github.com/wxt-dev/wxt/pull/978), released in [v0.19.10](https://github.com/wxt-dev/wxt/releases/tag/wxt-v0.19.10),
broke variable expansion in dotenv files, a Vite built-in feature.

I encountered this while migrating from v0.18.2 to the latest.

Since already defined variables in process.env take presedence,
the call to dotenv-expand by vite won't have any effect. Calling
dotenv-expand ourselves to mimic what vite does restores the lost
functionality.

Vite has a slightly more complex env loading logic, so these changes
won't bring 100% parity, but should be good for most use-cases.

See: https://github.com/vitejs/vite/blob/642d528b7b403eb91c67ff809ffa0fb99a1ff56e/packages/vite/src/node/env.ts

<!-- Describe your changes and why you made them -->

### Manual Testing

I've tested this in production already by applying the very same
changes with `pnpm patch` in my project.

### Related Issue

<!-- If this PR is related to an issue, please link it here -->

None reported so far (I did not bother to create an issue first).
