### PR TITLE
fix: auto icons override default icons

### DIFF
--- a/packages/auto-icons/src/index.ts
+++ b/packages/auto-icons/src/index.ts
@@ -32,7 +32,7 @@ export default defineWxtModule<AutoIconsOptions>({
 
     wxt.hooks.hook('build:manifestGenerated', async (wxt, manifest) => {
       if (manifest.icons)
-        return wxt.logger.warn(
+        wxt.logger.warn(
           '`[auto-icons]` icons property found in manifest, overwriting with auto-generated icons',
         );
 


### PR DESCRIPTION
just removed `return` statement in line 35. 
https://github.com/wxt-dev/wxt/blob/31071bd11e4926a73abaab8da4d9186dccbdb20c/packages/auto-icons/src/index.ts#L35

### Manual Testing

1. have default icons in the public folder `public/icon/*`
2. install auto icons
3. add a icon to `<src>/assets/icon.png`
4. `run npm run dev`

This PR closes #1592
