### PR TITLE
feat: allow setting `alias: false` to disable default aliases

### DIFF
--- a/packages/wxt/e2e/tests/typescript-project.test.ts
+++ b/packages/wxt/e2e/tests/typescript-project.test.ts
@@ -397,6 +397,44 @@ describe('TypeScript Project', () => {
     expect(output).toContain('./example.ts');
   });
 
+  it('should allow disabling the default aliases', async () => {
+    const project = new TestProject();
+    project.addFile('src/entrypoints/unlisted.html', '<html></html>');
+    project.setConfigFileConfig({
+      srcDir: 'src',
+      alias: false,
+    });
+
+    await project.prepare();
+
+    const output = await project.serializeFile('.wxt/tsconfig.json');
+    expect(output).toMatchInlineSnapshot(`
+      ".wxt/tsconfig.json
+      ----------------------------------------
+      {
+        "compilerOptions": {
+          "target": "ESNext",
+          "module": "ESNext",
+          "moduleResolution": "Bundler",
+          "noEmit": true,
+          "esModuleInterop": true,
+          "forceConsistentCasingInFileNames": true,
+          "resolveJsonModule": true,
+          "strict": true,
+          "skipLibCheck": true,
+          "paths": {
+
+          }
+        },
+        "include": [
+          "../**/*",
+          "./wxt.d.ts"
+        ],
+        "exclude": ["../.output"]
+      }"
+    `);
+  });
+
   it('should set correct import.meta.env.BROWSER type based on targetBrowsers', async () => {
     const project = new TestProject();
     project.addFile('entrypoints/unlisted.html', '<html></html>');

--- a/packages/wxt/src/core/resolve-config.ts
+++ b/packages/wxt/src/core/resolve-config.ts
@@ -133,15 +133,18 @@ export async function resolveConfig(
     defaults: userConfig.webExt ?? userConfig.runner,
   });
   // Make sure alias are absolute
-  const alias = Object.fromEntries(
-    Object.entries({
-      ...mergedConfig.alias,
-      '@': srcDir,
-      '~': srcDir,
-      '@@': root,
-      '~~': root,
-    }).map(([key, value]) => [key, path.resolve(root, value)]),
-  );
+  const alias =
+    mergedConfig.alias !== false
+      ? Object.fromEntries(
+          Object.entries({
+            ...mergedConfig.alias,
+            '@': srcDir,
+            '~': srcDir,
+            '@@': root,
+            '~~': root,
+          }).map(([key, value]) => [key, path.resolve(root, value)]),
+        )
+      : {};
 
   let devServerConfig: ResolvedConfig['dev']['server'];
   if (command === 'serve') {

--- a/packages/wxt/src/types.ts
+++ b/packages/wxt/src/types.ts
@@ -312,12 +312,14 @@ export interface InlineConfig {
    *
    * The key is the import alias and the value is either a relative path to the root directory or an absolute path.
    *
+   * Set to `false` to disable aliases, including the default ones. This is useful if you want to handle aliases in your own plugin. Note that WXT modules can still add aliases.
+   *
    * @example
    * {
    *   "testing": "src/utils/testing.ts"
    * }
    */
-  alias?: Record<string, string>;
+  alias?: Record<string, string> | false;
   /**
    * Experimental settings - use with caution.
    */


### PR DESCRIPTION
I want to use my own alias patterns without interference from wxt.
