### PR TITLE
feat!: add `{{modeSuffix}}` to zip templates and update defaults

### DIFF
--- a/packages/wxt/e2e/tests/zip.test.ts
+++ b/packages/wxt/e2e/tests/zip.test.ts
@@ -77,21 +77,22 @@ describe('Zipping', () => {
   it('should correctly apply template variables for zip file names based on provided config', async () => {
     const project = new TestProject({
       name: 'test',
-      version: '1.0.0',
+      version: '1.0.0-beta.1',
     });
     project.addFile(
       'entrypoints/background.ts',
       'export default defineBackground(() => {});',
     );
-    const artifactZip = '.output/test-1.0.0-firefox-development.zip';
-    const sourcesZip = '.output/test-1.0.0-development-sources.zip';
+    const artifactZip = '.output/test-1.0.0-beta.1-firefox-development.zip';
+    const sourcesZip = '.output/test-1.0.0-beta.1-development-sources.zip';
 
     await project.zip({
       browser: 'firefox',
       mode: 'development',
       zip: {
-        artifactTemplate: '{{name}}-{{version}}-{{browser}}-{{mode}}.zip',
-        sourcesTemplate: '{{name}}-{{version}}-{{mode}}-sources.zip',
+        artifactTemplate:
+          '{{name}}-{{packageVersion}}-{{browser}}-{{mode}}.zip',
+        sourcesTemplate: '{{name}}-{{packageVersion}}-{{mode}}-sources.zip',
       },
     });
 

--- a/packages/wxt/e2e/tests/zip.test.ts
+++ b/packages/wxt/e2e/tests/zip.test.ts
@@ -83,16 +83,17 @@ describe('Zipping', () => {
       'entrypoints/background.ts',
       'export default defineBackground(() => {});',
     );
-    const artifactZip = '.output/test-1.0.0-beta.1-firefox-development.zip';
-    const sourcesZip = '.output/test-1.0.0-beta.1-development-sources.zip';
+    const artifactZip = '.output/test-1.0.0-beta.1-firefox-dev.zip';
+    const sourcesZip = '.output/test-1.0.0-beta.1-sources-dev.zip';
 
     await project.zip({
       browser: 'firefox',
       mode: 'development',
       zip: {
         artifactTemplate:
-          '{{name}}-{{packageVersion}}-{{browser}}-{{mode}}.zip',
-        sourcesTemplate: '{{name}}-{{packageVersion}}-{{mode}}-sources.zip',
+          '{{name}}-{{packageVersion}}-{{browser}}{{modeSuffix}}.zip',
+        sourcesTemplate:
+          '{{name}}-{{packageVersion}}-sources{{modeSuffix}}.zip',
       },
     });
 

--- a/packages/wxt/src/core/resolve-config.ts
+++ b/packages/wxt/src/core/resolve-config.ts
@@ -301,8 +301,9 @@ function resolveZipConfig(
   const downloadedPackagesDir = path.resolve(root, '.wxt/local_modules');
   return {
     name: undefined,
-    sourcesTemplate: '{{name}}-{{packageVersion}}-sources.zip',
-    artifactTemplate: '{{name}}-{{packageVersion}}-{{browser}}.zip',
+    sourcesTemplate: '{{name}}-{{packageVersion}}-sources{{modeSuffix}}.zip',
+    artifactTemplate:
+      '{{name}}-{{packageVersion}}-{{browser}}{{modeSuffix}}.zip',
     sourcesRoot: root,
     includeSources: [],
     compressionLevel: 9,

--- a/packages/wxt/src/core/resolve-config.ts
+++ b/packages/wxt/src/core/resolve-config.ts
@@ -301,8 +301,8 @@ function resolveZipConfig(
   const downloadedPackagesDir = path.resolve(root, '.wxt/local_modules');
   return {
     name: undefined,
-    sourcesTemplate: '{{name}}-{{version}}-sources.zip',
-    artifactTemplate: '{{name}}-{{version}}-{{browser}}.zip',
+    sourcesTemplate: '{{name}}-{{packageVersion}}-sources.zip',
+    artifactTemplate: '{{name}}-{{packageVersion}}-{{browser}}.zip',
     sourcesRoot: root,
     includeSources: [],
     compressionLevel: 9,

--- a/packages/wxt/src/core/zip.ts
+++ b/packages/wxt/src/core/zip.ts
@@ -30,6 +30,11 @@ export async function zip(config?: InlineConfig): Promise<string[]> {
   const projectName =
     wxt.config.zip.name ??
     safeFilename(packageJson?.name || path.basename(process.cwd()));
+  const modeSuffixes: Record<string, string | undefined> = {
+    production: '',
+    development: '-dev',
+  };
+  const modeSuffix = modeSuffixes[wxt.config.mode] ?? `-${wxt.config.mode}`;
   const applyTemplate = (template: string): string =>
     template
       .replaceAll('{{name}}', projectName)
@@ -39,6 +44,7 @@ export async function zip(config?: InlineConfig): Promise<string[]> {
         output.manifest.version_name ?? output.manifest.version,
       )
       .replaceAll('{{packageVersion}}', packageJson?.version)
+      .replaceAll('{{modeSuffix}}', modeSuffix)
       .replaceAll('{{mode}}', wxt.config.mode)
       .replaceAll('{{manifestVersion}}', `mv${wxt.config.manifestVersion}`);
 

--- a/packages/wxt/src/types.ts
+++ b/packages/wxt/src/types.ts
@@ -150,9 +150,10 @@ export interface InlineConfig {
      * - <span v-pre>`{{packageVersion}}`</span> - The version from the package.json
      * - <span v-pre>`{{browser}}`</span> - The target browser from the `--browser` CLI flag
      * - <span v-pre>`{{mode}}`</span> - The current mode
+     * - <span v-pre>`{{modeSuffix}}`</span>: A suffix based on the mode ('-dev' for development, '' for production)
      * - <span v-pre>`{{manifestVersion}}`</span> - Either "2" or "3"
      *
-     * @default "{{name}}-{{packageVersion}}-{{browser}}.zip"
+     * @default "{{name}}-{{packageVersion}}-{{browser}}{{modeSuffix}}.zip"
      */
     artifactTemplate?: string;
     /**
@@ -175,9 +176,10 @@ export interface InlineConfig {
      * - <span v-pre>`{{packageVersion}}`</span> - The version from the package.json
      * - <span v-pre>`{{browser}}`</span> - The target browser from the `--browser` CLI flag
      * - <span v-pre>`{{mode}}`</span> - The current mode
+     * - <span v-pre>`{{modeSuffix}}`</span>: A suffix based on the mode ('-dev' for development, '' for production)
      * - <span v-pre>`{{manifestVersion}}`</span> - Either "2" or "3"
      *
-     * @default "{{name}}-{{packageVersion}}-sources.zip"
+     * @default "{{name}}-{{packageVersion}}-sources{{modeSuffix}}.zip"
      */
     sourcesTemplate?: string;
     /**

--- a/packages/wxt/src/types.ts
+++ b/packages/wxt/src/types.ts
@@ -152,7 +152,7 @@ export interface InlineConfig {
      * - <span v-pre>`{{mode}}`</span> - The current mode
      * - <span v-pre>`{{manifestVersion}}`</span> - Either "2" or "3"
      *
-     * @default "{{name}}-{{version}}-{{browser}}.zip"
+     * @default "{{name}}-{{packageVersion}}-{{browser}}.zip"
      */
     artifactTemplate?: string;
     /**
@@ -177,7 +177,7 @@ export interface InlineConfig {
      * - <span v-pre>`{{mode}}`</span> - The current mode
      * - <span v-pre>`{{manifestVersion}}`</span> - Either "2" or "3"
      *
-     * @default "{{name}}-{{version}}-sources.zip"
+     * @default "{{name}}-{{packageVersion}}-sources.zip"
      */
     sourcesTemplate?: string;
     /**


### PR DESCRIPTION
BREAKING CHANGE: use `{{packageVersion}}` as default in artifactTemplate and sourcesTemplate & add template variable `{{modeSuffix}}` to artifactTemplate and sourcesTemplate and use it as default

### Overview

This PR is a continuation of PR #1604 and #1612 and the associated discussion and introduces a breaking change to the default templates for artifactTemplate and sourcesTemplate:

1. it replaces `{{version}}` with `{{packageVersion}}` in the artifactTemplate and sourcesTemplate
2. adds `{{modeSuffix}}` as a new template variable for artifactTemplate and sourcesTemplate
3. adds `{{modeSuffix}}` to the end of artifactTemplate and sourcesTemplate

```
sourcesTemplate: '{{name}}-{{packageVersion}}-sources{{modeSuffix}}.zip'
artifactTemplate: '{{name}}-{{packageVersion}}-{{browser}}{{modeSuffix}}.zip'
```

### Manual Testing

1. set the version in `package.json`to `1.0.0-beta.1`
2. remove any custom artifactTemplate and sourcesTemplate in `wxt.config.ts`
3. run `wxt zip -m development` & `wxt zip -m development -b firefox`
4. the resulting zip file should be named like:
    ```
    extensionname-1.0.0-beta.1-chrome-dev.zip
    extensionname-1.0.0-beta.1-firefox-dev.zip
    extensionname-1.0.0-beta.1-sources-dev.zip
   ```
### Related Issue

This PR closes #1618
