### PR TITLE
fix: add missing timer clear methods to ContentScriptContext

### DIFF
--- a/packages/wxt/src/client/content-scripts/content-script-context.ts
+++ b/packages/wxt/src/client/content-scripts/content-script-context.ts
@@ -1,6 +1,6 @@
-import { ContentScriptDefinition } from '../../types';
 import { browser } from 'wxt/browser';
 import { logger } from '../../sandbox/utils/logger';
+import { ContentScriptDefinition } from '../../types';
 import { WxtLocationChangeEvent, getUniqueEventName } from './custom-events';
 import { createLocationWatcher } from './location-watcher';
 
@@ -161,6 +161,38 @@ export class ContentScriptContext implements AbortController {
 
     this.onInvalidated(() => cancelIdleCallback(id));
     return id;
+  }
+
+  /**
+   * Clears a timeout set by ctx.setTimeout.
+   */
+  clearTimeout(id: number | null): void {
+    if (id !== null) {
+      clearTimeout(id);
+    }
+  }
+
+  /**
+   * Clears an interval set by ctx.setInterval.
+   */
+  clearInterval(id: number | null): void {
+    if (id !== null) {
+      clearInterval(id);
+    }
+  }
+
+  /**
+   * Cancels an animation frame request set by ctx.requestAnimationFrame.
+   */
+  cancelAnimationFrame(id: number): void {
+    cancelAnimationFrame(id);
+  }
+
+  /**
+   * Cancels an idle callback request set by ctx.requestIdleCallback.
+   */
+  cancelIdleCallback(id: number): void {
+    cancelIdleCallback(id);
   }
 
   /**


### PR DESCRIPTION
### Overview

Added missing timer clear methods (`clearTimeout`, `clearInterval`, `cancelAnimationFrame`, `cancelIdleCallback`) to the ContentScriptContext class. The current class provides corresponding timer creation methods (`setTimeout`, `setInterval`, etc.) but lacks methods to clear them, causing TypeScript compilation errors.

### Manual Testing

Test with code using ContentScriptContext like:
```typescript
const timerId = ctx.setTimeout(() => {
  console.log('This should not run');
}, 1000);

ctx.clearTimeout(timerId); // This should work properly
```

### Related Issue

No related issue. 
