### PR TITLE
ci: Use deploy key to bypass branch protection rules

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,7 +41,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          ssh-key: ${{ secrets.DEPLOY_KEY }}
+          ssh-key: ${{ secrets.DEPLOY_KEY }} # https://github.com/sbellone/release-workflow-example
 
       - name: Setup
         uses: ./.github/actions/setup

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,6 +41,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          ssh-key: ${{ secrets.DEPLOY_KEY }}
 
       - name: Setup
         uses: ./.github/actions/setup


### PR DESCRIPTION
### Overview

Branch protection rules have been disabled because our release action pushes to the `main` branch. This PR adds a deploy key to the publish workflow to allow CI to bypass the rules and push the version/changelog to `main`.

https://github.com/sbellone/release-workflow-example

### Todo

- [x] Re-enable branch protection rules