### PR TITLE
feat: adding property styles in root document

### DIFF
--- a/packages/wxt/src/client/content-scripts/ui/index.ts
+++ b/packages/wxt/src/client/content-scripts/ui/index.ts
@@ -129,7 +129,15 @@ export async function createShadowRootUi<TMounted>(
 ): Promise<ShadowRootContentScriptUi<TMounted>> {
   const css = [options.css ?? ''];
   if (ctx.options?.cssInjectionMode === 'ui') {
-    const entryCss = await loadCss();
+    let entryCss = await loadCss();
+    let propertyCss = entryCss
+      .slice(entryCss.indexOf('@property'))
+      .replaceAll('inherits: false', 'inherits: true');
+    const styleElem = document.createElement('style');
+    styleElem.id = 'wxt-style';
+    styleElem.innerHTML = `${propertyCss}`;
+    document.head.append(styleElem);
+    entryCss = entryCss.slice(0, entryCss.indexOf('@property'));
     // Replace :root selectors with :host since we're in a shadow root
     css.push(entryCss.replaceAll(':root', ':host'));
   }


### PR DESCRIPTION
### Overview

Just extracted the property styles from entryCss text and append it in the root document.
Don't know if this follows standard and consistency. Please let me know.

### Manual Testing

Create components within shadowDOM using `createShadowRootUi` API.

### Related Issue

<!-- If this PR is related to an issue, please link it here -->

This PR closes #1461 
