### PR TITLE
fix: Allow custom API URL in Google Analytics 4 provider options

### DIFF
--- a/packages/analytics/modules/analytics/providers/google-analytics-4.ts
+++ b/packages/analytics/modules/analytics/providers/google-analytics-4.ts
@@ -4,6 +4,7 @@ import type { BaseAnalyticsEvent } from '../types';
 const DEFAULT_ENGAGEMENT_TIME_IN_MSEC = 100;
 
 export interface GoogleAnalytics4ProviderOptions {
+  apiUrl: string | undefined;
   apiSecret: string;
   measurementId: string;
 }
@@ -18,7 +19,7 @@ export const googleAnalytics4 =
       ): Promise<void> => {
         const url = new URL(
           config?.debug ? '/debug/mp/collect' : '/mp/collect',
-          'https://www.google-analytics.com',
+          options?.apiUrl ? options.apiUrl : 'https://www.google-analytics.com',
         );
         if (options.apiSecret)
           url.searchParams.set('api_secret', options.apiSecret);


### PR DESCRIPTION
### Overview

see dicussion: Help adding Umami and/or GA4 #1596

avoid leaking google analytics api_serect in extension by forwarding request to self-hosted server

### Manual Testing

<!-- Describe how to test your changes to make sure the PR works as intended -->

### Related Issue

N/A
