### PR TITLE
chore: update docs to point to webExt instead of runner; update config in demo

### DIFF
--- a/docs/guide/essentials/config/browser-startup.md
+++ b/docs/guide/essentials/config/browser-startup.md
@@ -22,7 +22,7 @@ You can configure browser startup in 3 places:
    });
    ```
 
-2. `<rootDir>/wxt.config.ts`: Via the [`runner` config](/api/reference/wxt/interfaces/InlineConfig#runner), included in version control
+2. `<rootDir>/wxt.config.ts`: Via the [`webExt` config](/api/reference/wxt/interfaces/InlineConfig#webext), included in version control
 3. `$HOME/web-ext.config.ts`: Provide default values for all WXT projects on your computer
 
 ## Recipes

--- a/packages/wxt-demo/wxt.config.ts
+++ b/packages/wxt-demo/wxt.config.ts
@@ -20,7 +20,7 @@ export default defineConfig({
   analysis: {
     open: true,
   },
-  runner: {
+  webExt: {
     startUrls: ['https://duckduckgo.com'],
   },
   example: {


### PR DESCRIPTION
### Overview

[Browser startup docs](https://wxt.dev/guide/essentials/config/browser-startup.html) mentions (and points to) `runner` prop, deprecated for `webExt`