### PR TITLE
fix: init project should allow the .git folder to exist

### DIFF
--- a/packages/wxt/src/core/initialize.ts
+++ b/packages/wxt/src/core/initialize.ts
@@ -58,7 +58,9 @@ export async function initialize(options: {
 
   const isExists = await fs.pathExists(input.directory);
   if (isExists) {
-    const isEmpty = (await fs.readdir(input.directory)).length === 0;
+    const isEmpty =
+      (await fs.readdir(input.directory)).filter((dir) => dir !== '.git')
+        .length === 0;
     if (!isEmpty) {
       consola.error(
         `The directory ${path.resolve(input.directory)} is not empty. Aborted.`,


### PR DESCRIPTION
### Overview
I created an empty project on GitHub and cloned it locally. After that, a .git folder existed. The existence of the .git folder should be allowed when initializing the project.

<!-- Describe your changes and why you made them -->

### Manual Testing

<!-- Describe how to test your changes to make sure the PR works as intended -->

### Related Issue

<!-- If this PR is related to an issue, please link it here -->

This PR closes #<issue_number>
