### PR TITLE
docs: add "PIPX" to the home page

### DIFF
--- a/docs/.vitepress/components/UsingWxtSection.vue
+++ b/docs/.vitepress/components/UsingWxtSection.vue
@@ -7,6 +7,7 @@ import useListExtensionDetails, {
 // Add extension IDs here. Order doesn't matter, will be sorted by a combination of weekly active users and rating.
 // Change the commit message or PR title to: "docs: Added "[extension name]" to the homepage"
 const chromeExtensionIds = [
+  'nkbikckldmljjiiajklecmgmajgapbfl', // PIPX - Take Control of Picture-in-Picture, Automatically
   'ocfdgncpifmegplaglcnglhioflaimkd', // GitHub: Better Line Counts
   'mgmdkjcljneegjfajchedjpdhbadklcf', // Anime Skip Player
   'bfbnagnphiehemkdgmmficmjfddgfhpl', // UltraWideo


### PR DESCRIPTION
Request to add "PIPX - Take Control of Picture-in-Picture, Automatically" extension to the "Who's Using WXT?" section in the homepage.
