### PR TITLE
fix: Return early if no migration is needed

### DIFF
--- a/packages/storage/src/index.ts
+++ b/packages/storage/src/index.ts
@@ -379,6 +379,9 @@ function createStorage(): WxtStorage {
             `Version downgrade detected (v${currentVersion} -> v${targetVersion}) for "${key}"`,
           );
         }
+        if (currentVersion === targetVersion) {
+          return;
+        }
 
         console.debug(
           `[@wxt-dev/storage] Running storage migration for ${key}: v${currentVersion} -> v${targetVersion}`,


### PR DESCRIPTION
### Overview

One thing I noticed is that the migration will run regardless of if the current version is the desired version, e.g. if the current version is 2 and the target version is also 2 I can still see the debug message in console like

```
@wxt-dev/storage] Running storage migration for local:settings: v2 -> v2 background.js:652:19
[@wxt-dev/storage] Storage migration completed for local:settings v2 
```

I don't think there's any reason to not return early if the version matches, as the array below will have zero element anyway.
```ts
        const migrationsToRun = Array.from(
          { length: targetVersion - currentVersion },
          (_, i) => currentVersion + i + 1,
        );
```
