### PR TITLE
feat: add `{{packageVersion}}` as template variable

### DIFF
--- a/packages/wxt/src/core/zip.ts
+++ b/packages/wxt/src/core/zip.ts
@@ -31,6 +31,7 @@ export async function zip(config?: InlineConfig): Promise<string[]> {
     safeFilename(
       (await getPackageJson())?.name || path.basename(process.cwd()),
     );
+  const packageVersion = (await getPackageJson())?.version;
   const applyTemplate = (template: string): string =>
     template
       .replaceAll('{{name}}', projectName)
@@ -39,6 +40,7 @@ export async function zip(config?: InlineConfig): Promise<string[]> {
         '{{version}}',
         output.manifest.version_name ?? output.manifest.version,
       )
+      .replaceAll('{{packageVersion}}', packageVersion)
       .replaceAll('{{mode}}', wxt.config.mode)
       .replaceAll('{{manifestVersion}}', `mv${wxt.config.manifestVersion}`);
 


### PR DESCRIPTION
### Overview

This PR adds {{packageVersion}} as an additional template variable to artifactTemplate and sourcesTemplate.
Currently only {{version}} can be used. However, when building for Firefox, a package version such as 1.0.0-beta.1 is reduced to 1.0.0 because Firefox does not allow suffixes in the version in the manifest file. Therefore, the version numbers in the file names of the zip files for Firefox differ from the version number in the file name for Chrome, e.g.:
```
myextension-1.0.0-beta.1-chrome.zip
myextension-1.0.0-firefox.zip
myextension-1.0.0-sources.zip
```

With this PR and when using {{packageVersion}} instead of {{version}}, the version in the file names is the same:
```
myextension-1.0.0-beta.1-chrome.zip
myextension-1.0.0-beta.1-firefox.zip
myextension-1.0.0-beta.1-sources.zip
```

### Manual Testing

Change your package version to 1.0.0-beta.1 .
Set a custom artifactTemplate and sourcesTemplate in your wxt.config.ts:
```
artifactTemplate: "{{name}}-{{packageVersion}}-{{browser}}.zip",
sourcesTemplate: "{{name}}-{{packageVersion}}-sources.zip" ,
```
Run `wxt zip -b firefox`.
The resulting zip files should contain the package version `1.0.0-beta.1` in the file name.

### Related Issue

N/A
I think this PR might be beneficial for people like me who want to see the package version number in the filename.
