### PR TITLE
fix: rootDir, not srdDir for public/_locales

### DIFF
--- a/docs/guide/essentials/i18n.md
+++ b/docs/guide/essentials/i18n.md
@@ -22,7 +22,7 @@ This page discusses how to setup internationalization using the vanilla `browser
 
    <!-- prettier-ignore -->
    ```html
-   📂 {srcDir}/
+   📂 {rootDir}/
       📂 public/
          📂 _locales/
             📂 en/


### PR DESCRIPTION
### Overview

Fixing docs to call use the `rootDir`, not the `srcDir` when configuring the `public/_locales` directory.

### Manual Testing

N/A

### Related Issue

N/A