### PR TITLE
fix: wxt normal logs are drowned by `dotenv@17.0.0` ads

### DIFF
--- a/packages/wxt/src/core/utils/env.ts
+++ b/packages/wxt/src/core/utils/env.ts
@@ -8,6 +8,7 @@ import type { TargetBrowser } from '../../types';
 export function loadEnv(mode: string, browser: TargetBrowser) {
   return expand(
     config({
+      quiet: true,
       // Files on top override files below
       path: [
         `.env.${mode}.${browser}.local`,


### PR DESCRIPTION
dotenv@17.0.0 prints “tip: 📡 auto-backup env with Radar: https://dotenvx.com/radar” ads by default, which is very annoying and needs to be turned off.

https://github.com/motdotla/dotenv/commit/b1d4a78198151ca4ef525b1fb5f77e2636622e5f

<img width="978" height="292" alt="Image" src="https://github.com/user-attachments/assets/ad3b4403-6873-469d-bff4-a93a4ce9e014" />

```
❯ pnpm why dotenv
Legend: production dependency, optional only, dev only

devDependencies:
@wxt-dev/auto-icons 1.1.0
└─┬ wxt 0.20.11 peer
  ├─┬ c12 3.2.0
  │ └── dotenv 17.2.2
  ├── dotenv 17.2.2
  ├─┬ dotenv-expand 12.0.3
  │ └── dotenv 16.6.1
  └─┬ publish-browser-extension 3.0.2
    └── dotenv 16.6.1
wxt 0.20.11
├─┬ c12 3.2.0
│ └── dotenv 17.2.2
├── dotenv 17.2.2
├─┬ dotenv-expand 12.0.3
│ └── dotenv 16.6.1
└─┬ publish-browser-extension 3.0.2
  └── dotenv 16.6.1
```