### PR TITLE
fix: improve Chrome path search

### DIFF
--- a/packages/runner/src/browser-paths.ts
+++ b/packages/runner/src/browser-paths.ts
@@ -30,7 +30,10 @@ export const KNOWN_BROWSER_PATHS: Record<
     windows: [],
   },
   chrome: {
-    mac: ['/Applications/Chrome.app/Contents/MacOS/Google Chrome'],
+    mac: [
+      '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome',
+      '/Applications/Chrome.app/Contents/MacOS/Google Chrome',
+    ],
     linux: [],
     windows: ['C:\\Program Files\\Google\\Chrome\\Application\\chrome.exe'],
   },
@@ -42,6 +45,7 @@ export const KNOWN_BROWSER_PATHS: Record<
   'chrome-canary': {
     mac: [
       '/Applications/Google Chrome Canary.app/Contents/MacOS/Google Chrome Canary',
+      '/Applications/Chrome Canary.app/Contents/MacOS/Google Chrome Canary',
     ],
     linux: [],
     windows: [],


### PR DESCRIPTION
### Overview

When I tried `pnpm test` locally for #1806, I saw this error:

```
FAIL  src/__tests__/options.test.ts > Options > firefoxArgs > should log a warning when --remote-debugging-port is passed in
Error: Could not find "chrome" binary.

If it is installed in a custom location, you can specify the path with the browserPaths option.
 ❯ Module.resolveRunOptions src/options.ts:63:11
```

My `/Applications` folder contained `Google Chrome.app` instead of `Chrome.app` (it was installed via `homebrew` a while ago). Adding an alternative path to `KNOWN_BROWSER_PATHS` resolved the error. I also added the second path for Chrome Canary just in case.

### Manual Testing

`pnpm test` stopped showing the above error.

### Related Issue

NA