### PR TITLE
fix: Don't remove top-level destructured variable definitions when importing entrypoints

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -4,7 +4,9 @@
 
   "[json]": { "editor.defaultFormatter": "esbenp.prettier-vscode" },
   "[yaml]": { "editor.defaultFormatter": "esbenp.prettier-vscode" },
-  "[typescript]": { "editor.defaultFormatter": "esbenp.prettier-vscode" },
+  "[typescript]": {
+    "editor.defaultFormatter": "vscode.typescript-language-features"
+  },
   "[markdown]": { "editor.defaultFormatter": "esbenp.prettier-vscode" },
 
   // Additional guidelines for Copilot

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -4,9 +4,7 @@
 
   "[json]": { "editor.defaultFormatter": "esbenp.prettier-vscode" },
   "[yaml]": { "editor.defaultFormatter": "esbenp.prettier-vscode" },
-  "[typescript]": {
-    "editor.defaultFormatter": "vscode.typescript-language-features"
-  },
+  "[typescript]": { "editor.defaultFormatter": "esbenp.prettier-vscode" },
   "[markdown]": { "editor.defaultFormatter": "esbenp.prettier-vscode" },
 
   // Additional guidelines for Copilot

--- a/packages/wxt/src/core/utils/__tests__/transform.test.ts
+++ b/packages/wxt/src/core/utils/__tests__/transform.test.ts
@@ -137,5 +137,40 @@ export default defineContentScript({
 
       expect(actual).toEqual(expected);
     });
+
+    it('should not remove any variables delcared outside the main function that are used', () => {
+      const input = `
+        const [ a ] = [ 123, 456 ];
+        const { b } = { b: 123 };
+        const { c: { d } } = { c: { d: 123 } };
+        const { e, ...rest } = { e: 123, f: 456 };
+
+        console.log(a);
+        console.log(b);
+        console.log(d);
+        console.log(e);
+        console.log(f);
+        console.log(rest);
+
+        export default defineBackground(() => {
+          console.log('Hello background!', { id: browser.runtime.id });
+        });`;
+      const expected = `const [ a ] = [ 123, 456 ];
+const { b } = { b: 123 };
+const { c: { d } } = { c: { d: 123 } };
+const { e, ...rest } = { e: 123, f: 456 };
+
+console.log(a);
+console.log(b);
+console.log(d);
+console.log(e);
+console.log(f);
+console.log(rest);
+
+export default defineBackground();`;
+
+      const actual = removeMainFunctionCode(input).code;
+      expect(actual).toEqual(expected);
+    });
   });
 });

--- a/packages/wxt/src/core/utils/__tests__/transform.test.ts
+++ b/packages/wxt/src/core/utils/__tests__/transform.test.ts
@@ -149,7 +149,6 @@ export default defineContentScript({
         console.log(b);
         console.log(d);
         console.log(e);
-        console.log(f);
         console.log(rest);
 
         export default defineBackground(() => {
@@ -164,7 +163,6 @@ console.log(a);
 console.log(b);
 console.log(d);
 console.log(e);
-console.log(f);
 console.log(rest);
 
 export default defineBackground();`;


### PR DESCRIPTION
### Overview

#1485 

support:

- `const [a, b] = [1, 2];`
- `const { x, y: renamedY, z = 3 } = someObject;`
- `const { foo: { bar } } = nested;`
- `const { unused, ...rest } = obj;`

### Manual Testing

run **packages/wxt/src/core/utils/__tests__/transform.test.ts**.

### Related Issue

#1485 

This PR closes #1485 
