### PR TITLE
chore(templates): Fix typo vite -> wxt

### DIFF
--- a/templates/vanilla/entrypoints/popup/main.ts
+++ b/templates/vanilla/entrypoints/popup/main.ts
@@ -1,12 +1,12 @@
 import './style.css';
 import typescriptLogo from '@/assets/typescript.svg';
-import viteLogo from '/wxt.svg';
+import wxtLogo from '/wxt.svg';
 import { setupCounter } from '@/components/counter';
 
 document.querySelector<HTMLDivElement>('#app')!.innerHTML = `
   <div>
     <a href="https://wxt.dev" target="_blank">
-      <img src="${viteLogo}" class="logo" alt="WXT logo" />
+      <img src="${wxtLogo}" class="logo" alt="WXT logo" />
     </a>
     <a href="https://www.typescriptlang.org/" target="_blank">
       <img src="${typescriptLogo}" class="logo vanilla" alt="TypeScript logo" />


### PR DESCRIPTION
### Overview

This is probably because the template is a rewritten version of vite's vanilla html template

### Manual Testing

Not relevant

### Related Issue

Not relevant


