### PR TITLE
ci: prevent action running on forks

### DIFF
--- a/.github/workflows/pkg.pr.new.yml
+++ b/.github/workflows/pkg.pr.new.yml
@@ -14,6 +14,7 @@ jobs:
   build:
     name: Publish Test Packages
     runs-on: ubuntu-22.04
+    if: ${{ github.repository == 'wxt-dev/wxt' }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/vhs.yml
+++ b/.github/workflows/vhs.yml
@@ -12,6 +12,7 @@ jobs:
   vhs:
     name: Create VHS
     runs-on: ubuntu-22.04
+    if: ${{ github.repository == 'wxt-dev/wxt' }}
     permissions:
       contents: write
     steps:


### PR DESCRIPTION
### Overview
When I fork the repository and synchronize the upstream code, the related actions will fail to run. Therefore, I think the related actions should be prevented from running in the forked repository.
<!-- Describe your changes and why you made them -->

### Manual Testing

<!-- Describe how to test your changes to make sure the PR works as intended -->

### Related Issue

<!-- If this PR is related to an issue, please link it here -->

This PR closes #<issue_number>
