### PR TITLE
fix: restarting keyboardShortcuts listener on file changes.

### DIFF
--- a/packages/wxt/src/core/create-server.ts
+++ b/packages/wxt/src/core/create-server.ts
@@ -109,13 +109,15 @@ async function createServerInternal(): Promise<WxtDevServer> {
       await buildAndOpenBrowser();
 
       // Listen for file changes and reload different parts of the extension accordingly
-      const reloadOnChange = createFileReloader(server);
+      const reloadOnChange = () => {
+        createFileReloader(server);
+        keyboardShortcuts.start();
+        keyboardShortcuts.printHelp({
+          canReopenBrowser:
+            !wxt.config.runnerConfig.config.disabled && !!runner.canOpen?.(),
+        });
+      };
       server.watcher.on('all', reloadOnChange);
-      keyboardShortcuts.start();
-      keyboardShortcuts.printHelp({
-        canReopenBrowser:
-          !wxt.config.runnerConfig.config.disabled && !!runner.canOpen?.(),
-      });
     },
 
     async stop() {


### PR DESCRIPTION
### Overview

I noticed that keyboard shortcuts weren't working after files were being saved or HMR was triggered.
Hope this fixes it.
