### PR TITLE
Fix comment for default publicDir location

### DIFF
--- a/packages/wxt/src/types.ts
+++ b/packages/wxt/src/types.ts
@@ -29,7 +29,7 @@ export interface InlineConfig {
   /**
    * Directory containing files that will be copied to the output directory as-is.
    *
-   * @default "${config.root}/public"
+   * @default "${config.srcDir}/public"
    */
   publicDir?: string;
   /**


### PR DESCRIPTION
### Overview

The documentation for `publicDir` says that the default value is `${config.root}/public` but it should be `${config.srcDir}/public`