### PR TITLE
feat(config): add browser path for Zen via Homebrew

### DIFF
--- a/packages/runner/src/browser-paths.ts
+++ b/packages/runner/src/browser-paths.ts
@@ -96,7 +96,12 @@ export const KNOWN_BROWSER_PATHS: Record<
     windows: [],
   },
   zen: {
-    mac: ['/Applications/Zen Browser.app/Contents/MacOS/zen'],
+    mac: [
+      '/Applications/Zen Browser.app/Contents/MacOS/zen',
+      // Homebrew Cask
+      // https://github.com/Homebrew/homebrew-cask/blob/main/Casks/z/zen.rb#L23C13-L23C19
+      '/Applications/Zen.app/Contents/MacOS/zen'
+    ],
     linux: [],
     windows: [],
   },

--- a/packages/runner/src/browser-paths.ts
+++ b/packages/runner/src/browser-paths.ts
@@ -100,7 +100,7 @@ export const KNOWN_BROWSER_PATHS: Record<
       '/Applications/Zen Browser.app/Contents/MacOS/zen',
       // Homebrew Cask
       // https://github.com/Homebrew/homebrew-cask/blob/main/Casks/z/zen.rb#L23C13-L23C19
-      '/Applications/Zen.app/Contents/MacOS/zen'
+      '/Applications/Zen.app/Contents/MacOS/zen',
     ],
     linux: [],
     windows: [],


### PR DESCRIPTION
### Overview

Added alternative path for Zen Browser that Homebrew uses
https://github.com/Homebrew/homebrew-cask/blob/main/Casks/z/zen.rb#L23C13-L23C19

### Manual Testing

Uninstall Zen and install via homebrew
```sh
brew install zen --cask
wxt -b zen
```


### Related Issue
None that I know of

This PR closes nothing
