### PR TITLE
fix(types): use TType for DocumentEventMap key in ctx.addEventListener

### DIFF
--- a/packages/wxt/src/utils/content-script-context.ts
+++ b/packages/wxt/src/utils/content-script-context.ts
@@ -202,7 +202,7 @@ export class ContentScriptContext implements AbortController {
   ): void;
   addEventListener<TType extends keyof DocumentEventMap>(
     target: Document,
-    type: keyof DocumentEventMap,
+    type: TType,
     handler: (event: DocumentEventMap[TType]) => void,
     options?: AddEventListenerOptions,
   ): void;


### PR DESCRIPTION
### Overview

<!-- Describe your changes and why you made them -->

This PR fixes an incorrect type definition in `ContentScriptContext.addEventListener` with Document targets.
Previously, the method signature defined the parameter as:

```ts
addEventListener<TType extends keyof DocumentEventMap>(
  target: Document,
  type: keyof DocumentEventMap,
  handler: (event: DocumentEventMap[TType]) => void,
  options?: AddEventListenerOptions,
): void;
```

Here, type was hardcoded as `keyof DocumentEventMap` instead of using the generic `TType`.
This caused type inference issues when registering event listeners, making TypeScript report incompatibility errors (e.g., with click handlers typed as `PointerEvent`).

The fix updates the method signature to:

```ts
addEventListener<TType extends keyof DocumentEventMap>(
  target: Document,
  type: TType,
  handler: (event: DocumentEventMap[TType]) => void,
  options?: AddEventListenerOptions,
): void;
```

This ensures proper type inference for the event handler parameter.

### Manual Testing

<!-- Describe how to test your changes to make sure the PR works as intended -->

1. Create a content script using `ctx.addEventListener` with different event types:
    ```ts
    ctx.addEventListener(document, "click", (e) => {
      e.clientX;  // ✅ properly inferred as PointerEvent
    });

    ctx.addEventListener(document, "click", (e: PointerEvent) => {  // ✅ No error of "No overload matches this call."
      ...
    });

    ```

2. Confirm that TypeScript correctly infers the handler parameter type depending on the event name.

### Related Issue

<!-- If this PR is related to an issue, please link it here -->

N/A.
