### PR TITLE
feat: basic support for firefox android dev mode

### DIFF
--- a/packages/wxt/src/core/runners/web-ext.ts
+++ b/packages/wxt/src/core/runners/web-ext.ts
@@ -46,32 +46,41 @@ export function createWebExtRunner(): ExtensionRunner {
               prefs: wxtUserConfig?.firefoxPrefs,
               args: wxtUserConfig?.firefoxArgs,
             }
-          : {
-              chromiumBinary: wxtUserConfig?.binaries?.[wxt.config.browser],
-              chromiumProfile: wxtUserConfig?.chromiumProfile,
-              chromiumPref: defu(
-                wxtUserConfig?.chromiumPref,
-                DEFAULT_CHROMIUM_PREFS,
-              ),
-              args: [
-                '--unsafely-disable-devtools-self-xss-warnings',
-                '--disable-features=DisableLoadExtensionCommandLineSwitch',
-                ...(wxtUserConfig?.chromiumArgs ?? []),
-              ],
-            }),
+          : wxt.config.browser === 'firefox-android'
+            ? {
+                firefoxApk: wxtUserConfig?.firefoxAndroidApk,
+                adbDevice: wxtUserConfig?.firefoxAndroidDevice,
+              }
+            : {
+                chromiumBinary: wxtUserConfig?.binaries?.[wxt.config.browser],
+                chromiumProfile: wxtUserConfig?.chromiumProfile,
+                chromiumPref: defu(
+                  wxtUserConfig?.chromiumPref,
+                  DEFAULT_CHROMIUM_PREFS,
+                ),
+                args: [
+                  '--unsafely-disable-devtools-self-xss-warnings',
+                  '--disable-features=DisableLoadExtensionCommandLineSwitch',
+                  ...(wxtUserConfig?.chromiumArgs ?? []),
+                ],
+              }),
       };
 
       const finalConfig = {
         ...userConfig,
         target:
-          wxt.config.browser === 'firefox' ? 'firefox-desktop' : 'chromium',
+          wxt.config.browser === 'firefox'
+            ? 'firefox-desktop'
+            : wxt.config.browser === 'firefox-android'
+              ? 'firefox-android'
+              : 'chromium',
         sourceDir: wxt.config.outDir,
         // Don't add a "Reload Manager" extension alongside dev extension, WXT
-        // already handles reloads intenrally.
-        noReloadManagerExtension: true,
+        // already handles reloads internally (except firefox-android).
+        noReloadManagerExtension: wxt.config.browser !== 'firefox-android',
         // WXT handles reloads, so disable auto-reload behaviors in web-ext
-        noReload: true,
-        noInput: true,
+        noReload: wxt.config.browser !== 'firefox-android',
+        noInput: wxt.config.browser !== 'firefox-android',
       };
       const options = {
         // Don't call `process.exit(0)` after starting web-ext

--- a/packages/wxt/src/types.ts
+++ b/packages/wxt/src/types.ts
@@ -1015,6 +1015,14 @@ export interface WebExtConfig {
    * @see https://extensionworkshop.com/documentation/develop/web-ext-command-reference/#keep-profile-changes
    */
   keepProfileChanges?: boolean;
+  /**
+   * @see https://extensionworkshop.com/documentation/develop/web-ext-command-reference/#adb-device
+   */
+  firefoxAndroidDevice?: string;
+  /**
+   * @see https://extensionworkshop.com/documentation/develop/web-ext-command-reference/#firefox-apk
+   */
+  firefoxAndroidApk?: string;
 }
 
 export interface WxtBuilder {

--- a/packages/wxt/src/virtual/background-entrypoint.ts
+++ b/packages/wxt/src/virtual/background-entrypoint.ts
@@ -6,7 +6,10 @@ import { browser } from 'wxt/browser';
 import { keepServiceWorkerAlive } from './utils/keep-service-worker-alive';
 import { reloadContentScript } from './utils/reload-content-scripts';
 
-if (import.meta.env.COMMAND === 'serve') {
+if (
+  import.meta.env.COMMAND === 'serve' &&
+  import.meta.env.BROWSER !== 'firefox-android'
+) {
   try {
     const ws = getDevServerWebSocket();
     ws.addWxtEventListener('wxt:reload-extension', () => {


### PR DESCRIPTION
### Overview

Add additional configuration options for web-ext config and disable dev server connection in background script, delegating reload process to web-ext

### Manual Testing

Follow https://extensionworkshop.com/documentation/develop/developing-extensions-for-firefox-for-android/ to setup android device or emulator

### Related Issue

https://github.com/wxt-dev/wxt/issues/631

This PR closes #631
