### PR TITLE
fix(injectScript): wait for the script to load

### DIFF
--- a/packages/wxt/src/utils/inject-script.ts
+++ b/packages/wxt/src/utils/inject-script.ts
@@ -32,11 +32,17 @@ export async function injectScript(
     script.src = url;
   }
 
-  if (!options?.keepInDom) {
-    script.onload = () => script.remove();
-  }
+  await new Promise<void>((resolve, reject) => {
+    script.onload = () => {
+      resolve();
+      if (!options?.keepInDom) {
+        script.remove();
+      }
+    };
+    script.onerror = () => reject();
 
-  (document.head ?? document.documentElement).append(script);
+    (document.head ?? document.documentElement).append(script);
+  });
 }
 
 export interface InjectScriptOptions {


### PR DESCRIPTION
### Case
```ts
// content.ts
export default defineContentScript({
  async main() {
    await injectScript('/injected.js')
    console.log('content script started')
  },
})
// injected.ts
export default defineUnlistedScript({
  main() {
    console.log('injected script started')
  },
})
```
### Result
#### Before change
```sh
content script started
injected script started
```
#### After change
```sh
injected script started
content script started
```
Ensure that the code runs in the expected order.

