### PR TITLE
docs: Add AI assistant to https://wxt.dev

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -27,6 +27,7 @@ const ogImage = 'https://wxt.dev/social-preview.png';
 // https://vitepress.dev/reference/site-config
 export default defineConfig({
   extends: knowledge({
+    serverUrl: 'https://knowledge.wxt.dev',
     paths: {
       '/': 'docs',
       '/api/': 'api-reference',

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "typedoc-vitepress-theme": "1.0.0-next.3",
     "typescript": "^5.6.3",
     "vitepress": "^1.5.0",
-    "vitepress-knowledge": "^0.3.0",
+    "vitepress-knowledge": "^0.3.1",
     "vitest-mock-extended": "^2.0.2",
     "vue": "^3.5.12",
     "wxt": "workspace:*"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -80,8 +80,8 @@ importers:
         specifier: ^1.5.0
         version: 1.5.0(@algolia/client-search@4.20.0)(@types/node@20.17.6)(@types/react@18.3.12)(postcss@8.4.47)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.80.7)(search-insights@2.15.0)(typescript@5.6.3)
       vitepress-knowledge:
-        specifier: ^0.3.0
-        version: 0.3.0(vitepress@1.5.0(@algolia/client-search@4.20.0)(@types/node@20.17.6)(@types/react@18.3.12)(postcss@8.4.47)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.80.7)(search-insights@2.15.0)(typescript@5.6.3))
+        specifier: ^0.3.1
+        version: 0.3.1(vitepress@1.5.0(@algolia/client-search@4.20.0)(@types/node@20.17.6)(@types/react@18.3.12)(postcss@8.4.47)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.80.7)(search-insights@2.15.0)(typescript@5.6.3))
       vitest-mock-extended:
         specifier: ^2.0.2
         version: 2.0.2(typescript@5.6.3)(vitest@2.1.4(@types/node@20.17.6)(happy-dom@16.6.0)(sass@1.80.7))
@@ -5000,8 +5000,8 @@ packages:
       vite:
         optional: true
 
-  vitepress-knowledge@0.3.0:
-    resolution: {integrity: sha512-P3M6u30cV7bgbIFWOvfkyaDHhkk4rrVTzU8Qc8N1iEtn1lCP9Ulk3+PZXVzJ8sf7UEg1ObUMPrWFJd1XjuZJdQ==}
+  vitepress-knowledge@0.3.1:
+    resolution: {integrity: sha512-5BAUdYBvVxOmJQItd/Aa9ZlrKdiDdKKL3z3sp/uwAQshB007NxN4eaROO2NdWVDArB7nQBFSQmbsVuwYmBpLfg==}
     peerDependencies:
       vitepress: ^1.0.0
 
@@ -9789,7 +9789,7 @@ snapshots:
     optionalDependencies:
       vite: 5.4.11(@types/node@20.17.6)(sass@1.80.7)
 
-  vitepress-knowledge@0.3.0(vitepress@1.5.0(@algolia/client-search@4.20.0)(@types/node@20.17.6)(@types/react@18.3.12)(postcss@8.4.47)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.80.7)(search-insights@2.15.0)(typescript@5.6.3)):
+  vitepress-knowledge@0.3.1(vitepress@1.5.0(@algolia/client-search@4.20.0)(@types/node@20.17.6)(@types/react@18.3.12)(postcss@8.4.47)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.80.7)(search-insights@2.15.0)(typescript@5.6.3)):
     dependencies:
       linkedom: 0.18.6
       node-html-markdown: 1.3.0


### PR DESCRIPTION
### Overview

Adds a chatbot to the docs website (video from test before it was added to WXT):

[wxt-ask-ai-demo.webm](https://github.com/user-attachments/assets/b865babe-0cdb-4591-8d99-8200905940ba)

### Manual Testing

<!-- Describe how to test your changes to make sure the PR works as intended -->
The chat won't function on netlify PRs. CORS will block any request you try and make to the API.

It will work if you run `pnpm docs:dev` and open the docs locally at http://localhost:5173

You can also view the server's OpenAPI docs here: https://knowledge.wxt.dev/swagger

### Related Issue

<!-- If this PR is related to an issue, please link it here -->
N/A
