### PR TITLE
Correct "Host permissions" docs showing a code example for "permissions"

### DIFF
--- a/docs/guide/essentials/config/manifest.md
+++ b/docs/guide/essentials/config/manifest.md
@@ -183,7 +183,7 @@ export default defineConfig({
 ```ts
 export default defineConfig({
   manifest: {
-    permissions: ['storage', 'tabs'],
+    host_permissions: ['https://www.google.com/*'],
   },
 });
 ```


### PR DESCRIPTION
### Overview

The docs for config/manifest/host_permissions was showing a copy-pasted code example from config/manifest/permissions. I changed the example to one that's accurate for the host_permissions field.

### Manual Testing

n/a, it's just docs

### Related Issue

n/a
