### PR TITLE
feat: type-safe `import.meta.env.BROWSER` with new `targetBrowers` config

### DIFF
--- a/docs/guide/essentials/config/environment-variables.md
+++ b/docs/guide/essentials/config/environment-variables.md
@@ -35,7 +35,7 @@ WXT provides some custom environment variables based on the current command:
 | Usage                              | Type      | Description                                           |
 | ---------------------------------- | --------- | ----------------------------------------------------- |
 | `import.meta.env.MANIFEST_VERSION` | `2 │ 3`   | The target manifest version                           |
-| `import.meta.env.BROWSER`          | `string`  | The target browser.                                   |
+| `import.meta.env.BROWSER`          | `string`  | The target browser                                    |
 | `import.meta.env.CHROME`           | `boolean` | Equivalent to `import.meta.env.BROWSER === "chrome"`  |
 | `import.meta.env.FIREFOX`          | `boolean` | Equivalent to `import.meta.env.BROWSER === "firefox"` |
 | `import.meta.env.SAFARI`           | `boolean` | Equivalent to `import.meta.env.BROWSER === "safari"`  |

--- a/docs/guide/essentials/config/environment-variables.md
+++ b/docs/guide/essentials/config/environment-variables.md
@@ -42,7 +42,7 @@ WXT provides some custom environment variables based on the current command:
 | `import.meta.env.EDGE`             | `boolean` | Equivalent to `import.meta.env.BROWSER === "edge"`    |
 | `import.meta.env.OPERA`            | `boolean` | Equivalent to `import.meta.env.BROWSER === "opera"`   |
 
