### PR TITLE
fix: Prevent Unlisted CSS from being excluded in the build when using CSS preprocessor

### DIFF
--- a/packages/wxt/e2e/tests/output-structure.test.ts
+++ b/packages/wxt/e2e/tests/output-structure.test.ts
@@ -220,6 +220,77 @@ describe('Output Directory Structure', () => {
     expect(await project.fileExists('.output/chrome-mv3/unlisted.js'));
   });
 
+  it('should support CSS entrypoints', async () => {
+    const project = new TestProject();
+
+    project.addFile(
+      'entrypoints/plain-one.css',
+      `body {
+        font: 100% Helvetica, sans-serif;
+        color: #333;
+      }`,
+    );
+
+    project.addFile(
+      'entrypoints/plain-two.content.css',
+      `body {
+        font: 100% Helvetica, sans-serif;
+        color: #333;
+      }`,
+    );
+
+    project.addFile(
+      'entrypoints/sass-one.scss',
+      `$font-stack: Helvetica, sans-serif;
+      $primary-color: #333;
+
+      body {
+        font: 100% $font-stack;
+        color: $primary-color;
+      }`,
+    );
+
+    project.addFile(
+      'entrypoints/sass-two.content.scss',
+      `$font-stack: Helvetica, sans-serif;
+      $primary-color: #333;
+
+      body {
+        font: 100% $font-stack;
+        color: $primary-color;
+      }`,
+    );
+
+    await project.build();
+
+    expect(await project.serializeOutput(['.output/chrome-mv3/manifest.json']))
+      .toMatchInlineSnapshot(`
+        ".output/chrome-mv3/assets/plain-one.css
+        ----------------------------------------
+        body{font:100% Helvetica,sans-serif;color:#333}
+
+        ================================================================================
+        .output/chrome-mv3/assets/sass-one.css
+        ----------------------------------------
+        body{font:100% Helvetica,sans-serif;color:#333}
+
+        ================================================================================
+        .output/chrome-mv3/content-scripts/plain-two.css
+        ----------------------------------------
+        body{font:100% Helvetica,sans-serif;color:#333}
+
+        ================================================================================
+        .output/chrome-mv3/content-scripts/sass-two.css
+        ----------------------------------------
+        body{font:100% Helvetica,sans-serif;color:#333}
+
+        ================================================================================
+        .output/chrome-mv3/manifest.json
+        ----------------------------------------
+        <contents-ignored>"
+      `);
+  });
+
   it("should output to a custom directory when overriding 'outDir'", async () => {
     const project = new TestProject();
     project.addFile('entrypoints/unlisted.html', '<html></html>');

--- a/packages/wxt/src/core/builders/vite/index.ts
+++ b/packages/wxt/src/core/builders/vite/index.ts
@@ -308,7 +308,10 @@ export async function createViteBuilder(
     async build(group) {
       let entryConfig;
       if (Array.isArray(group)) entryConfig = getMultiPageConfig(group);
-      else if (group.inputPath.endsWith('.css'))
+      else if (
+        group.type === 'content-script-style' ||
+        group.type === 'unlisted-style'
+      )
         entryConfig = getCssConfig(group);
       else entryConfig = getLibModeConfig(group);
 


### PR DESCRIPTION
### Overview

<!-- Describe your changes and why you made them -->

Currently, the build function of `viteBuilder` determines whether a file is a CSS entrypoint by checking if its file extension ends with `.css`. As a result, Unlisted CSS using preprocessors like Sass are not built as CSS entrypoints and ignored during the build.

This PR updates the CSS entrypoint detection to use the `group.type` value and adds e2e tests for CSS entrypoints.

This is my first PR to an open-source project, so if there's anything I missed or did incorrectly, please let me know. Thanks!

### Manual Testing

<!-- Describe how to test your changes to make sure the PR works as intended -->

Please check the CSS entrypoint e2e tests I added to the PR.

### Related Issue

<!-- If this PR is related to an issue, please link it here -->

This PR closes #1580.
