### PR TITLE
ci: Create script to list unreleased commits for each package

### DIFF
--- a/scripts/list-unreleased-commits.sh
+++ b/scripts/list-unreleased-commits.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+
+set -e
+
+PACKAGES_DIR="./packages"
+export GIT_PAGER=cat
+IGNORED_DIRS=("browser" "wxt-demo")
+
+if [ ! -d "$PACKAGES_DIR" ]; then
+    echo "Error: Directory '$PACKAGES_DIR' not found."
+    exit 1
+fi
+
+echo "Checking for changes in packages since their last tag..."
+echo ""
+
+for dir in "$PACKAGES_DIR"/*; do
+    if [ -d "$dir" ]; then
+        pkg_name=$(basename "$dir")
+
+        # Check if the package name is in the ignored directories list
+        if [[ " ${IGNORED_DIRS[*]} " =~ " $pkg_name " ]]; then
+            echo "Skipping ignored package: $pkg_name"
+            continue # Skip to the next directory
+        fi
+
+        echo "----------------------------------------"
+        echo "Package: $pkg_name"
+
+        # Find the latest tag for the package, e.g., "my-package-v1.2.3"
+        # Sorts tags by version and picks the most recent one.
+        last_tag=$(git tag --list "${pkg_name}-v*" --sort=-v:refname | head -n 1)
+
+        if [ -n "$last_tag" ]; then
+            # If a tag is found, show commits since that tag for the specific package directory
+            echo "Commits since last tag ($last_tag):"
+            git log "${last_tag}..HEAD" --oneline -- "$dir"
+        else
+            # If no tag is found, show all commits for that package directory
+            echo "No tags found for this package. Listing all commits:"
+            git log --oneline -- "$dir"
+        fi
+        echo ""
+    fi
+done


### PR DESCRIPTION
### Overview

I have been known to forget to release packages after PR are merged... The new script will list all the commits for a package since it's last release. You can then easily decide which packages need released.

For example, I forgot to release #1771 and that caused someone to report https://github.com/wxt-dev/wxt/issues/1866.

```plaintext
$ ./scripts/list-unreleased-commits.sh
...

----------------------------------------
Package: module-vue
Commits since last tag (module-vue-v1.0.2):
7a814724 (origin/main, origin/HEAD, main) chore(deps): Upgrade all dev dependencies (#1876)
9399d8df chore: Create script for managing dependency upgrades (#1875)
a6eef643 chore(deps): Upgrade typescript from 5.8.3 to 5.9.2
e7db1195 chore: wxt & @wxt-dev/module-vue support Vite 7 (#1771)
6f970efd chore: Upgrade `@aklinker1/check` to v2 (#1647)
4add8820 chore: Stop using PNPM catalog (#1644)
28cff9c9 chore: Move production dependencies to PNPM 10 catelog (#1494)
8ce197b0 chore: Use PNPM 10's new catelog feature (#1493)
e20de4ca chore: Add funding links to `package.json` files (#1446)

...
```
