### PR TITLE
fix: input_components is supported by mv3

### DIFF
--- a/packages/wxt/src/core/utils/__tests__/manifest.test.ts
+++ b/packages/wxt/src/core/utils/__tests__/manifest.test.ts
@@ -1351,7 +1351,6 @@ describe('Manifest Utils', () => {
         event_rules: {},
         file_browser_handlers: {},
         file_system_provider_capabilities: {},
-        input_components: {},
         nacl_modules: {},
         natively_connectable: {},
         offline_enabled: {},

--- a/packages/wxt/src/core/utils/manifest.ts
+++ b/packages/wxt/src/core/utils/manifest.ts
@@ -716,7 +716,6 @@ const mv2OnlyKeys = [
   'event_rules',
   'file_browser_handlers',
   'file_system_provider_capabilities',
-  'input_components',
   'nacl_modules',
   'natively_connectable',
   'offline_enabled',


### PR DESCRIPTION
### Overview

Guess I'm the first one trying to use wxt to build an input method for ChromeOS.
The `input_components` should be kept in manifest.
It's documented by Google https://developer.chrome.com/docs/extensions/reference/manifest and used by an input method developed by Google https://github.com/google/jscin/blob/4fd228d2ef445ed615d8f9a5217a1dfa867ba6db/src/chrome/manifest.json#L18

### Manual Testing

<!-- Describe how to test your changes to make sure the PR works as intended -->

### Related Issue

<!-- If this PR is related to an issue, please link it here -->

This PR closes #<issue_number>
