### PR TITLE
fix: avoid leaking `@types/node` into client code

### DIFF
--- a/packages/wxt/src/client-types.ts
+++ b/packages/wxt/src/client-types.ts
@@ -1,0 +1,55 @@
+import type {
+  BackgroundEntrypointOptions,
+  BaseEntrypointOptions,
+  IsolatedWorldContentScriptEntrypointOptions,
+  MainWorldContentScriptEntrypointOptions,
+} from './option-types';
+import type { ContentScriptContext } from './utils/content-script-context';
+
+export type WxtPlugin = () => void;
+
+export interface IsolatedWorldContentScriptDefinition
+  extends IsolatedWorldContentScriptEntrypointOptions {
+  /**
+   * Main function executed when the content script is loaded.
+   *
+   * When running a content script with `browser.scripting.executeScript`,
+   * values returned from this function will be returned in the `executeScript`
+   * result as well. Otherwise returning a value does nothing.
+   */
+  main(ctx: ContentScriptContext): any | Promise<any>;
+}
+
+export interface MainWorldContentScriptDefinition
+  extends MainWorldContentScriptEntrypointOptions {
+  /**
+   * Main function executed when the content script is loaded.
+   *
+   * When running a content script with `browser.scripting.executeScript`,
+   * values returned from this function will be returned in the `executeScript`
+   * result as well. Otherwise returning a value does nothing.
+   */
+  main(): any | Promise<any>;
+}
+
+export type ContentScriptDefinition =
+  | IsolatedWorldContentScriptDefinition
+  | MainWorldContentScriptDefinition;
+
+export interface BackgroundDefinition extends BackgroundEntrypointOptions {
+  /**
+   * Main function executed when the background script is started. Cannot be async.
+   */
+  main(): void;
+}
+
+export interface UnlistedScriptDefinition extends BaseEntrypointOptions {
+  /**
+   * Main function executed when the unlisted script is ran.
+   *
+   * When running a content script with `browser.scripting.executeScript`,
+   * values returned from this function will be returned in the `executeScript`
+   * result as well. Otherwise returning a value does nothing.
+   */
+  main(): any | Promise<any>;
+}

