### PR TITLE
docs: add "Add QR Code Generator Icon Back To Address Bar" to the home page

### DIFF
--- a/docs/.vitepress/components/UsingWxtSection.vue
+++ b/docs/.vitepress/components/UsingWxtSection.vue
@@ -89,6 +89,7 @@ const chromeExtensionIds = [
   'nhmbcmalgpkjbomhlhgdicanmkkaajmg', // Chatslator: Livestream Chat Translator
   'mbamjfdjbcdgpopfnkkmlohadbbnplhm', // 公众号阅读增强器 - https://wxreader.honwhy.wang
   'hannhecbnjnnbbafffmogdlnajpcomek', // 토탐정
+  'kacblhilkacgfnkjfodalohcnllcgmjd', // Add QR Code Generator Icon Back To Address Bar
 ];
 
 const { data, err, isLoading } = useListExtensionDetails(chromeExtensionIds);


### PR DESCRIPTION
Request to add "Add QR Code Generator Icon Back To Address Bar" extension to the "Who's Using WXT?" section in the homepage.