### PR TITLE
docs: add radiofrance extension to usingWXT

### DIFF
--- a/docs/.vitepress/components/UsingWxtSection.vue
+++ b/docs/.vitepress/components/UsingWxtSection.vue
@@ -70,6 +70,7 @@ const chromeExtensionIds = [
   'hafcajcllbjnoolpfngclfmmgpikdhlm', // Monochromate
   'bmoggiinmnodjphdjnmpcnlleamkfedj', // AliasVault - Open-Source Password & (Email) Alias Manager
   'hlnhhamckimoaiekbglafiebkfimhapb', // SnapThePrice: AI-Powered Real-time Lowest Price Finder
+  'gdjampjdgjmbifnhldgcnccdjkcoicmg', // radiofrance - news & broadcasts (French), music (international)
 ];
 
 const { data, err, isLoading } = useListExtensionDetails(chromeExtensionIds);


### PR DESCRIPTION
### Overview

Adds the [radiofrance extension](https://chromewebstore.google.com/detail/radiofrance/gdjampjdgjmbifnhldgcnccdjkcoicmg) to the list of projects using WXT in the documentation
