### PR TITLE
fix: add JSDoc type annotation to auto-imports for ESlint

### DIFF
--- a/packages/wxt/e2e/tests/__snapshots__/auto-imports.test.ts.snap
+++ b/packages/wxt/e2e/tests/__snapshots__/auto-imports.test.ts.snap
@@ -110,6 +110,7 @@ export default {
   name: "wxt/auto-imports",
   languageOptions: {
     globals,
+    /** @type {import('eslint').Linter.SourceType} */
     sourceType: "module",
   },
 };

--- a/packages/wxt/src/builtin-modules/unimport.ts
+++ b/packages/wxt/src/builtin-modules/unimport.ts
@@ -141,6 +141,7 @@ export default {
   name: "wxt/auto-imports",
   languageOptions: {
     globals,
+    /** @type {import('eslint').Linter.SourceType} */
     sourceType: "module",
   },
 };


### PR DESCRIPTION
### Overview

Add type annotation for auto-imports (ESLint 9). If typechecked, `eslint.config.js` may pop an error:

```js
      The types of 'languageOptions.sourceType' are incompatible between these types.
        Type 'string' is not assignable to type 'SourceType | undefined'.ts(2322)
```

### Manual Testing

On a project running checks on JS, IDE should not show squiggly lines

### Related Issue

No related issue
