### PR TITLE
fix: fix typescript error on `defineItem` fallback

### DIFF
--- a/packages/storage/src/__tests__/index.test.ts
+++ b/packages/storage/src/__tests__/index.test.ts
@@ -1281,6 +1281,19 @@ describe('Storage Utils', () => {
       it('should define a nullable value when options are not passed', () => {
         const item = storage.defineItem<number>(`local:test`);
         expectTypeOf(item).toEqualTypeOf<WxtStorageItem<number | null, {}>>();
+
+        const item2 = storage.defineItem<number>(`local:test`, {});
+        expectTypeOf(item2).toEqualTypeOf<WxtStorageItem<number | null, {}>>();
+
+        const item3 = storage.defineItem<number>(`local:test`, {
+          fallback: undefined,
+        });
+        expectTypeOf(item3).toEqualTypeOf<WxtStorageItem<number | null, {}>>();
+
+        const item4 = storage.defineItem<number>(`local:test`, {
+          defaultValue: undefined,
+        });
+        expectTypeOf(item4).toEqualTypeOf<WxtStorageItem<number | null, {}>>();
       });
 
       it('should define a non-null value when options are passed with a nullish default value', () => {
@@ -1288,6 +1301,11 @@ describe('Storage Utils', () => {
           defaultValue: 123,
         });
         expectTypeOf(item).toEqualTypeOf<WxtStorageItem<number, {}>>();
+
+        const item2 = storage.defineItem(`local:test`, {
+          fallback: 123,
+        });
+        expectTypeOf(item2).toEqualTypeOf<WxtStorageItem<number, {}>>();
       });
 
       it('should define a nullable value when options are passed with null default value', () => {

--- a/packages/storage/src/index.ts
+++ b/packages/storage/src/index.ts
@@ -750,8 +750,20 @@ export interface WxtStorage {
   ): WxtStorageItem<TValue | null, TMetadata>;
   defineItem<TValue, TMetadata extends Record<string, unknown> = {}>(
     key: StorageItemKey,
-    options: WxtStorageItemOptions<TValue>,
+    options: WxtStorageItemOptions<TValue> & { fallback: TValue },
   ): WxtStorageItem<TValue, TMetadata>;
+  defineItem<TValue, TMetadata extends Record<string, unknown> = {}>(
+    key: StorageItemKey,
+    options: WxtStorageItemOptions<TValue> & { fallback?: never },
+  ): WxtStorageItem<TValue | null, TMetadata>;
+  defineItem<TValue, TMetadata extends Record<string, unknown> = {}>(
+    key: StorageItemKey,
+    options: WxtStorageItemOptions<TValue> & { defaultValue: TValue },
+  ): WxtStorageItem<TValue, TMetadata>;
+  defineItem<TValue, TMetadata extends Record<string, unknown> = {}>(
+    key: StorageItemKey,
+    options: WxtStorageItemOptions<TValue> & { defaultValue?: never },
+  ): WxtStorageItem<TValue | null, TMetadata>;
 }
 
 interface WxtStorageDriver {

--- a/packages/storage/src/index.ts
+++ b/packages/storage/src/index.ts
@@ -754,15 +754,11 @@ export interface WxtStorage {
   ): WxtStorageItem<TValue, TMetadata>;
   defineItem<TValue, TMetadata extends Record<string, unknown> = {}>(
     key: StorageItemKey,
-    options: WxtStorageItemOptions<TValue> & { fallback?: never },
-  ): WxtStorageItem<TValue | null, TMetadata>;
-  defineItem<TValue, TMetadata extends Record<string, unknown> = {}>(
-    key: StorageItemKey,
     options: WxtStorageItemOptions<TValue> & { defaultValue: TValue },
   ): WxtStorageItem<TValue, TMetadata>;
   defineItem<TValue, TMetadata extends Record<string, unknown> = {}>(
     key: StorageItemKey,
-    options: WxtStorageItemOptions<TValue> & { defaultValue?: never },
+    options: WxtStorageItemOptions<TValue>,
   ): WxtStorageItem<TValue | null, TMetadata>;
 }
 


### PR DESCRIPTION
### Overview

Currently, the second signature of `WxtStorage.defineItem` method is incorrect that it doesn't respect the fallback value.

https://github.com/wxt-dev/wxt/blob/4c35798dbaaf96983d1148544716568beae41732/packages/storage/src/index.ts#L748-L754

The following examples show the bug clearly.

```typescript
export const storageTodoItems = storage.defineItem<StorageTodoItem[]>(
  'local:StorageTodoItems',
  { fallback: [] },
)  // Type is StorageTodoItem[]

export const storageTodoItems = storage.defineItem<StorageTodoItem[]>(
  'local:StorageTodoItems',
)  // Type is StorageTodoItem[] | null

export const storageTodoItems = storage.defineItem<StorageTodoItem[]>(
  'local:StorageTodoItems', {}
)  // Type is StorageTodoItem[]. Wrong!!!
```

### Manual Testing

```typescript
export const storageTodoItems = storage.defineItem<StorageTodoItem[]>(
  'local:StorageTodoItems',
)  // Type is StorageTodoItem[] | null

export const storageTodoItems = storage.defineItem<StorageTodoItem[]>(
  'local:StorageTodoItems',
  {},
)  // Type is StorageTodoItem[] | null

export const storageTodoItems = storage.defineItem<StorageTodoItem[]>(
  'local:StorageTodoItems',
  { fallback: [] },
)  // Type is StorageTodoItem[]
```

### Related Issue