-The `BROWSER` can be a safer literal string union type of all browser names that you want to support, see [`targetBrowsers`](/api/reference/wxt/interfaces/InlineConfig#targetBrowers) option.
+The `BROWSER` can be a safer literal string union type of all browser names that you want to support, see [`targetBrowsers`](/api/reference/wxt/interfaces/InlineConfig#targetBrowsers) option.
 
 You can also access all of [Vite's environment variables](https://vite.dev/guide/env-and-mode.html#env-variables):
 

--- a/docs/guide/essentials/config/environment-variables.md
+++ b/docs/guide/essentials/config/environment-variables.md
@@ -42,7 +42,7 @@ WXT provides some custom environment variables based on the current command:
 | `import.meta.env.EDGE`             | `boolean` | Equivalent to `import.meta.env.BROWSER === "edge"`    |
 | `import.meta.env.OPERA`            | `boolean` | Equivalent to `import.meta.env.BROWSER === "opera"`   |
 
-The `BROWSER` can be a safer literal string union type of all browser names that you want to support, see [`targetBrowsers`](/api/reference/wxt/interfaces/InlineConfig#targetbrowsers) option.
+You can set the [`targetBrowsers`](/api/reference/wxt/interfaces/InlineConfig#targetbrowsers) option to make the `BROWSER` variable a more specific type, like `"chrome" | "firefox"`.
 
 You can also access all of [Vite's environment variables](https://vite.dev/guide/env-and-mode.html#env-variables):
 

--- a/docs/guide/essentials/config/environment-variables.md
+++ b/docs/guide/essentials/config/environment-variables.md
@@ -35,12 +35,14 @@ WXT provides some custom environment variables based on the current command:
 | Usage                              | Type      | Description                                           |
 | ---------------------------------- | --------- | ----------------------------------------------------- |
 | `import.meta.env.MANIFEST_VERSION` | `2 │ 3`   | The target manifest version                           |
-| `import.meta.env.BROWSER`          | `string`  | The target browser                                    |
+| `import.meta.env.BROWSER`          | `string`  | The target browser.                                   |
 | `import.meta.env.CHROME`           | `boolean` | Equivalent to `import.meta.env.BROWSER === "chrome"`  |
 | `import.meta.env.FIREFOX`          | `boolean` | Equivalent to `import.meta.env.BROWSER === "firefox"` |
 | `import.meta.env.SAFARI`           | `boolean` | Equivalent to `import.meta.env.BROWSER === "safari"`  |
 | `import.meta.env.EDGE`             | `boolean` | Equivalent to `import.meta.env.BROWSER === "edge"`    |
 | `import.meta.env.OPERA`            | `boolean` | Equivalent to `import.meta.env.BROWSER === "opera"`   |
+
+The `BROWSER` can be a safer literal string union type of all browser names that you want to support, see [`targetBrowsers`](/api/reference/wxt/interfaces/InlineConfig#targetBrowers) option.
 
 You can also access all of [Vite's environment variables](https://vite.dev/guide/env-and-mode.html#env-variables):
 

--- a/docs/guide/essentials/config/environment-variables.md
+++ b/docs/guide/essentials/config/environment-variables.md
@@ -42,7 +42,7 @@ WXT provides some custom environment variables based on the current command:
 | `import.meta.env.EDGE`             | `boolean` | Equivalent to `import.meta.env.BROWSER === "edge"`    |
 | `import.meta.env.OPERA`            | `boolean` | Equivalent to `import.meta.env.BROWSER === "opera"`   |
 
-The `BROWSER` can be a safer literal string union type of all browser names that you want to support, see [`targetBrowsers`](/api/reference/wxt/interfaces/InlineConfig#targetBrowsers) option.
+The `BROWSER` can be a safer literal string union type of all browser names that you want to support, see [`targetBrowsers`](/api/reference/wxt/interfaces/InlineConfig#targetbrowsers) option.
 
 You can also access all of [Vite's environment variables](https://vite.dev/guide/env-and-mode.html#env-variables):
 

--- a/packages/wxt-demo/wxt.config.ts
+++ b/packages/wxt-demo/wxt.config.ts
@@ -3,6 +3,7 @@ import { presetUno } from 'unocss';
 
 export default defineConfig({
   srcDir: 'src',
+  targetBrowsers: ['chrome', 'firefox', 'safari'],
   manifest: {
     permissions: ['storage'],
     default_locale: 'en',

--- a/packages/wxt/e2e/tests/typescript-project.test.ts
+++ b/packages/wxt/e2e/tests/typescript-project.test.ts
@@ -396,6 +396,19 @@ describe('TypeScript Project', () => {
     expect(output).toContain('./example.ts');
   });
 
+  it('should set correct import.meta.env.BROWSER type based on targetBrowsers', async () => {
+    const project = new TestProject();
+    project.addFile('entrypoints/unlisted.html', '<html></html>');
+    project.setConfigFileConfig({
+      targetBrowsers: ['firefox', 'chrome'],
+    });
+
+    await project.prepare();
+
+    const output = await project.serializeFile('.wxt/types/globals.d.ts');
+    expect(output).toContain('readonly BROWSER: "firefox" | "chrome";');
+  });
+
   // TODO: Once a module has been published, use it here for testing - local files are never added to the .wxt/wxt.d.ts file
   it.todo(
     'should add modules from NPM to the TS project if they have a configKey',

--- a/packages/wxt/src/core/resolve-config.ts
+++ b/packages/wxt/src/core/resolve-config.ts
@@ -72,8 +72,7 @@ export async function resolveConfig(
   const browser = mergedConfig.browser ?? 'chrome';
   const targetBrowsers = mergedConfig.targetBrowsers ?? [];
   if (targetBrowsers.length > 0 && targetBrowsers.indexOf(browser) === -1) {
-    // Should we stop?
-    logger.warn(
+    throw new Error(
       `Current target browser \`${browser}\` is not in your \`targetBrowsers\` list!`,
     );
   }

--- a/packages/wxt/src/core/resolve-config.ts
+++ b/packages/wxt/src/core/resolve-config.ts
@@ -71,7 +71,7 @@ export async function resolveConfig(
 
   const browser = mergedConfig.browser ?? 'chrome';
   const targetBrowsers = mergedConfig.targetBrowsers ?? [];
-  if (targetBrowsers.length > 0 && targetBrowsers.indexOf(browser) === -1) {
+  if (targetBrowsers.length > 0 && !targetBrowsers.includes(browser)) {
     throw new Error(
       `Current target browser \`${browser}\` is not in your \`targetBrowsers\` list!`,
     );

--- a/packages/wxt/src/core/resolve-config.ts
+++ b/packages/wxt/src/core/resolve-config.ts
@@ -70,6 +70,13 @@ export async function resolveConfig(
   if (debug) logger.level = LogLevels.debug;
 
   const browser = mergedConfig.browser ?? 'chrome';
+  const targetBrowsers = mergedConfig.targetBrowsers ?? [];
+  if (targetBrowsers.length > 0 && targetBrowsers.indexOf(browser) === -1) {
+    // Should we stop?
+    logger.warn(
+      `Current target browser \`${browser}\` is not in your \`targetBrowsers\` list!`,
+    );
+  }
   const manifestVersion =
     mergedConfig.manifestVersion ??
     (browser === 'firefox' || browser === 'safari' ? 2 : 3);
@@ -197,6 +204,7 @@ export async function resolveConfig(
 
   return {
     browser,
+    targetBrowsers,
     command,
     debug,
     entrypointsDir,

--- a/packages/wxt/src/core/utils/globals.ts
+++ b/packages/wxt/src/core/utils/globals.ts
@@ -12,7 +12,12 @@ export function getGlobals(
     {
       name: 'BROWSER',
       value: config.browser,
-      type: `string`,
+      type:
+        config.targetBrowsers.length === 0
+          ? 'string'
+          : config.targetBrowsers
+              .map((browser) => JSON.stringify(browser))
+              .join(' | '),
     },
     {
       name: 'CHROME',

--- a/packages/wxt/src/core/utils/globals.ts
+++ b/packages/wxt/src/core/utils/globals.ts
@@ -15,9 +15,7 @@ export function getGlobals(
       type:
         config.targetBrowsers.length === 0
           ? 'string'
-          : config.targetBrowsers
-              .map((browser) => `"${browser}"`)
-              .join(' | '),
+          : config.targetBrowsers.map((browser) => `"${browser}"`).join(' | '),
     },
     {
       name: 'CHROME',

--- a/packages/wxt/src/core/utils/globals.ts
+++ b/packages/wxt/src/core/utils/globals.ts
@@ -16,7 +16,7 @@ export function getGlobals(
         config.targetBrowsers.length === 0
           ? 'string'
           : config.targetBrowsers
-              .map((browser) => JSON.stringify(browser))
+              .map((browser) => `"${browser}"`)
               .join(' | '),
     },
     {

--- a/packages/wxt/src/core/utils/testing/fake-objects.ts
+++ b/packages/wxt/src/core/utils/testing/fake-objects.ts
@@ -235,6 +235,7 @@ export const fakeResolvedConfig = fakeObjectCreator<ResolvedConfig>(() => {
 
   return {
     browser,
+    targetBrowsers: [],
     command,
     entrypointsDir: fakeDir(),
     modulesDir: fakeDir(),

--- a/packages/wxt/src/types.ts
+++ b/packages/wxt/src/types.ts
@@ -109,8 +109,7 @@ export interface InlineConfig {
    */
   browser?: TargetBrowser;
   /**
-   * Set the browser set you design to support. If it's not empty, the generated `import.meta.env.BROWSER`
-   * will be a narrowed string type that only accept the browser name in provided list.
+   * Target browsers to support. If not empty, `import.meta.env.BROWSER` will be narrowed to a string literal type containing only the specified browser names.
    *
    * @default []
    */

--- a/packages/wxt/src/types.ts
+++ b/packages/wxt/src/types.ts
@@ -109,6 +109,13 @@ export interface InlineConfig {
    */
   browser?: TargetBrowser;
   /**
+   * Set the browser set you design to support. If it's not empty, the generated `import.meta.env.BROWSER`
+   * will be a narrowed string type that only accept the browser name in provided list.
+   *
+   * @default []
+   */
+  targetBrowsers?: TargetBrowser[];
+  /**
    * Explicitly set a manifest version to target. This will override the default manifest version
    * for each command, and can be overridden by the command line `--mv2` or `--mv3` option.
    */
@@ -1311,6 +1318,7 @@ export interface ResolvedConfig {
   mode: string;
   command: WxtCommand;
   browser: TargetBrowser;
+  targetBrowsers: TargetBrowser[];
   manifestVersion: TargetManifestVersion;
   env: ConfigEnv;
   logger: Logger;

--- a/packages/wxt/src/types.ts
+++ b/packages/wxt/src/types.ts
@@ -109,7 +109,7 @@ export interface InlineConfig {
    */
   browser?: TargetBrowser;
   /**
-   * Target browsers to support. If not empty, `import.meta.env.BROWSER` will be narrowed to a string literal type containing only the specified browser names.
+   * Target browsers to support. When set, `import.meta.env.BROWSER` will be narrowed to a string literal type containing only the specified browser names.
    *
    * @default []
    */


### PR DESCRIPTION
### Overview

Currently, `import.meta.env.BROWSER` is typed as a string, which, while technically correct from a type system perspective, can be limiting in practical development. An extension might only support a specific set of browsers, such as "chrome" | "firefox".

Instead of a string, defining BROWSER as an enum-like type could offer several advantages. TypeScript's controw flow analyze makes this approach particularly useful. For instance, a switch statement on import.meta.env.BROWSER would no longer require a default case. The absence of a default case is beneficial because it prevents potential oversights when adding support for new browsers like "edge" in the future. With an enum-like type, the type checker would enforce the addition of a new case in all relevant locations.

### Manual Testing

add `targetBrowsers: ["firefox", "chrome"]` in `wxt.config.js` config file, then run `wxt prepare`(e.g. `pnpm run -F wxt wxt prepare <project-root>`), you should notice the type of `import.meta.env.BROWSER` is`"firefox" | "chrome"` instead of `string`.

A simple e2e is added, `pnpm -F wxt test -t targetBrowers` to run it.

### Unresolved concerns

- [x] Should we stop the prepare/build/dev process if current browser setting is not in the targetBrowsers list? <br>Yes!

### Related Issue

<!-- If this PR is related to an issue, please link it here -->

N/A, If you want more context, join the [discord thread](https://discord.com/channels/1212416027611365476/1359491654565757149):
