### PR TITLE
docs: Update environment-variables.md with info about env.DEV

### DIFF
--- a/docs/guide/essentials/config/environment-variables.md
+++ b/docs/guide/essentials/config/environment-variables.md
@@ -86,8 +86,8 @@ Note that Vite's runtime environment variables, like `import.meta.env.DEV`, will
 ```ts
 export default defineConfig({
   manifest: ({ mode }) => {
-    const isDev = mode === "development";
-    console.log("Is development mode:", isDev);
+    const isDev = mode === 'development';
+    console.log('Is development mode:', isDev);
 
     // ...
   },

--- a/docs/guide/essentials/config/environment-variables.md
+++ b/docs/guide/essentials/config/environment-variables.md
@@ -79,7 +79,7 @@ export default defineConfig({
 });
 ```
 
-Note env variables like `import.meta.env.DEV` will not be defined here, instead access the mode like this:
+Note that Vite's runtime environment variables, like `import.meta.env.DEV`, will not be defined. Instead, access the `mode` like this:
 
 ```ts
 export default defineConfig({

--- a/docs/guide/essentials/config/environment-variables.md
+++ b/docs/guide/essentials/config/environment-variables.md
@@ -87,11 +87,7 @@ export default defineConfig({
     const isDev = mode === "development";
     console.log("Is development mode:", isDev);
 
-    return {
-      oauth2: {
-        client_id: import.meta.env.WXT_APP_CLIENT_ID
-      }
-    };
+    // ...
   },
 });
 ```

--- a/docs/guide/essentials/config/environment-variables.md
+++ b/docs/guide/essentials/config/environment-variables.md
@@ -80,4 +80,21 @@ export default defineConfig({
 });
 ```
 
+Note env variables like `import.meta.env.DEV` will not be defined here, instead access the mode like this:
+
+```ts
+export default defineConfig({
+  manifest: ({ mode }) => {
+    const isDev = mode === "development";
+    console.log("Is development mode:", isDev);
+
+    return {
+      oauth2: {
+        client_id: import.meta.env.WXT_APP_CLIENT_ID
+      }
+    };
+  },
+});
+```
+
 WXT can't load your `.env` files until after the config file has been loaded. So by using the function syntax for `manifest`, it defers creating the object until after the `.env` files are loaded into the process.

--- a/docs/guide/essentials/config/environment-variables.md
+++ b/docs/guide/essentials/config/environment-variables.md
@@ -65,7 +65,6 @@ To use environment variables in the manifest, you need to use the function synta
 
 ```ts
 export default defineConfig({
-  extensionApi: 'chrome',
   modules: ['@wxt-dev/module-vue'],
   manifest: { // [!code --]
     oauth2: { // [!code --]

--- a/docs/guide/essentials/config/environment-variables.md
+++ b/docs/guide/essentials/config/environment-variables.md
@@ -79,6 +79,8 @@ export default defineConfig({
 });
 ```
 
+WXT can't load your `.env` files until after the config file has been loaded. So by using the function syntax for `manifest`, it defers creating the object until after the `.env` files are loaded into the process.
+
 Note that Vite's runtime environment variables, like `import.meta.env.DEV`, will not be defined. Instead, access the `mode` like this:
 
 ```ts
@@ -91,5 +93,3 @@ export default defineConfig({
   },
 });
 ```
-
-WXT can't load your `.env` files until after the config file has been loaded. So by using the function syntax for `manifest`, it defers creating the object until after the `.env` files are loaded into the process.


### PR DESCRIPTION
I'm not sure if this is a bug or intended but if it's not a bug and the docs just need to updated, hopefully this is correct. I also removed the deprecated chromeApi key. 