### PR TITLE
fix(paths): add browser paths for Arc & Dia on macos

### DIFF
--- a/packages/runner/src/browser-paths.ts
+++ b/packages/runner/src/browser-paths.ts
@@ -1,11 +1,13 @@
 export type BrowserPlatform = 'windows' | 'mac' | 'linux';
 
 export type KnownTarget =
+  | 'arc'
   | 'chromium'
   | 'chrome'
   | 'chrome-beta'
   | 'chrome-dev'
   | 'chrome-canary'
+  | 'dia'
   | 'edge'
   | 'edge-beta'
   | 'edge-dev'
@@ -21,6 +23,11 @@ export const KNOWN_BROWSER_PATHS: Record<
 > = {
   // Chromium based targets
 
+  arc: {
+    mac: ['/Applications/Arc.app/Contents/MacOS/Arc'],
+    linux: [],
+    windows: [],
+  }, 
   chromium: {
     mac: [],
     linux: [
@@ -48,6 +55,11 @@ export const KNOWN_BROWSER_PATHS: Record<
   },
   'chrome-dev': {
     mac: [],
+    linux: [],
+    windows: [],
+  },
+  dia: {
+    mac: ['/Applications/Dia.app/Contents/MacOS/Dia'],
     linux: [],
     windows: [],
   },
@@ -107,10 +119,12 @@ export const KNOWN_BROWSER_PATHS: Record<
  */
 export const FALLBACK_TARGETS: Partial<Record<KnownTarget, KnownTarget[]>> = {
   chrome: [
+    'arc',
     'chromium',
     'chrome-canary',
     'chrome-beta',
     'chrome-dev',
+    'dia',
     'edge',
     'edge-canary',
     'edge-beta',

--- a/packages/runner/src/browser-paths.ts
+++ b/packages/runner/src/browser-paths.ts
@@ -27,7 +27,7 @@ export const KNOWN_BROWSER_PATHS: Record<
     mac: ['/Applications/Arc.app/Contents/MacOS/Arc'],
     linux: [],
     windows: [],
-  }, 
+  },
   chromium: {
     mac: [],
     linux: [


### PR DESCRIPTION
### Overview

Added browser paths for both Arc & Dia chromium browsers by the Browser Company

### Manual Testing
Install Arc & Dia browsers

```sh
wxt -b dia
wxt -b arc
```

### Related Issue
I couldn't find one

This PR closes nothing
