### PR TITLE
feat: Remove script element immediately in injectScript

### DIFF
--- a/packages/wxt/src/utils/inject-script.ts
+++ b/packages/wxt/src/utils/inject-script.ts
@@ -32,11 +32,11 @@ export async function injectScript(
     script.src = url;
   }
 
-  if (!options?.keepInDom) {
-    script.onload = () => script.remove();
-  }
-
   (document.head ?? document.documentElement).append(script);
+
+  if (!options?.keepInDom) {
+    script.remove();
+  }
 }
 
 export interface InjectScriptOptions {


### PR DESCRIPTION
### Overview

I am trying to minimize any chance of my extension leaving something in the DOM or the window object etc.

A script which fails to load would be left in the DOM. Rather than adding an onerror handler, it seems that the script element can just be removed immediately after being added.

Everything seems to work: the script is executed; onload, onerror handlers do the right thing; document.currentScript invoked by the script returns the detached script element.

### Manual Testing

Just using injectScript normally should suffice. I am working on an extension which uses injectScript. It seems to work fine with this change.

### Related Issue

N/A
