### PR TITLE
feat(storage): Add `onMigrationComplete` callback

### DIFF
--- a/packages/storage/src/index.ts
+++ b/packages/storage/src/index.ts
@@ -872,7 +872,7 @@ export interface WxtStorageItemOptions<T> {
   /**
    * A callback function that runs on migration complete.
    */
-  onMigrationComplete?: (storage: T, targetVersion: number) => void;
+  onMigrationComplete?: (migratedValue: T, targetVersion: number) => void;
 }
 
 export type StorageAreaChanges = {

--- a/packages/storage/src/index.ts
+++ b/packages/storage/src/index.ts
@@ -410,9 +410,7 @@ function createStorage(): WxtStorage {
           { key: driverKey, value: migratedValue },
           { key: driverMetaKey, value: { ...meta, v: targetVersion } },
         ]);
-        if (onMigrationComplete !== undefined) {
-          onMigrationComplete(migratedValue, targetVersion);
-        }
+        onMigrationComplete?.(migratedValue, targetVersion);
         console.debug(
           `[@wxt-dev/storage] Storage migration completed for ${key} v${targetVersion}`,
           { migratedValue },

--- a/packages/storage/src/index.ts
+++ b/packages/storage/src/index.ts
@@ -359,7 +359,11 @@ function createStorage(): WxtStorage {
     defineItem: (key, opts?: WxtStorageItemOptions<any>) => {
       const { driver, driverKey } = resolveKey(key);
 
-      const { version: targetVersion = 1, migrations = {} } = opts ?? {};
+      const {
+        version: targetVersion = 1,
+        migrations = {},
+        onMigrationComplete,
+      } = opts ?? {};
       if (targetVersion < 1) {
         throw Error(
           'Storage item version cannot be less than 1. Initial versions should be set to 1, not 0.',
@@ -406,6 +410,9 @@ function createStorage(): WxtStorage {
           { key: driverKey, value: migratedValue },
           { key: driverMetaKey, value: { ...meta, v: targetVersion } },
         ]);
+        if (onMigrationComplete !== undefined) {
+          onMigrationComplete(migratedValue, targetVersion);
+        }
         console.debug(
           `[@wxt-dev/storage] Storage migration completed for ${key} v${targetVersion}`,
           { migratedValue },
@@ -862,6 +869,10 @@ export interface WxtStorageItemOptions<T> {
    * A map of version numbers to the functions used to migrate the data to that version.
    */
   migrations?: Record<number, (oldValue: any) => any>;
+  /**
+   * A callback function that runs on migration complete.
+   */
+  onMigrationComplete?: (storage: T, targetVersion: number) => void;
 }
 
 export type StorageAreaChanges = {


### PR DESCRIPTION
### Overview

Following https://github.com/wxt-dev/wxt/pull/1513 part of https://github.com/wxt-dev/wxt/pull/1511.

This PR introduces a new option `onMigrationComplete` to the storage `defineItem` that has two parameters, the migrated item and the migrated version.

Note: there might be conflicts and I will resolve when one is merged.

### Manual Testing

<!-- Describe how to test your changes to make sure the PR works as intended -->

I have added a unit test case for the new option `onMigrationComplete`

### Related Issue

<!-- If this PR is related to an issue, please link it here -->

This PR closes #1503 
