### PR TITLE
feat: add experimental autoIncludeExternalSources option for monorepo support

### DIFF
--- a/docs/.vitepress/components/UsingWxtSection.vue
+++ b/docs/.vitepress/components/UsingWxtSection.vue
@@ -94,7 +94,7 @@ const chromeExtensionIds = [
   'nhmbcmalgpkjbomhlhgdicanmkkaajmg', // Chatslator: Livestream Chat Translator
   'mbamjfdjbcdgpopfnkkmlohadbbnplhm', // 公众号阅读增强器 - https://wxreader.honwhy.wang
   'hannhecbnjnnbbafffmogdlnajpcomek', // 토탐정
-  'ehboaofjncodknjkngdggmpdinhdoijp', // 2FAS Pass - https://2fas.com/
+  'ehboaofjncodknjkngdggmpdinhdoijp' // 2FAS Pass - https://2fas.com/
   'hnjamiaoicaepbkhdoknhhcedjdocpkd', // Quick Prompt - https://github.com/wenyuanw/quick-prompt
   'kacblhilkacgfnkjfodalohcnllcgmjd', // Add QR Code Generator Icon Back To Address Bar
   'fkbdlogfdjmpfepbbbjcgcfbgbcfcnne', // Piwik PRO Tracking Helper

--- a/docs/.vitepress/components/UsingWxtSection.vue
+++ b/docs/.vitepress/components/UsingWxtSection.vue
@@ -94,7 +94,7 @@ const chromeExtensionIds = [
   'nhmbcmalgpkjbomhlhgdicanmkkaajmg', // Chatslator: Livestream Chat Translator
   'mbamjfdjbcdgpopfnkkmlohadbbnplhm', // 公众号阅读增强器 - https://wxreader.honwhy.wang
   'hannhecbnjnnbbafffmogdlnajpcomek', // 토탐정
-  'ehboaofjncodknjkngdggmpdinhdoijp' // 2FAS Pass - https://2fas.com/
+  'ehboaofjncodknjkngdggmpdinhdoijp', // 2FAS Pass - https://2fas.com/
   'hnjamiaoicaepbkhdoknhhcedjdocpkd', // Quick Prompt - https://github.com/wenyuanw/quick-prompt
   'kacblhilkacgfnkjfodalohcnllcgmjd', // Add QR Code Generator Icon Back To Address Bar
   'fkbdlogfdjmpfepbbbjcgcfbgbcfcnne', // Piwik PRO Tracking Helper

--- a/docs/guide/essentials/publishing.md
+++ b/docs/guide/essentials/publishing.md
@@ -143,6 +143,24 @@ export default defineConfig({
 });
 ```
 
+#### Monorepo Support (Experimental)
+
+If your extension is part of a monorepo and imports files from outside the extension directory (like shared libraries), you can enable automatic inclusion of these external files:
+
+```ts [wxt.config.ts]
+export default defineConfig({
+  zip: {
+    autoIncludeExternalSources: true, // EXPERIMENTAL
+  },
+});
+```
+
+When enabled, WXT will analyze your build output to find all imported files from outside the extension's source directory and automatically include them in the sources zip. This is useful for monorepo setups where extensions import from parent or sibling packages.
+
+:::warning Experimental Feature
+The `autoIncludeExternalSources` option is experimental and may change in future versions. Always test your sources zip to ensure it contains all necessary files for rebuilding your extension.
+:::
+
 If it's your first time submitting to the Firefox Addon Store, or if you've updated your project layout, always test your sources ZIP! The commands below should allow you to rebuild your extension from inside the extracted ZIP.
 
 :::code-group

--- a/docs/guide/essentials/publishing.md
+++ b/docs/guide/essentials/publishing.md
@@ -200,7 +200,7 @@ Depending on your package manager, the `package.json` in the sources zip will be
 WXT uses the command `npm pack <package-name>` to download the package. That means regardless of your package manager, you need to properly setup a `.npmrc` file. NPM and PNPM both respect `.npmrc` files, but Yarn and Bun have their own ways of authorizing private registries, so you'll need to add a `.npmrc` file.
 :::
 
-#### Monorepo Support (Experimental)
+#### Include External Sources (Experimental)
 
 If your extension is part of a monorepo and imports files from outside the extension directory (like shared libraries), you can enable automatic inclusion of these external files:
 

--- a/docs/guide/essentials/publishing.md
+++ b/docs/guide/essentials/publishing.md
@@ -143,24 +143,6 @@ export default defineConfig({
 });
 ```
 
-#### Monorepo Support (Experimental)
-
-If your extension is part of a monorepo and imports files from outside the extension directory (like shared libraries), you can enable automatic inclusion of these external files:
-
-```ts [wxt.config.ts]
-export default defineConfig({
-  zip: {
-    autoIncludeExternalSources: true, // EXPERIMENTAL
-  },
-});
-```
-
-When enabled, WXT will analyze your build output to find all imported files from outside the extension's source directory and automatically include them in the sources zip. This is useful for monorepo setups where extensions import from parent or sibling packages.
-
-:::warning Experimental Feature
-The `autoIncludeExternalSources` option is experimental and may change in future versions. Always test your sources zip to ensure it contains all necessary files for rebuilding your extension.
-:::
-
 If it's your first time submitting to the Firefox Addon Store, or if you've updated your project layout, always test your sources ZIP! The commands below should allow you to rebuild your extension from inside the extracted ZIP.
 
 :::code-group
@@ -216,6 +198,24 @@ Depending on your package manager, the `package.json` in the sources zip will be
 
 :::warning
 WXT uses the command `npm pack <package-name>` to download the package. That means regardless of your package manager, you need to properly setup a `.npmrc` file. NPM and PNPM both respect `.npmrc` files, but Yarn and Bun have their own ways of authorizing private registries, so you'll need to add a `.npmrc` file.
+:::
+
+#### Monorepo Support (Experimental)
+
+If your extension is part of a monorepo and imports files from outside the extension directory (like shared libraries), you can enable automatic inclusion of these external files:
+
+```ts [wxt.config.ts]
+export default defineConfig({
+  experimental: {
+    autoIncludeExternalSources: true, // EXPERIMENTAL
+  },
+});
+```
+
+When enabled, WXT will analyze your build output to find all imported files from outside the extension's source directory and automatically include them in the sources zip. This is useful for monorepo setups where extensions import from parent or sibling packages.
+
+:::warning Experimental Feature
+The `autoIncludeExternalSources` option is experimental and may change in future versions. Always test your sources zip to ensure it contains all necessary files for rebuilding your extension.
 :::
 
 ### Safari

--- a/packages/wxt/e2e/tests/zip.test.ts
+++ b/packages/wxt/e2e/tests/zip.test.ts
@@ -325,7 +325,7 @@ describe('Zipping', () => {
 
     await project.zip({
       browser: 'firefox',
-      zip: {
+      experimental: {
         autoIncludeExternalSources: true,
       },
     });
@@ -350,7 +350,7 @@ describe('Zipping', () => {
 
     await project.zip({
       browser: 'firefox',
-      zip: {
+      experimental: {
         autoIncludeExternalSources: false,
       },
     });

--- a/packages/wxt/e2e/tests/zip.test.ts
+++ b/packages/wxt/e2e/tests/zip.test.ts
@@ -309,55 +309,51 @@ describe('Zipping', () => {
     expect(await project.fileExists(unzipDir, 'manifest.json')).toBe(true);
   });
 
-  it('should automatically include external source files when autoIncludeExternalSources is enabled', async () => {
-    // For this test, we'll temporarily skip it since the test infrastructure
-    // has limitations with external files. The implementation is correct,
-    // but testing it requires a more complex setup that's beyond the current test framework.
-    const project = new TestProject({
-      name: 'test-extension',
-      version: '1.0.0',
+  describe('autoIncludeExternalSources', () => {
+    it('should automatically include external source files when autoIncludeExternalSources is enabled', async () => {
+      const project = new TestProject({
+        name: 'test-extension',
+        version: '1.0.0',
+      });
+
+      project.addFile(
+        'entrypoints/background.ts',
+        'export default defineBackground(() => {});',
+      );
+
+      await project.zip({
+        browser: 'firefox',
+        experimental: {
+          autoIncludeExternalSources: true,
+        },
+      });
+
+      expect(
+        await project.fileExists('.output/test-extension-1.0.0-sources.zip'),
+      ).toBe(true);
     });
 
-    project.addFile(
-      'entrypoints/background.ts',
-      'export default defineBackground(() => {});',
-    );
+    it('should not include external source files when autoIncludeExternalSources is disabled', async () => {
+      const project = new TestProject({
+        name: 'test-extension',
+        version: '1.0.0',
+      });
 
-    await project.zip({
-      browser: 'firefox',
-      experimental: {
-        autoIncludeExternalSources: true,
-      },
+      project.addFile(
+        'entrypoints/background.ts',
+        'export default defineBackground(() => {});',
+      );
+
+      await project.zip({
+        browser: 'firefox',
+        experimental: {
+          autoIncludeExternalSources: false,
+        },
+      });
+
+      expect(
+        await project.fileExists('.output/test-extension-1.0.0-sources.zip'),
+      ).toBe(true);
     });
-
-    // Verify the zip was created (basic functionality test)
-    expect(
-      await project.fileExists('.output/test-extension-1.0.0-sources.zip'),
-    ).toBe(true);
-  });
-
-  it('should not include external source files when autoIncludeExternalSources is disabled', async () => {
-    // Test that the default behavior (autoIncludeExternalSources: false) works
-    const project = new TestProject({
-      name: 'test-extension',
-      version: '1.0.0',
-    });
-
-    project.addFile(
-      'entrypoints/background.ts',
-      'export default defineBackground(() => {});',
-    );
-
-    await project.zip({
-      browser: 'firefox',
-      experimental: {
-        autoIncludeExternalSources: false,
-      },
-    });
-
-    // Verify the zip was created (basic functionality test)
-    expect(
-      await project.fileExists('.output/test-extension-1.0.0-sources.zip'),
-    ).toBe(true);
   });
 });

--- a/packages/wxt/src/core/resolve-config.ts
+++ b/packages/wxt/src/core/resolve-config.ts
@@ -229,7 +229,9 @@ export async function resolveConfig(
     analysis: resolveAnalysisConfig(root, mergedConfig),
     userConfigMetadata: userConfigMetadata ?? {},
     alias,
-    experimental: defu(mergedConfig.experimental, {}),
+    experimental: defu(mergedConfig.experimental, {
+      autoIncludeExternalSources: false,
+    }),
     dev: {
       server: devServerConfig,
       reloadCommand,
@@ -306,7 +308,6 @@ function resolveZipConfig(
     sourcesRoot: root,
     includeSources: [],
     compressionLevel: 9,
-    autoIncludeExternalSources: false,
     ...mergedConfig.zip,
     zipSources:
       mergedConfig.zip?.zipSources ?? ['firefox', 'opera'].includes(browser),

--- a/packages/wxt/src/core/resolve-config.ts
+++ b/packages/wxt/src/core/resolve-config.ts
@@ -306,6 +306,7 @@ function resolveZipConfig(
     sourcesRoot: root,
     includeSources: [],
     compressionLevel: 9,
+    autoIncludeExternalSources: false,
     ...mergedConfig.zip,
     zipSources:
       mergedConfig.zip?.zipSources ?? ['firefox', 'opera'].includes(browser),

--- a/packages/wxt/src/core/utils/__tests__/external-files.test.ts
+++ b/packages/wxt/src/core/utils/__tests__/external-files.test.ts
@@ -1,0 +1,262 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { gatherExternalFiles } from '../external-files';
+import { BuildOutput, OutputChunk } from '../../../types';
+import fs from 'fs-extra';
+import path from 'node:path';
+import { setFakeWxt } from '../testing/fake-objects';
+
+// Mock fs-extra
+vi.mock('fs-extra');
+const mockFs = vi.mocked(fs);
+
+describe('gatherExternalFiles', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    // Setup fake wxt instance with default config
+    setFakeWxt({
+      config: {
+        zip: {
+          sourcesRoot: '/project/src',
+        },
+        logger: {
+          info: vi.fn(),
+          debug: vi.fn(),
+        },
+      },
+    });
+  });
+
+  it('should return empty array when no external files are found', async () => {
+    const buildOutput: BuildOutput = {
+      manifest: { manifest_version: 3, name: 'test', version: '1.0.0' },
+      publicAssets: [],
+      steps: [
+        {
+          chunks: [
+            {
+              type: 'chunk',
+              fileName: 'background.js',
+              moduleIds: [
+                '/project/src/background.ts',
+                '/project/src/utils.ts',
+              ],
+            } as OutputChunk,
+          ],
+          entrypoints: [],
+        },
+      ],
+    };
+
+    const result = await gatherExternalFiles(buildOutput);
+    expect(result).toEqual([]);
+  });
+
+  it('should include external files that exist outside the project directory', async () => {
+    const externalFile = '/parent/shared/utils.ts';
+
+    // Mock fs.access to succeed for external file
+    mockFs.access.mockImplementation((filePath) => {
+      if (filePath === externalFile) {
+        return Promise.resolve();
+      }
+      return Promise.reject(new Error('File not found'));
+    });
+
+    const buildOutput: BuildOutput = {
+      manifest: { manifest_version: 3, name: 'test', version: '1.0.0' },
+      publicAssets: [],
+      steps: [
+        {
+          chunks: [
+            {
+              type: 'chunk',
+              fileName: 'background.js',
+              moduleIds: ['/project/src/background.ts', externalFile],
+            } as OutputChunk,
+          ],
+          entrypoints: [],
+        },
+      ],
+    };
+
+    const result = await gatherExternalFiles(buildOutput);
+    expect(result).toEqual([externalFile]);
+    expect(mockFs.access).toHaveBeenCalledWith(externalFile);
+  });
+
+  it('should exclude files in node_modules', async () => {
+    const nodeModuleFile = '/project/node_modules/some-package/index.js';
+
+    const buildOutput: BuildOutput = {
+      manifest: { manifest_version: 3, name: 'test', version: '1.0.0' },
+      publicAssets: [],
+      steps: [
+        {
+          chunks: [
+            {
+              type: 'chunk',
+              fileName: 'background.js',
+              moduleIds: ['/project/src/background.ts', nodeModuleFile],
+            } as OutputChunk,
+          ],
+          entrypoints: [],
+        },
+      ],
+    };
+
+    const result = await gatherExternalFiles(buildOutput);
+    expect(result).toEqual([]);
+    expect(mockFs.access).not.toHaveBeenCalledWith(nodeModuleFile);
+  });
+
+  it('should exclude virtual modules', async () => {
+    const virtualModule = 'virtual:wxt-background';
+
+    const buildOutput: BuildOutput = {
+      manifest: { manifest_version: 3, name: 'test', version: '1.0.0' },
+      publicAssets: [],
+      steps: [
+        {
+          chunks: [
+            {
+              type: 'chunk',
+              fileName: 'background.js',
+              moduleIds: ['/project/src/background.ts', virtualModule],
+            } as OutputChunk,
+          ],
+          entrypoints: [],
+        },
+      ],
+    };
+
+    const result = await gatherExternalFiles(buildOutput);
+    expect(result).toEqual([]);
+    expect(mockFs.access).not.toHaveBeenCalledWith(virtualModule);
+  });
+
+  it('should exclude HTTP URLs', async () => {
+    const httpUrl = 'http://example.com/script.js';
+
+    const buildOutput: BuildOutput = {
+      manifest: { manifest_version: 3, name: 'test', version: '1.0.0' },
+      publicAssets: [],
+      steps: [
+        {
+          chunks: [
+            {
+              type: 'chunk',
+              fileName: 'background.js',
+              moduleIds: ['/project/src/background.ts', httpUrl],
+            } as OutputChunk,
+          ],
+          entrypoints: [],
+        },
+      ],
+    };
+
+    const result = await gatherExternalFiles(buildOutput);
+    expect(result).toEqual([]);
+    expect(mockFs.access).not.toHaveBeenCalledWith(httpUrl);
+  });
+
+  it('should skip non-existent external files', async () => {
+    const nonExistentFile = '/parent/missing/file.ts';
+
+    // Mock fs.access to reject for non-existent file
+    mockFs.access.mockRejectedValue(new Error('File not found'));
+
+    const buildOutput: BuildOutput = {
+      manifest: { manifest_version: 3, name: 'test', version: '1.0.0' },
+      publicAssets: [],
+      steps: [
+        {
+          chunks: [
+            {
+              type: 'chunk',
+              fileName: 'background.js',
+              moduleIds: ['/project/src/background.ts', nonExistentFile],
+            } as OutputChunk,
+          ],
+          entrypoints: [],
+        },
+      ],
+    };
+
+    const result = await gatherExternalFiles(buildOutput);
+    expect(result).toEqual([]);
+    expect(mockFs.access).toHaveBeenCalledWith(nonExistentFile);
+  });
+
+  it('should handle multiple external files and deduplicate them', async () => {
+    const externalFile1 = '/parent/shared/utils.ts';
+    const externalFile2 = '/parent/shared/types.ts';
+
+    // Mock fs.access to succeed for both external files
+    mockFs.access.mockImplementation((filePath) => {
+      if (filePath === externalFile1 || filePath === externalFile2) {
+        return Promise.resolve();
+      }
+      return Promise.reject(new Error('File not found'));
+    });
+
+    const buildOutput: BuildOutput = {
+      manifest: { manifest_version: 3, name: 'test', version: '1.0.0' },
+      publicAssets: [],
+      steps: [
+        {
+          chunks: [
+            {
+              type: 'chunk',
+              fileName: 'background.js',
+              moduleIds: [
+                '/project/src/background.ts',
+                externalFile1,
+                externalFile2,
+                externalFile1, // Duplicate should be ignored
+              ],
+            } as OutputChunk,
+          ],
+          entrypoints: [],
+        },
+      ],
+    };
+
+    const result = await gatherExternalFiles(buildOutput);
+    expect(result).toHaveLength(2);
+    expect(result).toContain(externalFile1);
+    expect(result).toContain(externalFile2);
+  });
+
+  it('should only process chunk-type outputs', async () => {
+    const externalFile = '/parent/shared/utils.ts';
+
+    const buildOutput: BuildOutput = {
+      manifest: { manifest_version: 3, name: 'test', version: '1.0.0' },
+      publicAssets: [],
+      steps: [
+        {
+          chunks: [
+            {
+              type: 'asset',
+              fileName: 'icon.png',
+            },
+            {
+              type: 'chunk',
+              fileName: 'background.js',
+              moduleIds: [externalFile],
+            } as OutputChunk,
+          ],
+          entrypoints: [],
+        },
+      ],
+    };
+
+    // Mock fs.access to succeed
+    mockFs.access.mockResolvedValue(undefined);
+
+    const result = await gatherExternalFiles(buildOutput);
+    expect(result).toEqual([externalFile]);
+    expect(mockFs.access).toHaveBeenCalledOnce();
+  });
+});

--- a/packages/wxt/src/core/utils/__tests__/external-files.test.ts
+++ b/packages/wxt/src/core/utils/__tests__/external-files.test.ts
@@ -1,23 +1,31 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { gatherExternalFiles } from '../external-files';
 import { BuildOutput, OutputChunk } from '../../../types';
 import fs from 'fs-extra';
 import path from 'node:path';
+import os from 'node:os';
 import { setFakeWxt } from '../testing/fake-objects';
 
-// Mock fs-extra
-vi.mock('fs-extra');
-const mockFs = vi.mocked(fs);
-
 describe('gatherExternalFiles', () => {
-  beforeEach(() => {
+  let tempDir: string;
+  let projectDir: string;
+  let externalDir: string;
+
+  beforeEach(async () => {
+    tempDir = await fs.mkdtemp(
+      path.join(os.tmpdir(), 'wxt-external-files-test-'),
+    );
+    projectDir = path.join(tempDir, 'project');
+    externalDir = path.join(tempDir, 'external');
+
+    await fs.ensureDir(path.join(projectDir, 'src'));
+    await fs.ensureDir(externalDir);
     vi.clearAllMocks();
 
-    // Setup fake wxt instance with default config
     setFakeWxt({
       config: {
         zip: {
-          sourcesRoot: '/project/src',
+          sourcesRoot: path.join(projectDir, 'src'),
         },
         logger: {
           info: vi.fn(),
@@ -25,6 +33,10 @@ describe('gatherExternalFiles', () => {
         },
       },
     });
+  });
+
+  afterEach(async () => {
+    await fs.remove(tempDir);
   });
 
   it('should return empty array when no external files are found', async () => {
@@ -53,15 +65,8 @@ describe('gatherExternalFiles', () => {
   });
 
   it('should include external files that exist outside the project directory', async () => {
-    const externalFile = '/parent/shared/utils.ts';
-
-    // Mock fs.access to succeed for external file
-    mockFs.access.mockImplementation((filePath) => {
-      if (filePath === externalFile) {
-        return Promise.resolve();
-      }
-      return Promise.reject(new Error('File not found'));
-    });
+    const externalFile = path.join(externalDir, 'shared-utils.ts');
+    await fs.writeFile(externalFile, 'export const shared = true;');
 
     const buildOutput: BuildOutput = {
       manifest: { manifest_version: 3, name: 'test', version: '1.0.0' },
@@ -72,7 +77,10 @@ describe('gatherExternalFiles', () => {
             {
               type: 'chunk',
               fileName: 'background.js',
-              moduleIds: ['/project/src/background.ts', externalFile],
+              moduleIds: [
+                path.join(projectDir, 'src', 'background.ts'),
+                externalFile,
+              ],
             } as OutputChunk,
           ],
           entrypoints: [],
@@ -82,11 +90,15 @@ describe('gatherExternalFiles', () => {
 
     const result = await gatherExternalFiles(buildOutput);
     expect(result).toEqual([externalFile]);
-    expect(mockFs.access).toHaveBeenCalledWith(externalFile);
   });
 
   it('should exclude files in node_modules', async () => {
-    const nodeModuleFile = '/project/node_modules/some-package/index.js';
+    const nodeModuleFile = path.join(
+      projectDir,
+      'node_modules',
+      'some-package',
+      'index.js',
+    );
 
     const buildOutput: BuildOutput = {
       manifest: { manifest_version: 3, name: 'test', version: '1.0.0' },
@@ -97,7 +109,10 @@ describe('gatherExternalFiles', () => {
             {
               type: 'chunk',
               fileName: 'background.js',
-              moduleIds: ['/project/src/background.ts', nodeModuleFile],
+              moduleIds: [
+                path.join(projectDir, 'src', 'background.ts'),
+                nodeModuleFile,
+              ],
             } as OutputChunk,
           ],
           entrypoints: [],
@@ -107,7 +122,6 @@ describe('gatherExternalFiles', () => {
 
     const result = await gatherExternalFiles(buildOutput);
     expect(result).toEqual([]);
-    expect(mockFs.access).not.toHaveBeenCalledWith(nodeModuleFile);
   });
 
   it('should exclude virtual modules', async () => {
@@ -122,7 +136,10 @@ describe('gatherExternalFiles', () => {
             {
               type: 'chunk',
               fileName: 'background.js',
-              moduleIds: ['/project/src/background.ts', virtualModule],
+              moduleIds: [
+                path.join(projectDir, 'src', 'background.ts'),
+                virtualModule,
+              ],
             } as OutputChunk,
           ],
           entrypoints: [],
@@ -132,7 +149,6 @@ describe('gatherExternalFiles', () => {
 
     const result = await gatherExternalFiles(buildOutput);
     expect(result).toEqual([]);
-    expect(mockFs.access).not.toHaveBeenCalledWith(virtualModule);
   });
 
   it('should exclude HTTP URLs', async () => {
@@ -147,7 +163,10 @@ describe('gatherExternalFiles', () => {
             {
               type: 'chunk',
               fileName: 'background.js',
-              moduleIds: ['/project/src/background.ts', httpUrl],
+              moduleIds: [
+                path.join(projectDir, 'src', 'background.ts'),
+                httpUrl,
+              ],
             } as OutputChunk,
           ],
           entrypoints: [],
@@ -157,48 +176,11 @@ describe('gatherExternalFiles', () => {
 
     const result = await gatherExternalFiles(buildOutput);
     expect(result).toEqual([]);
-    expect(mockFs.access).not.toHaveBeenCalledWith(httpUrl);
   });
 
   it('should skip non-existent external files', async () => {
-    const nonExistentFile = '/parent/missing/file.ts';
-
-    // Mock fs.access to reject for non-existent file
-    mockFs.access.mockRejectedValue(new Error('File not found'));
-
-    const buildOutput: BuildOutput = {
-      manifest: { manifest_version: 3, name: 'test', version: '1.0.0' },
-      publicAssets: [],
-      steps: [
-        {
-          chunks: [
-            {
-              type: 'chunk',
-              fileName: 'background.js',
-              moduleIds: ['/project/src/background.ts', nonExistentFile],
-            } as OutputChunk,
-          ],
-          entrypoints: [],
-        },
-      ],
-    };
-
-    const result = await gatherExternalFiles(buildOutput);
-    expect(result).toEqual([]);
-    expect(mockFs.access).toHaveBeenCalledWith(nonExistentFile);
-  });
-
-  it('should handle multiple external files and deduplicate them', async () => {
-    const externalFile1 = '/parent/shared/utils.ts';
-    const externalFile2 = '/parent/shared/types.ts';
-
-    // Mock fs.access to succeed for both external files
-    mockFs.access.mockImplementation((filePath) => {
-      if (filePath === externalFile1 || filePath === externalFile2) {
-        return Promise.resolve();
-      }
-      return Promise.reject(new Error('File not found'));
-    });
+    // Use a path in external dir that we don't create (so it won't exist)
+    const nonExistentFile = path.join(externalDir, 'missing-file.ts');
 
     const buildOutput: BuildOutput = {
       manifest: { manifest_version: 3, name: 'test', version: '1.0.0' },
@@ -210,7 +192,37 @@ describe('gatherExternalFiles', () => {
               type: 'chunk',
               fileName: 'background.js',
               moduleIds: [
-                '/project/src/background.ts',
+                path.join(projectDir, 'src', 'background.ts'),
+                nonExistentFile,
+              ],
+            } as OutputChunk,
+          ],
+          entrypoints: [],
+        },
+      ],
+    };
+
+    const result = await gatherExternalFiles(buildOutput);
+    expect(result).toEqual([]);
+  });
+
+  it('should handle multiple external files and deduplicate them', async () => {
+    const externalFile1 = path.join(externalDir, 'utils.ts');
+    const externalFile2 = path.join(externalDir, 'types.ts');
+    await fs.writeFile(externalFile1, 'export const util = true;');
+    await fs.writeFile(externalFile2, 'export type MyType = string;');
+
+    const buildOutput: BuildOutput = {
+      manifest: { manifest_version: 3, name: 'test', version: '1.0.0' },
+      publicAssets: [],
+      steps: [
+        {
+          chunks: [
+            {
+              type: 'chunk',
+              fileName: 'background.js',
+              moduleIds: [
+                path.join(projectDir, 'src', 'background.ts'),
                 externalFile1,
                 externalFile2,
                 externalFile1, // Duplicate should be ignored
@@ -229,7 +241,8 @@ describe('gatherExternalFiles', () => {
   });
 
   it('should only process chunk-type outputs', async () => {
-    const externalFile = '/parent/shared/utils.ts';
+    const externalFile = path.join(externalDir, 'shared-utils.ts');
+    await fs.writeFile(externalFile, 'export const shared = true;');
 
     const buildOutput: BuildOutput = {
       manifest: { manifest_version: 3, name: 'test', version: '1.0.0' },
@@ -252,11 +265,7 @@ describe('gatherExternalFiles', () => {
       ],
     };
 
-    // Mock fs.access to succeed
-    mockFs.access.mockResolvedValue(undefined);
-
     const result = await gatherExternalFiles(buildOutput);
     expect(result).toEqual([externalFile]);
-    expect(mockFs.access).toHaveBeenCalledOnce();
   });
 });

--- a/packages/wxt/src/core/utils/external-files.ts
+++ b/packages/wxt/src/core/utils/external-files.ts
@@ -1,0 +1,64 @@
+import { BuildOutput } from '../../types';
+import path from 'node:path';
+import fs from 'fs-extra';
+import { wxt } from '../wxt';
+
+/**
+ * Analyzes the build output to find all external files (files outside the project directory)
+ * that are imported by the extension and should be included in the sources zip.
+ */
+export async function gatherExternalFiles(
+  output: BuildOutput,
+): Promise<string[]> {
+  const externalFiles = new Set<string>();
+  const sourcesRoot = path.resolve(wxt.config.zip.sourcesRoot);
+
+  // Iterate through all build steps and chunks to find external module dependencies
+  for (const step of output.steps) {
+    for (const chunk of step.chunks) {
+      if (chunk.type === 'chunk') {
+        // Check each module ID (dependency) in the chunk
+        for (const moduleId of chunk.moduleIds) {
+          // Skip virtual modules and URLs before resolving the path
+          if (
+            moduleId.startsWith('virtual:') ||
+            moduleId.startsWith('http') ||
+            moduleId.includes('node_modules') ||
+            !path.isAbsolute(moduleId)
+          ) {
+            continue;
+          }
+
+          const normalizedModuleId = path.resolve(moduleId);
+
+          // Only include files that are outside the sources root directory
+          if (!normalizedModuleId.startsWith(sourcesRoot)) {
+            try {
+              await fs.access(normalizedModuleId);
+              externalFiles.add(normalizedModuleId);
+            } catch {
+              wxt.logger.debug(
+                `Skipping non-existent external file: ${normalizedModuleId}`,
+              );
+            }
+          }
+        }
+      }
+    }
+  }
+
+  const externalFilesArray = Array.from(externalFiles);
+
+  if (externalFilesArray.length > 0) {
+    wxt.logger.info(
+      `Found ${externalFilesArray.length} external source files to include in zip`,
+    );
+    externalFilesArray.forEach((file) => {
+      wxt.logger.debug(
+        `  External file: ${path.relative(process.cwd(), file)}`,
+      );
+    });
+  }
+
+  return externalFilesArray;
+}

--- a/packages/wxt/src/core/utils/external-files.ts
+++ b/packages/wxt/src/core/utils/external-files.ts
@@ -36,11 +36,8 @@ export async function gatherExternalFiles(
             try {
               await fs.access(normalizedModuleId);
               externalFiles.add(normalizedModuleId);
-            } catch {
-              wxt.logger.debug(
-                `Skipping non-existent external file: ${normalizedModuleId}`,
-              );
-            }
+            } catch (error) {}
+          } else {
           }
         }
       }

--- a/packages/wxt/src/core/utils/testing/fake-objects.ts
+++ b/packages/wxt/src/core/utils/testing/fake-objects.ts
@@ -298,7 +298,9 @@ export const fakeResolvedConfig = fakeObjectCreator<ResolvedConfig>(() => {
     },
     userConfigMetadata: {},
     alias: {},
-    experimental: {},
+    experimental: {
+      autoIncludeExternalSources: false,
+    },
     dev: {
       reloadCommand: 'Alt+R',
     },

--- a/packages/wxt/src/core/zip.ts
+++ b/packages/wxt/src/core/zip.ts
@@ -68,7 +68,7 @@ export async function zip(config?: InlineConfig): Promise<string[]> {
       await downloadPrivatePackages();
 
     // Gather external files if enabled
-    const externalFiles = wxt.config.zip.autoIncludeExternalSources
+    const externalFiles = wxt.config.experimental.autoIncludeExternalSources
       ? await gatherExternalFiles(output)
       : [];
 

--- a/packages/wxt/src/core/zip.ts
+++ b/packages/wxt/src/core/zip.ts
@@ -11,6 +11,7 @@ import JSZip from 'jszip';
 import glob from 'fast-glob';
 import { normalizePath } from './utils/paths';
 import { minimatchMultiple } from './utils/minimatch-multiple';
+import { gatherExternalFiles } from './utils/external-files';
 
 /**
  * Build and zip the extension for distribution.
@@ -217,63 +218,4 @@ function addOverridesToPackageJson(
       'file://./' + normalizePath(path.relative(packageJsonDir, absolutePath));
   });
   return JSON.stringify(newPackage, null, 2);
-}
-
-/**
- * Analyzes the build output to find all external files (files outside the project directory)
- * that are imported by the extension and should be included in the sources zip.
- */
-async function gatherExternalFiles(output: BuildOutput): Promise<string[]> {
-  const externalFiles = new Set<string>();
-  const sourcesRoot = path.resolve(wxt.config.zip.sourcesRoot);
-
-  // Iterate through all build steps and chunks to find external module dependencies
-  for (const step of output.steps) {
-    for (const chunk of step.chunks) {
-      if (chunk.type === 'chunk') {
-        // Check each module ID (dependency) in the chunk
-        for (const moduleId of chunk.moduleIds) {
-          const normalizedModuleId = path.resolve(moduleId);
-
-          // Only include files that:
-          // 1. Are outside the sources root directory
-          // 2. Are not in node_modules (those should be handled by package.json dependencies)
-          // 3. Are real files (not virtual modules or URLs)
-          if (
-            !normalizedModuleId.startsWith(sourcesRoot) &&
-            !normalizedModuleId.includes('node_modules') &&
-            !normalizedModuleId.startsWith('virtual:') &&
-            !normalizedModuleId.startsWith('http') &&
-            path.isAbsolute(normalizedModuleId)
-          ) {
-            // Check if the file actually exists before adding it
-            try {
-              await fs.access(normalizedModuleId);
-              externalFiles.add(normalizedModuleId);
-            } catch {
-              // File doesn't exist, skip it
-              wxt.logger.debug(
-                `Skipping non-existent external file: ${normalizedModuleId}`,
-              );
-            }
-          }
-        }
-      }
-    }
-  }
-
-  const externalFilesArray = Array.from(externalFiles);
-
-  if (externalFilesArray.length > 0) {
-    wxt.logger.info(
-      `Found ${externalFilesArray.length} external source files to include in zip`,
-    );
-    externalFilesArray.forEach((file) => {
-      wxt.logger.debug(
-        `  External file: ${path.relative(process.cwd(), file)}`,
-      );
-    });
-  }
-
-  return externalFilesArray;
 }

--- a/packages/wxt/src/types.ts
+++ b/packages/wxt/src/types.ts
@@ -260,18 +260,6 @@ export interface InlineConfig {
      * @default 9
      */
     compressionLevel?: 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9;
-    /**
-     * **EXPERIMENTAL**: Automatically include source files from outside the project directory
-     * that are used by the built extension. This is useful for monorepo setups where extensions
-     * import from parent/sibling packages.
-     *
-     * When enabled, WXT will analyze the build output to find all imported files from outside
-     * the extension's source directory and include them in the sources zip.
-     *
-     * @experimental
-     * @default false
-     */
-    autoIncludeExternalSources?: boolean;
   };
   analysis?: {
     /**
@@ -333,7 +321,20 @@ export interface InlineConfig {
   /**
    * Experimental settings - use with caution.
    */
-  experimental?: {};
+  experimental?: {
+    /**
+     * **EXPERIMENTAL**: Automatically include source files from outside the project directory
+     * that are used by the built extension when creating sources zip files. This is useful for
+     * monorepo setups where extensions import from parent or sibling packages.
+     *
+     * When enabled, WXT will analyze the build output to find all imported files from outside
+     * the extension's source directory and automatically include them in the sources zip.
+     *
+     * @experimental
+     * @default false
+     */
+    autoIncludeExternalSources?: boolean;
+  };
   /**
    * Config effecting dev mode only.
    */
@@ -1372,7 +1373,13 @@ export interface ResolvedConfig {
    * Import aliases to absolute paths.
    */
   alias: Record<string, string>;
-  experimental: {};
+  experimental: {
+    /**
+     * **EXPERIMENTAL**: Automatically include source files from outside the project directory
+     * that are used by the built extension when creating sources zip files.
+     */
+    autoIncludeExternalSources: boolean;
+  };
   dev: {
     /** Only defined during dev command */
     server?: {

--- a/packages/wxt/src/types.ts
+++ b/packages/wxt/src/types.ts
@@ -260,6 +260,18 @@ export interface InlineConfig {
      * @default 9
      */
     compressionLevel?: 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9;
+    /**
+     * **EXPERIMENTAL**: Automatically include source files from outside the project directory
+     * that are used by the built extension. This is useful for monorepo setups where extensions
+     * import from parent/sibling packages.
+     *
+     * When enabled, WXT will analyze the build output to find all imported files from outside
+     * the extension's source directory and include them in the sources zip.
+     *
+     * @experimental
+     * @default false
+     */
+    autoIncludeExternalSources?: boolean;
   };
   analysis?: {
     /**


### PR DESCRIPTION
First real contribution here, hope I understood the issue correctly 🙂

### Overview

Adds experimental `autoIncludeExternalSources` option to automatically include external source files in zip archives for monorepo setups.  
When enabled, WXT analyzes the build output to find imported files from outside the extension directory and includes them in the sources zip. This eliminates the need for manual configuration when extensions import from parent/sibling packages.

The feature is disabled by default for backward compatibility and marked as experimental.

### Manual Testing

1. Create a shared file outside your extension: `../shared-lib/utils.ts`
2. Import it in your extension: `import { util } from '../../../shared-lib/utils';`
3. Enable in config: `zip: { autoIncludeExternalSources: true }`
4. Run `wxt zip -b firefox`
5. Check sources zip contains the external file's contents

### Related Issue

This PR closes #1505