--- a/packages/wxt/src/core/resolve-config.ts
+++ b/packages/wxt/src/core/resolve-config.ts
@@ -361,7 +361,6 @@ async function getUnimportOptions(
   ];
 
   const defaultOptions: WxtResolvedUnimportOptions = {
-    imports: [{ name: 'fakeBrowser', from: 'wxt/testing' }],
     presets: [
       {
         from: 'wxt/browser',

--- a/packages/wxt/src/option-types.ts
+++ b/packages/wxt/src/option-types.ts
@@ -1,0 +1,155 @@
+import type { ManifestContentScript } from "./core/utils/types";
+import type { Browser } from '@wxt-dev/browser';
+
+export type TargetBrowser = string;
+
+/**
+ * Either a single value or a map of different browsers to the value for that browser.
+ */
+export type PerBrowserOption<T> = T | PerBrowserMap<T>;
+export type PerBrowserMap<T> = { [browser: TargetBrowser]: T };
+
+export interface BaseEntrypointOptions {
+  /**
+   * List of target browsers to include this entrypoint in. Defaults to being included in all
+   * builds. Cannot be used with `exclude`. You must choose one of the two options.
+   *
+   * @default undefined
+   */
+  include?: TargetBrowser[];
+  /**
+   * List of target browsers to exclude this entrypoint from. Cannot be used with `include`. You
+   * must choose one of the two options.
+   *
+   * @default undefined
+   */
+  exclude?: TargetBrowser[];
+}
+
+export interface BackgroundEntrypointOptions extends BaseEntrypointOptions {
+  persistent?: PerBrowserOption<boolean>;
+  /**
+   * Set to `"module"` to output the background entrypoint as ESM. ESM outputs can share chunks and
+   * reduce the overall size of the bundled extension.
+   *
+   * When `undefined`, the background is bundled individually into an IIFE format.
+   *
+   * @default undefined
+   */
+  type?: PerBrowserOption<'module'>;
+}
+
+export interface BaseContentScriptEntrypointOptions
+  extends BaseEntrypointOptions {
+  matches?: PerBrowserOption<NonNullable<ManifestContentScript['matches']>>;
+  /**
+   * See https://developer.chrome.com/docs/extensions/mv3/content_scripts/
+   * @default "documentIdle"
+   */
+  runAt?: PerBrowserOption<Browser.scripting.RegisteredContentScript['runAt']>;
+  /**
+   * See https://developer.chrome.com/docs/extensions/mv3/content_scripts/
+   * @default false
+   */
+  matchAboutBlank?: PerBrowserOption<
+    ManifestContentScript['match_about_blank']
+  >;
+  /**
+   * See https://developer.chrome.com/docs/extensions/mv3/content_scripts/
+   * @default []
+   */
+  excludeMatches?: PerBrowserOption<ManifestContentScript['exclude_matches']>;
+  /**
+   * See https://developer.chrome.com/docs/extensions/mv3/content_scripts/
+   * @default []
+   */
+  includeGlobs?: PerBrowserOption<ManifestContentScript['include_globs']>;
+  /**
+   * See https://developer.chrome.com/docs/extensions/mv3/content_scripts/
+   * @default []
+   */
+  excludeGlobs?: PerBrowserOption<ManifestContentScript['exclude_globs']>;
+  /**
+   * See https://developer.chrome.com/docs/extensions/mv3/content_scripts/
+   * @default false
+   */
+  allFrames?: PerBrowserOption<ManifestContentScript['all_frames']>;
+  /**
+   * See https://developer.chrome.com/docs/extensions/mv3/content_scripts/
+   * @default false
+   */
+  matchOriginAsFallback?: PerBrowserOption<boolean>;
+  /**
+   * Customize how imported/generated styles are injected with the content script. Regardless of the
+   * mode selected, CSS will always be built and included in the output directory.
+   *
+   * - `"manifest"` - Include the CSS in the manifest, under the content script's `css` array.
+   * - `"manual"` - Exclude the CSS from the manifest. You are responsible for manually loading it
+   *   onto the page. Use `browser.runtime.getURL("content-scripts/<name>.css")` to get the file's
+   *   URL
+   * - `"ui"` - Exclude the CSS from the manifest. CSS will be automatically added to your UI when
+   *   calling `createShadowRootUi`
+   *
+   * @default "manifest"
+   */
+  cssInjectionMode?: PerBrowserOption<'manifest' | 'manual' | 'ui'>;
+  /**
+   * Specify how the content script is registered.
+   *
+   * - `"manifest"`: The content script will be added to the `content_scripts` entry in the
+   *   manifest. This is the normal and most well known way of registering a content script.
+   * - `"runtime"`: The content script's `matches` is added to `host_permissions` and you are
+   *   responsible for using the scripting API to register/execute the content script
+   *   dynamically at runtime.
+   *
+   * @default "manifest"
+   */
+  registration?: PerBrowserOption<'manifest' | 'runtime'>;
+}
+
+export interface MainWorldContentScriptEntrypointOptions
+  extends BaseContentScriptEntrypointOptions {
+  /**
+   * See https://developer.chrome.com/docs/extensions/develop/concepts/content-scripts#isolated_world
+   */
+  world: 'MAIN';
+}
+
+export interface IsolatedWorldContentScriptEntrypointOptions
+  extends BaseContentScriptEntrypointOptions {
+  /**
+   * See https://developer.chrome.com/docs/extensions/develop/concepts/content-scripts#isolated_world
+   * @default "ISOLATED"
+   */
+  world?: 'ISOLATED';
+}
+
+export interface PopupEntrypointOptions extends BaseEntrypointOptions {
+  /**
+   * Defaults to "browser_action" to be equivalent to MV3's "action" key
+   */
+  mv2Key?: PerBrowserOption<'browser_action' | 'page_action'>;
+  defaultIcon?: Record<string, string>;
+  defaultTitle?: PerBrowserOption<string>;
+  browserStyle?: PerBrowserOption<boolean>;
+}
+
+export interface OptionsEntrypointOptions extends BaseEntrypointOptions {
+  openInTab?: PerBrowserOption<boolean>;
+  browserStyle?: PerBrowserOption<boolean>;
+  chromeStyle?: PerBrowserOption<boolean>;
+}
+
+export interface SidepanelEntrypointOptions extends BaseEntrypointOptions {
+  /**
+   * Firefox only. See https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/sidebar_action#syntax
+   * @default false
+   */
+  openAtInstall?: PerBrowserOption<boolean>;
+  /**
+   * @deprecated See https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/sidebar_action#syntax
+   */
+  browserStyle?: PerBrowserOption<boolean>;
+  defaultIcon?: string | Record<string, string>;
+  defaultTitle?: PerBrowserOption<string>;
+}

--- a/packages/wxt/src/utils/content-script-context.ts
+++ b/packages/wxt/src/utils/content-script-context.ts
@@ -1,5 +1,5 @@
 /** @module wxt/utils/content-script-context */
-import { ContentScriptDefinition } from '../types';
+import { ContentScriptDefinition } from '../client-types';
 import { browser } from 'wxt/browser';
 import { logger } from '../utils/internal/logger';
 import {

--- a/packages/wxt/src/utils/define-background.ts
+++ b/packages/wxt/src/utils/define-background.ts
@@ -1,5 +1,5 @@
 /** @module wxt/utils/define-background */
-import type { BackgroundDefinition } from '../types';
+import type { BackgroundDefinition } from '../client-types';
 
 export function defineBackground(main: () => void): BackgroundDefinition;
 export function defineBackground(

--- a/packages/wxt/src/utils/define-content-script.ts
+++ b/packages/wxt/src/utils/define-content-script.ts
@@ -1,5 +1,5 @@
 /** @module wxt/utils/define-content-script */
-import type { ContentScriptDefinition } from '../types';
+import type { ContentScriptDefinition } from '../client-types';
 
 export function defineContentScript(
   definition: ContentScriptDefinition,

--- a/packages/wxt/src/utils/define-unlisted-script.ts
+++ b/packages/wxt/src/utils/define-unlisted-script.ts
@@ -1,5 +1,5 @@
 /** @module wxt/utils/define-unlisted-script */
-import type { UnlistedScriptDefinition } from '../types';
+import type { UnlistedScriptDefinition } from '../client-types';
 
 export function defineUnlistedScript(
   main: () => void,

--- a/packages/wxt/src/utils/define-wxt-plugin.ts
+++ b/packages/wxt/src/utils/define-wxt-plugin.ts
@@ -1,5 +1,5 @@
 /** @module wxt/utils/define-wxt-plugin */
-import type { WxtPlugin } from '../types';
+import type { WxtPlugin } from '../client-types';
 
 export function defineWxtPlugin(plugin: WxtPlugin): WxtPlugin {
   return plugin;


### PR DESCRIPTION
### Overview

The `defineWxtPlugin` function is referenced by the generated `.wxt/types/imports.d.ts` module, which is used by client code. Therefore, we need to avoid importing from `wxt/src/types.ts`, as it depends on Node.js-specific packages (like `vite`). This inadvertently introduces Node.js globals into the extension's client environment, which is undesirable (e.g. it breaks the return type of `setTimeout`).

#### Edit 1

Updated other "offending" imports. Split out the option-related types (into `option-types.ts`) and the client-related types (into `client-types.ts`).

### Manual Testing

<!-- Describe how to test your changes to make sure the PR works as intended -->
Without this change, you should see `setTimeout` return a `NodeJS.Timeout` object.

After this change, `setTimeout` will return a number as expected.

### Related Issue

<!-- If this PR is related to an issue, please link it here -->

https://github.com/wxt-dev/wxt/issues/1459
