### PR TITLE
fix: Fix hashing issue with inline scripts

### DIFF
--- a/packages/wxt/src/core/builders/vite/plugins/devHtmlPrerender.ts
+++ b/packages/wxt/src/core/builders/vite/plugins/devHtmlPrerender.ts
@@ -128,7 +128,7 @@ export function devHtmlPrerender(
         // Resolve virtualized inline scripts
         if (id.startsWith(resolvedVirtualInlineScript)) {
           // id="virtual:wxt-inline-script?<hash>"
-          const hash = Number(id.substring(id.indexOf('?') + 1));
+          const hash = hash(id.substring(id.indexOf('?')));
           return inlineScriptContents[hash];
         }
 

--- a/packages/wxt/src/core/builders/vite/plugins/devHtmlPrerender.ts
+++ b/packages/wxt/src/core/builders/vite/plugins/devHtmlPrerender.ts
@@ -128,8 +128,8 @@ export function devHtmlPrerender(
         // Resolve virtualized inline scripts
         if (id.startsWith(resolvedVirtualInlineScript)) {
           // id="virtual:wxt-inline-script?<hash>"
-          const hash = hash(id.substring(id.indexOf('?')));
-          return inlineScriptContents[hash];
+          const newHash = hash(id.substring(id.indexOf('?')));
+          return inlineScriptContents[newHash];
         }
 
         // Ignore chunks during HTML file pre-rendering


### PR DESCRIPTION
### Overview

This bug cause of `ohash` v2 hash function change.

`ohash` hash function uses SHA256, so `Number(hashid)` return `NaN`. So I replaced it to `hash(hashId)`.

If reuse `murmurhash`, wait to merge https://github.com/unjs/ohash/pull/158

### Manual Testing

![스크린샷 2025-04-18 23 57 43](https://github.com/user-attachments/assets/454007bb-256b-4949-803f-92bb9408c841)

### Related Issue

This PR closes #1578 
