### PR TITLE
fix: Allow vite 6.0.9+

### DIFF
--- a/packages/wxt/e2e/tests/npm-packages.test.ts
+++ b/packages/wxt/e2e/tests/npm-packages.test.ts
@@ -21,8 +21,7 @@ test('Only one version of esbuild should be installed (each version is ~20mb of 
     if (name === 'esbuild') esbuildVersions.add(meta.version);
   });
 
-  // TODO: Revert to 1 once vite is upgraded to >6.0.8
-  expect([...esbuildVersions]).toHaveLength(2);
+  expect([...esbuildVersions]).toHaveLength(1);
 });
 
 function iterateDependencies(

--- a/packages/wxt/src/core/builders/vite/index.ts
+++ b/packages/wxt/src/core/builders/vite/index.ts
@@ -67,6 +67,11 @@ export async function createViteBuilder(
       ignored: [`${wxtConfig.outBaseDir}/**`, `${wxtConfig.wxtDir}/**`],
     };
 
+    // TODO: Remove once https://github.com/wxt-dev/wxt/pull/1411 is merged
+    config.legacy ??= {};
+    // @ts-ignore: Untyped option:
+    config.legacy.skipWebSocketTokenCheck = false;
+
     const server = getWxtDevServer?.();
 
     config.plugins ??= [];

--- a/packages/wxt/src/core/builders/vite/index.ts
+++ b/packages/wxt/src/core/builders/vite/index.ts
@@ -70,7 +70,7 @@ export async function createViteBuilder(
     // TODO: Remove once https://github.com/wxt-dev/wxt/pull/1411 is merged
     config.legacy ??= {};
     // @ts-ignore: Untyped option:
-    config.legacy.skipWebSocketTokenCheck = false;
+    config.legacy.skipWebSocketTokenCheck = true;
 
     const server = getWxtDevServer?.();
 

--- a/packages/wxt/src/core/builders/vite/plugins/bundleAnalysis.ts
+++ b/packages/wxt/src/core/builders/vite/plugins/bundleAnalysis.ts
@@ -6,7 +6,6 @@ import path from 'node:path';
 let increment = 0;
 
 export function bundleAnalysis(config: ResolvedConfig): vite.Plugin {
-  // @ts-expect-error: Mismatched vite version
   return visualizer({
     template: 'raw-data',
     filename: path.resolve(

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -449,7 +449,7 @@ importers:
         version: 3.0.7(@types/node@20.17.6)(happy-dom@17.1.8)(jiti@2.4.2)(sass@1.80.7)(tsx@4.19.3)(yaml@2.7.0)
       vitest-plugin-random-seed:
         specifier: 'catalog:'
-        version: 1.1.1(vite@6.0.8(@types/node@20.17.6)(jiti@2.4.2)(sass@1.80.7)(tsx@4.19.3)(yaml@2.7.0))
+        version: 1.1.1(vite@6.2.0(@types/node@20.17.6)(jiti@2.4.2)(sass@1.80.7)(tsx@4.19.3)(yaml@2.7.0))
       wxt:
         specifier: workspace:*
         version: link:../wxt
@@ -5202,46 +5202,6 @@ packages:
       terser:
         optional: true
 
-  vite@6.0.8:
-    resolution: {integrity: sha512-rJmB+6m3Qmo5nssFmm6hbSvaCS+5tH/iuTJYeHEOHMwqu/DPrjjBs1rlecCo4D0qy5xq506hMpkKx6pKaudUxA==}
-    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
-    hasBin: true
-    peerDependencies:
-      '@types/node': ^18.0.0 || ^20.0.0 || >=22.0.0
-      jiti: '>=1.21.0'
-      less: '*'
-      lightningcss: ^1.21.0
-      sass: '*'
-      sass-embedded: '*'
-      stylus: '*'
-      sugarss: '*'
-      terser: ^5.16.0
-      tsx: ^4.8.1
-      yaml: ^2.4.2
-    peerDependenciesMeta:
-      '@types/node':
-        optional: true
-      jiti:
-        optional: true
-      less:
-        optional: true
-      lightningcss:
-        optional: true
-      sass:
-        optional: true
-      sass-embedded:
-        optional: true
-      stylus:
-        optional: true
-      sugarss:
-        optional: true
-      terser:
-        optional: true
-      tsx:
-        optional: true
-      yaml:
-        optional: true
-
   vite@6.2.0:
     resolution: {integrity: sha512-7dPxoo+WsT/64rDcwoOjk76XHj+TqNTIvHKcuMQ1k4/SeHDaQt5GFAeLYzrimZrMpn/O6DtdI03WUjdxuPM0oQ==}
     engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
@@ -6879,13 +6839,13 @@ snapshots:
       chai: 5.2.0
       tinyrainbow: 2.0.0
 
-  '@vitest/mocker@3.0.7(vite@6.0.8(@types/node@20.17.6)(jiti@2.4.2)(sass@1.80.7)(tsx@4.19.3)(yaml@2.7.0))':
+  '@vitest/mocker@3.0.7(vite@6.2.0(@types/node@20.17.6)(jiti@2.4.2)(sass@1.80.7)(tsx@4.19.3)(yaml@2.7.0))':
     dependencies:
       '@vitest/spy': 3.0.7
       estree-walker: 3.0.3
       magic-string: 0.30.17
     optionalDependencies:
-      vite: 6.0.8(@types/node@20.17.6)(jiti@2.4.2)(sass@1.80.7)(tsx@4.19.3)(yaml@2.7.0)
+      vite: 6.2.0(@types/node@20.17.6)(jiti@2.4.2)(sass@1.80.7)(tsx@4.19.3)(yaml@2.7.0)
 
   '@vitest/pretty-format@3.0.7':
     dependencies:
@@ -9984,19 +9944,6 @@ snapshots:
       fsevents: 2.3.3
       sass: 1.80.7
 
-  vite@6.0.8(@types/node@20.17.6)(jiti@2.4.2)(sass@1.80.7)(tsx@4.19.3)(yaml@2.7.0):
-    dependencies:
-      esbuild: 0.24.2
-      postcss: 8.5.3
-      rollup: 4.34.9
-    optionalDependencies:
-      '@types/node': 20.17.6
-      fsevents: 2.3.3
-      jiti: 2.4.2
-      sass: 1.80.7
-      tsx: 4.19.3
-      yaml: 2.7.0
-
   vite@6.2.0(@types/node@20.17.6)(jiti@2.4.2)(sass@1.80.7)(tsx@4.19.3)(yaml@2.7.0):
     dependencies:
       esbuild: 0.25.0
@@ -10077,10 +10024,6 @@ snapshots:
       typescript: 5.6.3
       vitest: 3.0.7(@types/node@20.17.6)(happy-dom@17.1.8)(jiti@2.4.2)(sass@1.80.7)(tsx@4.19.3)(yaml@2.7.0)
 
-  vitest-plugin-random-seed@1.1.1(vite@6.0.8(@types/node@20.17.6)(jiti@2.4.2)(sass@1.80.7)(tsx@4.19.3)(yaml@2.7.0)):
-    dependencies:
-      vite: 6.0.8(@types/node@20.17.6)(jiti@2.4.2)(sass@1.80.7)(tsx@4.19.3)(yaml@2.7.0)
-
   vitest-plugin-random-seed@1.1.1(vite@6.2.0(@types/node@20.17.6)(jiti@2.4.2)(sass@1.80.7)(tsx@4.19.3)(yaml@2.7.0)):
     dependencies:
       vite: 6.2.0(@types/node@20.17.6)(jiti@2.4.2)(sass@1.80.7)(tsx@4.19.3)(yaml@2.7.0)
@@ -10088,7 +10031,7 @@ snapshots:
   vitest@3.0.7(@types/node@20.17.6)(happy-dom@17.1.8)(jiti@2.4.2)(sass@1.80.7)(tsx@4.19.3)(yaml@2.7.0):
     dependencies:
       '@vitest/expect': 3.0.7
-      '@vitest/mocker': 3.0.7(vite@6.0.8(@types/node@20.17.6)(jiti@2.4.2)(sass@1.80.7)(tsx@4.19.3)(yaml@2.7.0))
+      '@vitest/mocker': 3.0.7(vite@6.2.0(@types/node@20.17.6)(jiti@2.4.2)(sass@1.80.7)(tsx@4.19.3)(yaml@2.7.0))
       '@vitest/pretty-format': 3.0.7
       '@vitest/runner': 3.0.7
       '@vitest/snapshot': 3.0.7
@@ -10104,7 +10047,7 @@ snapshots:
       tinyexec: 0.3.2
       tinypool: 1.0.2
       tinyrainbow: 2.0.0
-      vite: 6.0.8(@types/node@20.17.6)(jiti@2.4.2)(sass@1.80.7)(tsx@4.19.3)(yaml@2.7.0)
+      vite: 6.2.0(@types/node@20.17.6)(jiti@2.4.2)(sass@1.80.7)(tsx@4.19.3)(yaml@2.7.0)
       vite-node: 3.0.7(@types/node@20.17.6)(jiti@2.4.2)(sass@1.80.7)(tsx@4.19.3)(yaml@2.7.0)
       why-is-node-running: 2.3.0
     optionalDependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -260,7 +260,7 @@ catalogs:
       version: 66.0.0
     vite:
       specifier: ^5.0.0 || ^6.0.0
-      version: 6.0.8
+      version: 6.2.0
     vite-node:
       specifier: ^2.1.4 || ^3.0.0
       version: 3.0.7
@@ -458,7 +458,7 @@ importers:
     dependencies:
       '@vitejs/plugin-react':
         specifier: 'catalog:'
-        version: 4.3.4(vite@6.0.8(@types/node@20.17.6)(jiti@2.4.2)(sass@1.80.7)(tsx@4.19.3)(yaml@2.7.0))
+        version: 4.3.4(vite@6.2.0(@types/node@20.17.6)(jiti@2.4.2)(sass@1.80.7)(tsx@4.19.3)(yaml@2.7.0))
     devDependencies:
       '@aklinker1/check':
         specifier: 'catalog:'
@@ -492,7 +492,7 @@ importers:
     dependencies:
       vite-plugin-solid:
         specifier: 'catalog:'
-        version: 2.11.6(solid-js@1.9.4)(vite@6.0.8(@types/node@20.17.6)(jiti@2.4.2)(sass@1.80.7)(tsx@4.19.3)(yaml@2.7.0))
+        version: 2.11.6(solid-js@1.9.4)(vite@6.2.0(@types/node@20.17.6)(jiti@2.4.2)(sass@1.80.7)(tsx@4.19.3)(yaml@2.7.0))
     devDependencies:
       '@aklinker1/check':
         specifier: 'catalog:'
@@ -517,7 +517,7 @@ importers:
     dependencies:
       '@sveltejs/vite-plugin-svelte':
         specifier: 'catalog:'
-        version: 5.0.3(svelte@5.1.6)(vite@6.0.8(@types/node@20.17.6)(jiti@2.4.2)(sass@1.80.7)(tsx@4.19.3)(yaml@2.7.0))
+        version: 5.0.3(svelte@5.1.6)(vite@6.2.0(@types/node@20.17.6)(jiti@2.4.2)(sass@1.80.7)(tsx@4.19.3)(yaml@2.7.0))
       svelte:
         specifier: '>=5'
         version: 5.1.6
@@ -542,7 +542,7 @@ importers:
     dependencies:
       '@vitejs/plugin-vue':
         specifier: 'catalog:'
-        version: 5.2.1(vite@6.0.8(@types/node@20.17.6)(jiti@2.4.2)(sass@1.80.7)(tsx@4.19.3)(yaml@2.7.0))(vue@3.5.13(typescript@5.6.3))
+        version: 5.2.1(vite@6.2.0(@types/node@20.17.6)(jiti@2.4.2)(sass@1.80.7)(tsx@4.19.3)(yaml@2.7.0))(vue@3.5.13(typescript@5.6.3))
     devDependencies:
       '@aklinker1/check':
         specifier: 'catalog:'
@@ -620,7 +620,7 @@ importers:
         version: 3.5.0(sass@1.80.7)(typescript@5.6.3)(vue@3.5.13(typescript@5.6.3))
       unocss:
         specifier: 'catalog:'
-        version: 66.0.0(postcss@8.5.3)(vite@6.0.8(@types/node@20.17.6)(jiti@2.4.2)(sass@1.80.7)(tsx@4.19.3)(yaml@2.7.0))(vue@3.5.13(typescript@5.6.3))
+        version: 66.0.0(postcss@8.5.3)(vite@6.2.0(@types/node@20.17.6)(jiti@2.4.2)(sass@1.80.7)(tsx@4.19.3)(yaml@2.7.0))(vue@3.5.13(typescript@5.6.3))
       wxt:
         specifier: workspace:*
         version: link:../wxt
@@ -761,7 +761,7 @@ importers:
         version: 3.13.1(rollup@4.34.9)(webpack-sources@3.2.3)
       vite:
         specifier: 'catalog:'
-        version: 6.0.8(@types/node@20.17.6)(jiti@2.4.2)(sass@1.80.7)(tsx@4.19.3)(yaml@2.7.0)
+        version: 6.2.0(@types/node@20.17.6)(jiti@2.4.2)(sass@1.80.7)(tsx@4.19.3)(yaml@2.7.0)
       vite-node:
         specifier: 'catalog:'
         version: 3.0.7(@types/node@20.17.6)(jiti@2.4.2)(sass@1.80.7)(tsx@4.19.3)(yaml@2.7.0)
@@ -819,7 +819,7 @@ importers:
         version: 3.0.7(@types/node@20.17.6)(happy-dom@17.1.8)(jiti@2.4.2)(sass@1.80.7)(tsx@4.19.3)(yaml@2.7.0)
       vitest-plugin-random-seed:
         specifier: 'catalog:'
-        version: 1.1.1(vite@6.0.8(@types/node@20.17.6)(jiti@2.4.2)(sass@1.80.7)(tsx@4.19.3)(yaml@2.7.0))
+        version: 1.1.1(vite@6.2.0(@types/node@20.17.6)(jiti@2.4.2)(sass@1.80.7)(tsx@4.19.3)(yaml@2.7.0))
 
   packages/wxt-demo:
     dependencies:
@@ -856,13 +856,13 @@ importers:
         version: 5.6.3
       unocss:
         specifier: 'catalog:'
-        version: 66.0.0(postcss@8.5.3)(vite@6.0.8(@types/node@20.17.6)(jiti@2.4.2)(sass@1.80.7)(tsx@4.19.3)(yaml@2.7.0))(vue@3.5.13(typescript@5.6.3))
+        version: 66.0.0(postcss@8.5.3)(vite@6.2.0(@types/node@20.17.6)(jiti@2.4.2)(sass@1.80.7)(tsx@4.19.3)(yaml@2.7.0))(vue@3.5.13(typescript@5.6.3))
       vitest:
         specifier: 'catalog:'
         version: 3.0.7(@types/node@20.17.6)(happy-dom@17.1.8)(jiti@2.4.2)(sass@1.80.7)(tsx@4.19.3)(yaml@2.7.0)
       vitest-plugin-random-seed:
         specifier: 'catalog:'
-        version: 1.1.1(vite@6.0.8(@types/node@20.17.6)(jiti@2.4.2)(sass@1.80.7)(tsx@4.19.3)(yaml@2.7.0))
+        version: 1.1.1(vite@6.2.0(@types/node@20.17.6)(jiti@2.4.2)(sass@1.80.7)(tsx@4.19.3)(yaml@2.7.0))
       wxt:
         specifier: workspace:*
         version: link:../wxt
@@ -5242,6 +5242,46 @@ packages:
       yaml:
         optional: true
 
+  vite@6.2.0:
+    resolution: {integrity: sha512-7dPxoo+WsT/64rDcwoOjk76XHj+TqNTIvHKcuMQ1k4/SeHDaQt5GFAeLYzrimZrMpn/O6DtdI03WUjdxuPM0oQ==}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^18.0.0 || ^20.0.0 || >=22.0.0
+      jiti: '>=1.21.0'
+      less: '*'
+      lightningcss: ^1.21.0
+      sass: '*'
+      sass-embedded: '*'
+      stylus: '*'
+      sugarss: '*'
+      terser: ^5.16.0
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      jiti:
+        optional: true
+      less:
+        optional: true
+      lightningcss:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
+        optional: true
+
   vitefu@1.0.6:
     resolution: {integrity: sha512-+Rex1GlappUyNN6UfwbVZne/9cYC4+R2XDk9xkNXBKMw6HQagdX9PgZ8V2v1WUSK1wfBLp7qbI1+XSNIlB1xmA==}
     peerDependencies:
@@ -6501,25 +6541,25 @@ snapshots:
 
   '@sindresorhus/is@5.4.1': {}
 
-  '@sveltejs/vite-plugin-svelte-inspector@4.0.1(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.1.6)(vite@6.0.8(@types/node@20.17.6)(jiti@2.4.2)(sass@1.80.7)(tsx@4.19.3)(yaml@2.7.0)))(svelte@5.1.6)(vite@6.0.8(@types/node@20.17.6)(jiti@2.4.2)(sass@1.80.7)(tsx@4.19.3)(yaml@2.7.0))':
+  '@sveltejs/vite-plugin-svelte-inspector@4.0.1(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.1.6)(vite@6.2.0(@types/node@20.17.6)(jiti@2.4.2)(sass@1.80.7)(tsx@4.19.3)(yaml@2.7.0)))(svelte@5.1.6)(vite@6.2.0(@types/node@20.17.6)(jiti@2.4.2)(sass@1.80.7)(tsx@4.19.3)(yaml@2.7.0))':
     dependencies:
-      '@sveltejs/vite-plugin-svelte': 5.0.3(svelte@5.1.6)(vite@6.0.8(@types/node@20.17.6)(jiti@2.4.2)(sass@1.80.7)(tsx@4.19.3)(yaml@2.7.0))
+      '@sveltejs/vite-plugin-svelte': 5.0.3(svelte@5.1.6)(vite@6.2.0(@types/node@20.17.6)(jiti@2.4.2)(sass@1.80.7)(tsx@4.19.3)(yaml@2.7.0))
       debug: 4.4.0
       svelte: 5.1.6
-      vite: 6.0.8(@types/node@20.17.6)(jiti@2.4.2)(sass@1.80.7)(tsx@4.19.3)(yaml@2.7.0)
+      vite: 6.2.0(@types/node@20.17.6)(jiti@2.4.2)(sass@1.80.7)(tsx@4.19.3)(yaml@2.7.0)
     transitivePeerDependencies:
       - supports-color
 
-  '@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.1.6)(vite@6.0.8(@types/node@20.17.6)(jiti@2.4.2)(sass@1.80.7)(tsx@4.19.3)(yaml@2.7.0))':
+  '@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.1.6)(vite@6.2.0(@types/node@20.17.6)(jiti@2.4.2)(sass@1.80.7)(tsx@4.19.3)(yaml@2.7.0))':
     dependencies:
-      '@sveltejs/vite-plugin-svelte-inspector': 4.0.1(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.1.6)(vite@6.0.8(@types/node@20.17.6)(jiti@2.4.2)(sass@1.80.7)(tsx@4.19.3)(yaml@2.7.0)))(svelte@5.1.6)(vite@6.0.8(@types/node@20.17.6)(jiti@2.4.2)(sass@1.80.7)(tsx@4.19.3)(yaml@2.7.0))
+      '@sveltejs/vite-plugin-svelte-inspector': 4.0.1(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.1.6)(vite@6.2.0(@types/node@20.17.6)(jiti@2.4.2)(sass@1.80.7)(tsx@4.19.3)(yaml@2.7.0)))(svelte@5.1.6)(vite@6.2.0(@types/node@20.17.6)(jiti@2.4.2)(sass@1.80.7)(tsx@4.19.3)(yaml@2.7.0))
       debug: 4.4.0
       deepmerge: 4.3.1
       kleur: 4.1.5
       magic-string: 0.30.17
       svelte: 5.1.6
-      vite: 6.0.8(@types/node@20.17.6)(jiti@2.4.2)(sass@1.80.7)(tsx@4.19.3)(yaml@2.7.0)
-      vitefu: 1.0.6(vite@6.0.8(@types/node@20.17.6)(jiti@2.4.2)(sass@1.80.7)(tsx@4.19.3)(yaml@2.7.0))
+      vite: 6.2.0(@types/node@20.17.6)(jiti@2.4.2)(sass@1.80.7)(tsx@4.19.3)(yaml@2.7.0)
+      vitefu: 1.0.6(vite@6.2.0(@types/node@20.17.6)(jiti@2.4.2)(sass@1.80.7)(tsx@4.19.3)(yaml@2.7.0))
     transitivePeerDependencies:
       - supports-color
 
@@ -6648,13 +6688,13 @@ snapshots:
 
   '@ungap/structured-clone@1.2.0': {}
 
-  '@unocss/astro@66.0.0(vite@6.0.8(@types/node@20.17.6)(jiti@2.4.2)(sass@1.80.7)(tsx@4.19.3)(yaml@2.7.0))(vue@3.5.13(typescript@5.6.3))':
+  '@unocss/astro@66.0.0(vite@6.2.0(@types/node@20.17.6)(jiti@2.4.2)(sass@1.80.7)(tsx@4.19.3)(yaml@2.7.0))(vue@3.5.13(typescript@5.6.3))':
     dependencies:
       '@unocss/core': 66.0.0
       '@unocss/reset': 66.0.0
-      '@unocss/vite': 66.0.0(vite@6.0.8(@types/node@20.17.6)(jiti@2.4.2)(sass@1.80.7)(tsx@4.19.3)(yaml@2.7.0))(vue@3.5.13(typescript@5.6.3))
+      '@unocss/vite': 66.0.0(vite@6.2.0(@types/node@20.17.6)(jiti@2.4.2)(sass@1.80.7)(tsx@4.19.3)(yaml@2.7.0))(vue@3.5.13(typescript@5.6.3))
     optionalDependencies:
-      vite: 6.0.8(@types/node@20.17.6)(jiti@2.4.2)(sass@1.80.7)(tsx@4.19.3)(yaml@2.7.0)
+      vite: 6.2.0(@types/node@20.17.6)(jiti@2.4.2)(sass@1.80.7)(tsx@4.19.3)(yaml@2.7.0)
     transitivePeerDependencies:
       - vue
 
@@ -6779,7 +6819,7 @@ snapshots:
     dependencies:
       '@unocss/core': 66.0.0
 
-  '@unocss/vite@66.0.0(vite@6.0.8(@types/node@20.17.6)(jiti@2.4.2)(sass@1.80.7)(tsx@4.19.3)(yaml@2.7.0))(vue@3.5.13(typescript@5.6.3))':
+  '@unocss/vite@66.0.0(vite@6.2.0(@types/node@20.17.6)(jiti@2.4.2)(sass@1.80.7)(tsx@4.19.3)(yaml@2.7.0))(vue@3.5.13(typescript@5.6.3))':
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@unocss/config': 66.0.0
@@ -6789,18 +6829,18 @@ snapshots:
       magic-string: 0.30.17
       tinyglobby: 0.2.10
       unplugin-utils: 0.2.4
-      vite: 6.0.8(@types/node@20.17.6)(jiti@2.4.2)(sass@1.80.7)(tsx@4.19.3)(yaml@2.7.0)
+      vite: 6.2.0(@types/node@20.17.6)(jiti@2.4.2)(sass@1.80.7)(tsx@4.19.3)(yaml@2.7.0)
     transitivePeerDependencies:
       - vue
 
-  '@vitejs/plugin-react@4.3.4(vite@6.0.8(@types/node@20.17.6)(jiti@2.4.2)(sass@1.80.7)(tsx@4.19.3)(yaml@2.7.0))':
+  '@vitejs/plugin-react@4.3.4(vite@6.2.0(@types/node@20.17.6)(jiti@2.4.2)(sass@1.80.7)(tsx@4.19.3)(yaml@2.7.0))':
     dependencies:
       '@babel/core': 7.26.9
       '@babel/plugin-transform-react-jsx-self': 7.25.9(@babel/core@7.26.9)
       '@babel/plugin-transform-react-jsx-source': 7.25.9(@babel/core@7.26.9)
       '@types/babel__core': 7.20.5
       react-refresh: 0.14.2
-      vite: 6.0.8(@types/node@20.17.6)(jiti@2.4.2)(sass@1.80.7)(tsx@4.19.3)(yaml@2.7.0)
+      vite: 6.2.0(@types/node@20.17.6)(jiti@2.4.2)(sass@1.80.7)(tsx@4.19.3)(yaml@2.7.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -6809,9 +6849,9 @@ snapshots:
       vite: 5.4.14(@types/node@20.17.6)(sass@1.80.7)
       vue: 3.5.13(typescript@5.6.3)
 
-  '@vitejs/plugin-vue@5.2.1(vite@6.0.8(@types/node@20.17.6)(jiti@2.4.2)(sass@1.80.7)(tsx@4.19.3)(yaml@2.7.0))(vue@3.5.13(typescript@5.6.3))':
+  '@vitejs/plugin-vue@5.2.1(vite@6.2.0(@types/node@20.17.6)(jiti@2.4.2)(sass@1.80.7)(tsx@4.19.3)(yaml@2.7.0))(vue@3.5.13(typescript@5.6.3))':
     dependencies:
-      vite: 6.0.8(@types/node@20.17.6)(jiti@2.4.2)(sass@1.80.7)(tsx@4.19.3)(yaml@2.7.0)
+      vite: 6.2.0(@types/node@20.17.6)(jiti@2.4.2)(sass@1.80.7)(tsx@4.19.3)(yaml@2.7.0)
       vue: 3.5.13(typescript@5.6.3)
 
   '@vitest/coverage-v8@3.0.7(vitest@3.0.7(@types/node@20.17.6)(happy-dom@17.1.8)(jiti@2.4.2)(sass@1.80.7)(tsx@4.19.3)(yaml@2.7.0))':
@@ -9812,9 +9852,9 @@ snapshots:
 
   universalify@2.0.0: {}
 
-  unocss@66.0.0(postcss@8.5.3)(vite@6.0.8(@types/node@20.17.6)(jiti@2.4.2)(sass@1.80.7)(tsx@4.19.3)(yaml@2.7.0))(vue@3.5.13(typescript@5.6.3)):
+  unocss@66.0.0(postcss@8.5.3)(vite@6.2.0(@types/node@20.17.6)(jiti@2.4.2)(sass@1.80.7)(tsx@4.19.3)(yaml@2.7.0))(vue@3.5.13(typescript@5.6.3)):
     dependencies:
-      '@unocss/astro': 66.0.0(vite@6.0.8(@types/node@20.17.6)(jiti@2.4.2)(sass@1.80.7)(tsx@4.19.3)(yaml@2.7.0))(vue@3.5.13(typescript@5.6.3))
+      '@unocss/astro': 66.0.0(vite@6.2.0(@types/node@20.17.6)(jiti@2.4.2)(sass@1.80.7)(tsx@4.19.3)(yaml@2.7.0))(vue@3.5.13(typescript@5.6.3))
       '@unocss/cli': 66.0.0
       '@unocss/core': 66.0.0
       '@unocss/postcss': 66.0.0(postcss@8.5.3)
@@ -9831,9 +9871,9 @@ snapshots:
       '@unocss/transformer-compile-class': 66.0.0
       '@unocss/transformer-directives': 66.0.0
       '@unocss/transformer-variant-group': 66.0.0
-      '@unocss/vite': 66.0.0(vite@6.0.8(@types/node@20.17.6)(jiti@2.4.2)(sass@1.80.7)(tsx@4.19.3)(yaml@2.7.0))(vue@3.5.13(typescript@5.6.3))
+      '@unocss/vite': 66.0.0(vite@6.2.0(@types/node@20.17.6)(jiti@2.4.2)(sass@1.80.7)(tsx@4.19.3)(yaml@2.7.0))(vue@3.5.13(typescript@5.6.3))
     optionalDependencies:
-      vite: 6.0.8(@types/node@20.17.6)(jiti@2.4.2)(sass@1.80.7)(tsx@4.19.3)(yaml@2.7.0)
+      vite: 6.2.0(@types/node@20.17.6)(jiti@2.4.2)(sass@1.80.7)(tsx@4.19.3)(yaml@2.7.0)
     transitivePeerDependencies:
       - postcss
       - supports-color
@@ -9906,7 +9946,7 @@ snapshots:
       debug: 4.4.0
       es-module-lexer: 1.6.0
       pathe: 2.0.3
-      vite: 6.0.8(@types/node@20.17.6)(jiti@2.4.2)(sass@1.80.7)(tsx@4.19.3)(yaml@2.7.0)
+      vite: 6.2.0(@types/node@20.17.6)(jiti@2.4.2)(sass@1.80.7)(tsx@4.19.3)(yaml@2.7.0)
     transitivePeerDependencies:
       - '@types/node'
       - jiti
@@ -9921,7 +9961,7 @@ snapshots:
       - tsx
       - yaml
 
-  vite-plugin-solid@2.11.6(solid-js@1.9.4)(vite@6.0.8(@types/node@20.17.6)(jiti@2.4.2)(sass@1.80.7)(tsx@4.19.3)(yaml@2.7.0)):
+  vite-plugin-solid@2.11.6(solid-js@1.9.4)(vite@6.2.0(@types/node@20.17.6)(jiti@2.4.2)(sass@1.80.7)(tsx@4.19.3)(yaml@2.7.0)):
     dependencies:
       '@babel/core': 7.26.9
       '@types/babel__core': 7.20.5
@@ -9929,8 +9969,8 @@ snapshots:
       merge-anything: 5.1.7
       solid-js: 1.9.4
       solid-refresh: 0.6.3(solid-js@1.9.4)
-      vite: 6.0.8(@types/node@20.17.6)(jiti@2.4.2)(sass@1.80.7)(tsx@4.19.3)(yaml@2.7.0)
-      vitefu: 1.0.6(vite@6.0.8(@types/node@20.17.6)(jiti@2.4.2)(sass@1.80.7)(tsx@4.19.3)(yaml@2.7.0))
+      vite: 6.2.0(@types/node@20.17.6)(jiti@2.4.2)(sass@1.80.7)(tsx@4.19.3)(yaml@2.7.0)
+      vitefu: 1.0.6(vite@6.2.0(@types/node@20.17.6)(jiti@2.4.2)(sass@1.80.7)(tsx@4.19.3)(yaml@2.7.0))
     transitivePeerDependencies:
       - supports-color
 
@@ -9957,9 +9997,22 @@ snapshots:
       tsx: 4.19.3
       yaml: 2.7.0
 
-  vitefu@1.0.6(vite@6.0.8(@types/node@20.17.6)(jiti@2.4.2)(sass@1.80.7)(tsx@4.19.3)(yaml@2.7.0)):
+  vite@6.2.0(@types/node@20.17.6)(jiti@2.4.2)(sass@1.80.7)(tsx@4.19.3)(yaml@2.7.0):
+    dependencies:
+      esbuild: 0.25.0
+      postcss: 8.5.3
+      rollup: 4.34.9
     optionalDependencies:
-      vite: 6.0.8(@types/node@20.17.6)(jiti@2.4.2)(sass@1.80.7)(tsx@4.19.3)(yaml@2.7.0)
+      '@types/node': 20.17.6
+      fsevents: 2.3.3
+      jiti: 2.4.2
+      sass: 1.80.7
+      tsx: 4.19.3
+      yaml: 2.7.0
+
+  vitefu@1.0.6(vite@6.2.0(@types/node@20.17.6)(jiti@2.4.2)(sass@1.80.7)(tsx@4.19.3)(yaml@2.7.0)):
+    optionalDependencies:
+      vite: 6.2.0(@types/node@20.17.6)(jiti@2.4.2)(sass@1.80.7)(tsx@4.19.3)(yaml@2.7.0)
 
   vitepress-knowledge@0.4.0(vitepress@1.6.3(@algolia/client-search@5.20.3)(@types/node@20.17.6)(@types/react@18.3.12)(postcss@8.5.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.80.7)(search-insights@2.15.0)(typescript@5.6.3)):
     dependencies:
@@ -10027,6 +10080,10 @@ snapshots:
   vitest-plugin-random-seed@1.1.1(vite@6.0.8(@types/node@20.17.6)(jiti@2.4.2)(sass@1.80.7)(tsx@4.19.3)(yaml@2.7.0)):
     dependencies:
       vite: 6.0.8(@types/node@20.17.6)(jiti@2.4.2)(sass@1.80.7)(tsx@4.19.3)(yaml@2.7.0)
+
+  vitest-plugin-random-seed@1.1.1(vite@6.2.0(@types/node@20.17.6)(jiti@2.4.2)(sass@1.80.7)(tsx@4.19.3)(yaml@2.7.0)):
+    dependencies:
+      vite: 6.2.0(@types/node@20.17.6)(jiti@2.4.2)(sass@1.80.7)(tsx@4.19.3)(yaml@2.7.0)
 
   vitest@3.0.7(@types/node@20.17.6)(happy-dom@17.1.8)(jiti@2.4.2)(sass@1.80.7)(tsx@4.19.3)(yaml@2.7.0):
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -259,7 +259,7 @@ catalogs:
       specifier: ^0.64.0 || ^0.65.0 || ^65.0.0 ||^66.0.0
       version: 66.0.0
     vite:
-      specifier: ^5.0.0 || <=6.0.8
+      specifier: ^5.0.0 || ^6.0.0
       version: 6.0.8
     vite-node:
       specifier: ^2.1.4 || ^3.0.0
@@ -9948,7 +9948,7 @@ snapshots:
     dependencies:
       esbuild: 0.24.2
       postcss: 8.5.3
-      rollup: 4.24.0
+      rollup: 4.34.9
     optionalDependencies:
       '@types/node': 20.17.6
       fsevents: 2.3.3

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -88,7 +88,7 @@ catalog:
   unbuild: ^3.5.0
   unimport: ^3.13.1
   unocss: ^0.64.0 || ^0.65.0 || ^65.0.0 ||^66.0.0
-  vite: ^5.0.0 || <=6.0.8
+  vite: ^5.0.0 || ^6.0.0
   vite-node: ^2.1.4 || ^3.0.0
   vite-plugin-solid: ^2.11.6
   vitepress: ^1.6.3


### PR DESCRIPTION
### Overview

Until #1411 is ready, this allows projects to use newer versions of vite. IT DOES NOT RESOLVE THE SECURITY ISSUE, that's what #1411 is for. But I've ran into some snags there and haven't had much time to work on it, so it hasn't ben merged after a month. So I'm releasing this just to allow people to upgrade.

### Manual Testing

Run the demo extension in dev mode. This PR also upgrades the local version of Vite used during development to `6.2.0`, which would break without this change.

### Related Issue

Related to:
- https://github.com/wxt-dev/wxt/issues/1360
- https://github.com/wxt-dev/wxt/issues/1362

But doesn't resolve them. Just applies an unsafe, temporary workaround.