### PR TITLE
[Advice needed] feat: Have injectScript return the return value of the script

### DIFF
--- a/packages/wxt/src/utils/inject-script.ts
+++ b/packages/wxt/src/utils/inject-script.ts
@@ -1,5 +1,6 @@
 /** @module wxt/utils/inject-script */
 import { browser } from 'wxt/browser';
+import { waitForScriptResultEvent } from './internal/script-result';
 
 export type ScriptPublicPath = Extract<
   // @ts-expect-error: PublicPath is generated per-project
@@ -16,7 +17,8 @@ export type ScriptPublicPath = Extract<
  * Make sure to add the injected script to your manifest's
  * `web_accessible_resources`.
  *
- * @returns A result object containing the created script element.
+ * @returns A result object containing the created script element and the return
+ * value of the script.
  */
 export async function injectScript(
   path: ScriptPublicPath,
@@ -39,6 +41,7 @@ export async function injectScript(
   // For MV2: Inline scripts execute synchronously when appended
   // For MV3: We need to wait for the load event
   const loadedPromise = isManifestV2 ? undefined : makeLoadedPromise(script);
+  const resultPromise = waitForScriptResultEvent(script);
 
   await options?.modifyScript?.(script);
 
@@ -49,9 +52,11 @@ export async function injectScript(
   }
 
   await loadedPromise;
+  const result = await resultPromise;
 
   return {
     script,
+    result,
   };
 }
 
@@ -100,4 +105,8 @@ export interface InjectScriptResult {
    * for them via `document.currentScript`.
    */
   script: HTMLScriptElement;
+  /**
+   * The return value of the script.
+   */
+  result: unknown;
 }

--- a/packages/wxt/src/utils/internal/script-result.ts
+++ b/packages/wxt/src/utils/internal/script-result.ts
@@ -1,0 +1,161 @@
+// The `MAIN` world script cannot use `browser.runtime.id`, but the uniqueness
+// of the event name is not an issue as the event is only dispatched on a
+// specific `script` element which is detached from the document.
+const SCRIPT_RESULT_EVENT_NAME = 'wxt:script-result';
+
+/**
+ * Dispatch a `CustomEvent` for a successful script result which carries a
+ * result value.
+ */
+export function dispatchScriptSuccessEvent(
+  target: EventTarget,
+  value: unknown,
+): boolean {
+  return dispatchScriptResultEvent(target, scriptSuccess(value));
+}
+
+/**
+ * Dispatch a `CustomEvent` for a failed script result which carries an `Error`
+ * value.
+ */
+export function dispatchScriptErrorEvent(
+  target: EventTarget,
+  error: Error,
+): boolean {
+  return dispatchScriptResultEvent(target, scriptError(error));
+}
+
+function dispatchScriptResultEvent(
+  target: EventTarget,
+  result: ScriptResult,
+): boolean {
+  return target.dispatchEvent(
+    new CustomEvent(SCRIPT_RESULT_EVENT_NAME, { detail: result }),
+  );
+}
+
+/**
+ * Add a one-time event listener for a script result `CustomEvent`, and return a
+ * `Promise` which either resolves with the result value or rejects with an
+ * error depending on whether the result is successful or not.
+ */
+export function waitForScriptResultEvent(
+  target: EventTarget,
+): Promise<unknown> {
+  return new Promise((resolve, reject) => {
+    target.addEventListener(
+      SCRIPT_RESULT_EVENT_NAME,
+      (event) => {
+        try {
+          resolve(parseScriptResultEvent(event));
+        } catch (err) {
+          reject(err);
+        }
+      },
+      { once: true },
+    );
+  });
+}
+
+function parseScriptResultEvent(event: Event): unknown {
+  if (!(event instanceof CustomEvent)) {
+    throw new Error(
+      `Expected a \`CustomEvent\`, got: \`${event.constructor.name}\``,
+    );
+  }
+
+  return parseScriptResult(event.detail as unknown);
+}
+
+type ScriptResult =
+  | { type: 'success'; value: unknown }
+  | { type: 'error'; error: Error };
+
+function scriptSuccess(value: unknown): ScriptResult {
+  return { type: 'success', value };
+}
+
+function scriptError(error: Error): ScriptResult {
+  return { type: 'error', error: deconstructError(error) };
+}
+
+function parseScriptResult(result: unknown): unknown {
+  if (!isScriptResult(result)) {
+    throw new Error(
+      `Expected a \`ScriptResult\`, got: ${JSON.stringify(result)}`,
+    );
+  }
+
+  switch (result.type) {
+    case 'success':
+      return result.value;
+    case 'error':
+      throw reconstructError(result.error);
+    default:
+      throw new Error(
+        `Impossible \`ScriptResult\`: ${JSON.stringify(result satisfies never)}`,
+      );
+  }
+}
+
+function isScriptResult(result: unknown): result is ScriptResult {
+  return (
+    result != null &&
+    typeof result === 'object' &&
+    'type' in result &&
+    typeof result.type === 'string' &&
+    ((result.type === 'success' && 'value' in result) ||
+      (result.type === 'error' &&
+        'error' in result &&
+        isDeconstructedError(result.error)))
+  );
+}
+
+/**
+ * A representation of an `Error` which can be transmitted within a
+ * `CustomEvent`.
+ */
+type DeconstructedError = {
+  name: string;
+  message: string;
+  stack?: string;
+};
+
+function deconstructError(error: Error): DeconstructedError {
+  const result: DeconstructedError = {
+    name: error.name,
+    message: error.message,
+  };
+
+  if ('stack' in error) result.stack = error.stack;
+
+  return result;
+}
+
+function reconstructError(deconstructedError: DeconstructedError): Error {
+  const error = new Error(deconstructedError.message);
+  error.name = deconstructedError.name;
+
+  if ('stack' in deconstructedError) {
+    error.stack = deconstructedError.stack;
+  } else {
+    delete error.stack;
+  }
+
+  return error;
+}
+
+function isDeconstructedError(value: unknown): value is DeconstructedError {
+  return (
+    value != null &&
+    typeof value === 'object' &&
+    'name' in value &&
+    value.name != null &&
+    typeof value.name === 'string' &&
+    'message' in value &&
+    value.message != null &&
+    typeof value.message === 'string' &&
+    (!('stack' in value) ||
+      (value.stack != null && typeof value.stack === 'string'))
+  );
+}

--- a/packages/wxt/src/virtual/unlisted-script-entrypoint.ts
+++ b/packages/wxt/src/virtual/unlisted-script-entrypoint.ts
@@ -1,42 +1,40 @@
 import definition from 'virtual:user-unlisted-script-entrypoint';
 import { logger } from '../utils/internal/logger';
+import {
+  dispatchScriptSuccessEvent,
+  dispatchScriptErrorEvent,
+} from '../utils/internal/script-result';
 import { initPlugins } from 'virtual:wxt-plugins';
 
-const result = (() => {
-  try {
-    initPlugins();
-  } catch (err) {
-    logger.error(
-      `Failed to initialize plugins for "${import.meta.env.ENTRYPOINT}"`,
-      err,
-    );
-    throw err;
-  }
-  let result;
-  try {
-    result = definition.main();
+// TODO: This only works with injectScript, not the scripting API.
 
-    if (result instanceof Promise) {
-      result = (result as Promise<any>).catch((err) => {
-        logger.error(
-          `The unlisted script "${import.meta.env.ENTRYPOINT}" crashed on startup!`,
-          err,
-        );
-        throw err;
-      });
+(async () => {
+  try {
+    const script = document.currentScript;
+    if (script === null) {
+      // This should never happen.
+      throw new Error(`\`document.currentScript\` is null!`);
     }
-  } catch (err) {
+
+    try {
+      initPlugins();
+      const result = await definition.main();
+      dispatchScriptSuccessEvent(script, result);
+    } catch (error) {
+      dispatchScriptErrorEvent(
+        script,
+        error instanceof Error ? error : new Error(`${error}`),
+      );
+    }
+  } catch (outerError) {
+    // This should never happen.
     logger.error(
       `The unlisted script "${import.meta.env.ENTRYPOINT}" crashed on startup!`,
-      err,
+      outerError,
     );
-    throw err;
+    throw outerError;
   }
-  return result;
 })();
 
-// Return the main function's result to the background when executed via the
-// scripting API. Default export causes the IIFE to return a value.
-// https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/scripting/executeScript#return_value
-// Tested on both Chrome and Firefox
-export default result;
+// TODO: Also support the scripting API.
+export default undefined;


### PR DESCRIPTION
### Overview

A sketch for having `injectScript` return the result value from the script. The code _works_, but it currently has changes to virtual/unlisted-script-entrypoint.ts that only work with `injectScript` while being broken with the `browser.scripting` API.

I would like to get feedback on how you would like that to be resolved. Some options I can think of:
- Have the entrypoint detect whether it is being run from `injectScript` or `executeScript`. I do not know how to achieve that reliably. `document.currentScript` can be overridden by the web page using `Object.defineProperty`, so its value might not be a reliable way to determine that.
- Build separate entrypoints depending on whether the script is injected using `injectScript` or `executeScript`.

### Manual Testing

Use `injectScript` on a script which either returns a value or throws an exception; see that `injectScript` returns the value or rethrows the exception.

### Related Issue

#1754 proposes having a way to pass an `UnlistedScriptDefinition` rather than the filename to `injectScript`. If something like that was implemented, the type of the return value of `injectScript` could be based on the type of `main` within the `UnlistedScriptDefinition`.