### PR TITLE
test: storage.defineItem should initialize item version if value did not exist beforehand

### DIFF
--- a/packages/storage/src/__tests__/index.test.ts
+++ b/packages/storage/src/__tests__/index.test.ts
@@ -939,6 +939,30 @@ describe('Storage Utils', () => {
         await waitForMigrations();
         expect(consoleSpy).toHaveBeenCalledTimes(0);
       });
+
+      it('should initialize item version if value did not exist beforehand', async () => {
+        const migrateToV2 = vi.fn((oldValue: string) => {
+          JSON.parse(oldValue);
+        });
+
+        const getItemDefinition = () =>
+          storage.defineItem<{
+            value: string;
+          }>('local:data', {
+            version: 2,
+            migrations: {
+              2: migrateToV2,
+            },
+          });
+        let item = getItemDefinition();
+        await item.setValue({ value: 'test' });
+        const actualMeta = await item.getMeta();
+        expect.soft(actualMeta).toBe({ v: 2 });
+
+        item = getItemDefinition();
+        await item.getValue();
+        expect(migrateToV2).toBeCalledTimes(0);
+      });
     });
 
     describe('getValue', () => {


### PR DESCRIPTION
### Overview

Failing test case for an issue

### Related Issue

https://github.com/wxt-dev/wxt/issues/1775
