### PR TITLE
feat: remove logs and add onMigrationComplete callback

### DIFF
--- a/packages/storage/src/index.ts
+++ b/packages/storage/src/index.ts
@@ -267,7 +267,6 @@ function createStorage(): WxtStorage {
           async ([storageArea, updates]) => {
             const driver = getDriver(storageArea as StorageArea);
             const metaKeys = updates.map(({ key }) => getMetaKey(key));
-            console.log(storageArea, metaKeys);
             const existingMetas = await driver.getItems(metaKeys);
             const existingMetaMap = Object.fromEntries(
               existingMetas.map(({ key, value }) => [key, getMetaValue(value)]),
@@ -359,7 +358,11 @@ function createStorage(): WxtStorage {
     defineItem: (key, opts?: WxtStorageItemOptions<any>) => {
       const { driver, driverKey } = resolveKey(key);
 
-      const { version: targetVersion = 1, migrations = {} } = opts ?? {};
+      const {
+        version: targetVersion = 1,
+        migrations = {},
+        onMigrationComplete,
+      } = opts ?? {};
       if (targetVersion < 1) {
         throw Error(
           'Storage item version cannot be less than 1. Initial versions should be set to 1, not 0.',
@@ -383,9 +386,6 @@ function createStorage(): WxtStorage {
           return;
         }
 
-        console.debug(
-          `[@wxt-dev/storage] Running storage migration for ${key}: v${currentVersion} -> v${targetVersion}`,
-        );
         const migrationsToRun = Array.from(
           { length: targetVersion - currentVersion },
           (_, i) => currentVersion + i + 1,
@@ -406,10 +406,9 @@ function createStorage(): WxtStorage {
           { key: driverKey, value: migratedValue },
           { key: driverMetaKey, value: { ...meta, v: targetVersion } },
         ]);
-        console.debug(
-          `[@wxt-dev/storage] Storage migration completed for ${key} v${targetVersion}`,
-          { migratedValue },
-        );
+        if (onMigrationComplete !== undefined) {
+          onMigrationComplete(migratedValue, targetVersion);
+        }
       };
       const migrationsDone =
         opts?.migrations == null
@@ -862,6 +861,10 @@ export interface WxtStorageItemOptions<T> {
    * A map of version numbers to the functions used to migrate the data to that version.
    */
   migrations?: Record<number, (oldValue: any) => any>;
+  /**
+   * A callback function that runs on migration complete.
+   */
+  onMigrationComplete?: (storage: T, targetVersion: number) => void;
 }
 
 export type StorageAreaChanges = {


### PR DESCRIPTION
### Overview

As mentioned #1503, the logs in storage should be cleared, and just this morning, an idea came to my mind that we can introduce a new option `onMigrationComplete` that let user decide if they want to do anything when migration just completed.

I have not added anything in the document as I assume the types should be automatically generated. 

### Manual Testing

I have added a unit test case for the new option `onMigrationComplete`

### Related Issue

<!-- If this PR is related to an issue, please link it here -->

This PR closes #1503
