### PR TITLE
fix: adding missing chromiumPort parameter in web-ext.ts to enable fixed port debugging

### DIFF
--- a/packages/wxt/src/core/runners/web-ext.ts
+++ b/packages/wxt/src/core/runners/web-ext.ts
@@ -39,6 +39,7 @@ export function createWebExtRunner(): ExtensionRunner {
         devtools: wxtUserConfig?.openDevtools,
         startUrl: wxtUserConfig?.startUrls,
         keepProfileChanges: wxtUserConfig?.keepProfileChanges,
+        chromiumPort: wxtUserConfig?.chromiumPort,
         ...(wxt.config.browser === 'firefox'
           ? {
               firefox: wxtUserConfig?.binaries?.firefox,


### PR DESCRIPTION
This fix enable to setup a fixed port to enable easy debugging with VSCode or other IDEs

### Overview

Everything was already there, I've just added the line to pass the parameters sets in wxtUserConfig to the web-ext runner.

### Manual Testing

* Set `chromiumPort` in wxt.config.ts.
* Launch `npm run dev`
* Browse to chrome://version
* Check that `remote-debugging-port` is the same as set in config file

You can also setup a fully working environment with this repo https://github.com/sylvaneau/wxt-react-vscode-template and try to debug your project with VSCode.

### Related Issue

<!-- If this PR is related to an issue, please link it here -->

This PR closes #52 
