### PR TITLE
docs: Add "AliasVault" to the homepage

### DIFF
--- a/docs/.vitepress/components/UsingWxtSection.vue
+++ b/docs/.vitepress/components/UsingWxtSection.vue
@@ -68,6 +68,7 @@ const chromeExtensionIds = [
   'dlnjcbkmomenmieechnmgglgcljhoepd', // Youtube Live Chat Fullscreen
   'keiealdacakpnbbljlmhfgcebmaadieg', // Python Code Runner
   'hafcajcllbjnoolpfngclfmmgpikdhlm', // Monochromate
+  'bmoggiinmnodjphdjnmpcnlleamkfedj', // AliasVault - Open-Source Password & (Email) Alias Manager
 ];
 
 const { data, err, isLoading } = useListExtensionDetails(chromeExtensionIds);


### PR DESCRIPTION
### Overview
Added AliasVault to the list on the homepage

--

Thanks a lot for making WXT! It worked like a charm for me in migrating my existing browser extension for Chrome to make it compatible with Firefox and Edge. The Firefox version has been approved yesterday and currently awaiting Edge. I am also going to be publishing the browser extension to Safari and Brave in the coming days. 😄 

BTW: AliasVault is fully open-source including the browser extension. The code for the browser extension can be found here for anyone who's interested: https://github.com/lanedirt/AliasVault/tree/main/browser-extension.

Thanks again!
