### PR TITLE
feat(storage): Add `debug` option to enable migration logs

### DIFF
--- a/packages/storage/src/__tests__/index.test.ts
+++ b/packages/storage/src/__tests__/index.test.ts
@@ -848,6 +848,41 @@ describe('Storage Utils', () => {
         await expect(item.migrate()).rejects.toThrow(expectedError);
       });
     });
+    it('should print migration logs if debug option is true', async () => {
+      await fakeBrowser.storage.local.set({
+        count: 2,
+        count$: { v: 1 },
+      });
+      const migrateToV2 = vi.fn((oldCount) => oldCount * 2);
+      const migrateToV3 = vi.fn((oldCount) => oldCount * 3);
+      const consoleSpy = vi.spyOn(console, 'debug');
+
+      storage.defineItem<number, { v: number }>(`local:count`, {
+        defaultValue: 0,
+        version: 3,
+        migrations: {
+          2: migrateToV2,
+          3: migrateToV3,
+        },
+        debug: true,
+      });
+      await waitForMigrations();
+
+      expect(consoleSpy).toHaveBeenCalledTimes(4);
+      expect(consoleSpy).toHaveBeenCalledWith(
+        `[@wxt-dev/storage] Running storage migration for local:count: v1 -> v3`,
+      );
+      expect(consoleSpy).toHaveBeenCalledWith(
+        `[@wxt-dev/storage] Storage migration processed for version: v2`,
+      );
+      expect(consoleSpy).toHaveBeenCalledWith(
+        `[@wxt-dev/storage] Storage migration processed for version: v3`,
+      );
+      expect(consoleSpy).toHaveBeenCalledWith(
+        `[@wxt-dev/storage] Storage migration completed for local:count v3`,
+        { migratedValue: expect.any(Number) },
+      );
+    });
 
     describe('getValue', () => {
       it('should return the value from storage', async () => {

--- a/packages/storage/src/__tests__/index.test.ts
+++ b/packages/storage/src/__tests__/index.test.ts
@@ -887,8 +887,6 @@ describe('Storage Utils', () => {
         await fakeBrowser.storage.local.set({
           count: 2,
           count$: { v: 1 },
-        });
-        await fakeBrowser.storage.local.set({
           count2: 2,
           count2$: { v: 1 },
         });

--- a/packages/storage/src/__tests__/index.test.ts
+++ b/packages/storage/src/__tests__/index.test.ts
@@ -847,41 +847,42 @@ describe('Storage Utils', () => {
 
         await expect(item.migrate()).rejects.toThrow(expectedError);
       });
-    });
-    it('should print migration logs if debug option is true', async () => {
-      await fakeBrowser.storage.local.set({
-        count: 2,
-        count$: { v: 1 },
-      });
-      const migrateToV2 = vi.fn((oldCount) => oldCount * 2);
-      const migrateToV3 = vi.fn((oldCount) => oldCount * 3);
-      const consoleSpy = vi.spyOn(console, 'debug');
 
-      storage.defineItem<number, { v: number }>(`local:count`, {
-        defaultValue: 0,
-        version: 3,
-        migrations: {
-          2: migrateToV2,
-          3: migrateToV3,
-        },
-        debug: true,
-      });
-      await waitForMigrations();
+      it('should print migration logs if debug option is true', async () => {
+        await fakeBrowser.storage.local.set({
+          count: 2,
+          count$: { v: 1 },
+        });
+        const migrateToV2 = vi.fn((oldCount) => oldCount * 2);
+        const migrateToV3 = vi.fn((oldCount) => oldCount * 3);
+        const consoleSpy = vi.spyOn(console, 'debug');
 
-      expect(consoleSpy).toHaveBeenCalledTimes(4);
-      expect(consoleSpy).toHaveBeenCalledWith(
-        `[@wxt-dev/storage] Running storage migration for local:count: v1 -> v3`,
-      );
-      expect(consoleSpy).toHaveBeenCalledWith(
-        `[@wxt-dev/storage] Storage migration processed for version: v2`,
-      );
-      expect(consoleSpy).toHaveBeenCalledWith(
-        `[@wxt-dev/storage] Storage migration processed for version: v3`,
-      );
-      expect(consoleSpy).toHaveBeenCalledWith(
-        `[@wxt-dev/storage] Storage migration completed for local:count v3`,
-        { migratedValue: expect.any(Number) },
-      );
+        storage.defineItem<number, { v: number }>(`local:count`, {
+          defaultValue: 0,
+          version: 3,
+          migrations: {
+            2: migrateToV2,
+            3: migrateToV3,
+          },
+          debug: true,
+        });
+        await waitForMigrations();
+
+        expect(consoleSpy).toHaveBeenCalledTimes(4);
+        expect(consoleSpy).toHaveBeenCalledWith(
+          `[@wxt-dev/storage] Running storage migration for local:count: v1 -> v3`,
+        );
+        expect(consoleSpy).toHaveBeenCalledWith(
+          `[@wxt-dev/storage] Storage migration processed for version: v2`,
+        );
+        expect(consoleSpy).toHaveBeenCalledWith(
+          `[@wxt-dev/storage] Storage migration processed for version: v3`,
+        );
+        expect(consoleSpy).toHaveBeenCalledWith(
+          `[@wxt-dev/storage] Storage migration completed for local:count v3`,
+          { migratedValue: expect.any(Number) },
+        );
+      });
     });
 
     describe('getValue', () => {

--- a/packages/storage/src/index.ts
+++ b/packages/storage/src/index.ts
@@ -267,7 +267,6 @@ function createStorage(): WxtStorage {
           async ([storageArea, updates]) => {
             const driver = getDriver(storageArea as StorageArea);
             const metaKeys = updates.map(({ key }) => getMetaKey(key));
-            console.log(storageArea, metaKeys);
             const existingMetas = await driver.getItems(metaKeys);
             const existingMetaMap = Object.fromEntries(
               existingMetas.map(({ key, value }) => [key, getMetaValue(value)]),
@@ -359,7 +358,11 @@ function createStorage(): WxtStorage {
     defineItem: (key, opts?: WxtStorageItemOptions<any>) => {
       const { driver, driverKey } = resolveKey(key);
 
-      const { version: targetVersion = 1, migrations = {} } = opts ?? {};
+      const {
+        version: targetVersion = 1,
+        migrations = {},
+        debug = false,
+      } = opts ?? {};
       if (targetVersion < 1) {
         throw Error(
           'Storage item version cannot be less than 1. Initial versions should be set to 1, not 0.',
@@ -383,9 +386,12 @@ function createStorage(): WxtStorage {
           return;
         }
 
-        console.debug(
-          `[@wxt-dev/storage] Running storage migration for ${key}: v${currentVersion} -> v${targetVersion}`,
-        );
+        console.log('debug', debug);
+        if (debug === true) {
+          console.debug(
+            `[@wxt-dev/storage] Running storage migration for ${key}: v${currentVersion} -> v${targetVersion}`,
+          );
+        }
         const migrationsToRun = Array.from(
           { length: targetVersion - currentVersion },
           (_, i) => currentVersion + i + 1,
@@ -396,6 +402,11 @@ function createStorage(): WxtStorage {
             migratedValue =
               (await migrations?.[migrateToVersion]?.(migratedValue)) ??
               migratedValue;
+            if (debug === true) {
+              console.debug(
+                `[@wxt-dev/storage] Storage migration processed for version: v${migrateToVersion}`,
+              );
+            }
           } catch (err) {
             throw new MigrationError(key, migrateToVersion, {
               cause: err,
@@ -406,10 +417,13 @@ function createStorage(): WxtStorage {
           { key: driverKey, value: migratedValue },
           { key: driverMetaKey, value: { ...meta, v: targetVersion } },
         ]);
-        console.debug(
-          `[@wxt-dev/storage] Storage migration completed for ${key} v${targetVersion}`,
-          { migratedValue },
-        );
+
+        if (debug === true) {
+          console.debug(
+            `[@wxt-dev/storage] Storage migration completed for ${key} v${targetVersion}`,
+            { migratedValue },
+          );
+        }
       };
       const migrationsDone =
         opts?.migrations == null
@@ -862,6 +876,11 @@ export interface WxtStorageItemOptions<T> {
    * A map of version numbers to the functions used to migrate the data to that version.
    */
   migrations?: Record<number, (oldValue: any) => any>;
+  /**
+   * Print debug logs, such as migration process.
+   * @default false
+   */
+  debug?: boolean;
 }
 
 export type StorageAreaChanges = {

--- a/packages/storage/src/index.ts
+++ b/packages/storage/src/index.ts
@@ -386,7 +386,6 @@ function createStorage(): WxtStorage {
           return;
         }
 
-        console.log('debug', debug);
         if (debug === true) {
           console.debug(
             `[@wxt-dev/storage] Running storage migration for ${key}: v${currentVersion} -> v${targetVersion}`,


### PR DESCRIPTION
### Overview

Part of https://github.com/wxt-dev/wxt/pull/1511, to remove console log/debug from the storage.


### Related Issue

<!-- If this PR is related to an issue, please link it here -->

This PR closes https://github.com/wxt-dev/wxt/issues/1503
