### PR TITLE
docs: fix svelte app unmount code

### DIFF
--- a/docs/guide/essentials/content-scripts.md
+++ b/docs/guide/essentials/content-scripts.md
@@ -205,13 +205,12 @@ export default defineContentScript({
   matches: ['<all_urls>'],
 
   main(ctx) {
-    let app: Record<string, any>;
     const ui = createIntegratedUi(ctx, {
       position: 'inline',
       anchor: 'body',
       onMount: (container) => {
         // Create the Svelte app inside the UI container
-        app = mount(App, { target: container });
+        return mount(App, { target: container });
       },
       onRemove: (app) => {
         // Destroy the app when the UI is removed
@@ -388,16 +387,15 @@ export default defineContentScript({
 
   async main(ctx) {
     // 3. Define your UI
-    let app: Record<string, any>;
     const ui = await createShadowRootUi(ctx, {
       name: 'example-ui',
       position: 'inline',
       anchor: 'body',
       onMount: (container) => {
         // Create the Svelte app inside the UI container
-        app = mount(App, { target: container });
+        return mount(App, { target: container });
       },
-      onRemove: () => {
+      onRemove: (app) => {
         // Destroy the app when the UI is removed
         unmount(app);
       },

--- a/docs/guide/essentials/content-scripts.md
+++ b/docs/guide/essentials/content-scripts.md
@@ -205,14 +205,13 @@ export default defineContentScript({
   matches: ['<all_urls>'],
 
   main(ctx) {
+    let app: Record<string, any>;
     const ui = createIntegratedUi(ctx, {
       position: 'inline',
       anchor: 'body',
       onMount: (container) => {
         // Create the Svelte app inside the UI container
-        mount(App, {
-          target: container,
-        });
+        app = mount(App, { target: container });
       },
       onRemove: (app) => {
         // Destroy the app when the UI is removed
@@ -389,15 +388,14 @@ export default defineContentScript({
 
   async main(ctx) {
     // 3. Define your UI
+    let app: Record<string, any>;
     const ui = await createShadowRootUi(ctx, {
       name: 'example-ui',
       position: 'inline',
       anchor: 'body',
       onMount: (container) => {
         // Create the Svelte app inside the UI container
-        mount(App, {
-          target: container,
-        });
+        app = mount(App, { target: container });
       },
       onRemove: () => {
         // Destroy the app when the UI is removed


### PR DESCRIPTION
### Overview

<!-- Describe your changes and why you made them -->

> Cannot find name 'app'. Did you mean 'App'? `ts(2552)`

https://svelte.dev/docs/svelte/imperative-component-api#unmount

```ts
import { mount, unmount } from 'svelte';
import App from './App.svelte';

const app = mount(App, { target: document.body });

// later
unmount(app, { outro: true });
```
