### PR TITLE
Keep `content_script` `matches` unsorted in manifest

### DIFF
--- a/packages/wxt/src/core/utils/content-scripts.ts
+++ b/packages/wxt/src/core/utils/content-scripts.ts
@@ -39,7 +39,8 @@ export function hashContentScriptOptions(
     Object.entries(withDefaults)
       // Sort any arrays so their values are consistent
       .map<[string, unknown]>(([key, value]) => {
-        if (Array.isArray(value)) return [key, value.sort()];
+      // Keeping matches unsorted gives developers more control on what users see in extension stores
+      if (Array.isArray(value) && key !== "matches") return [key, value.sort()];
         else return [key, value];
       })
       // Sort all the fields alphabetically


### PR DESCRIPTION
### Overview

I’ve noticed that host names in `matches` end up being sorted. This affects what extension users see in the store, so sorting may be therefore undesired. For example, if we have

```
www.example.com
m.example.com
another-less-important-example.com
```

, users will end up being presented with

```
another-less-important-example.com
m.example.com
www.example.com
```

That's somewhat less logical than the original sequence.

<!-- Describe your changes and why you made them -->

### Manual Testing

I tested the changes locally via `pnpm patch`.
<!-- Describe how to test your changes to make sure the PR works as intended -->

### Related Issue

I haven’t found or created one. The change is quite small so felt worth a PR right away. If you disagree with the idea, feel free to ignore this change. `pnpm patch` gives a good enough workaround, so host sorting is not blocking.