### PR TITLE
fix: Add another `defineItem` signature when `init` function is passed

### DIFF
--- a/packages/storage/src/__tests__/index.test.ts
+++ b/packages/storage/src/__tests__/index.test.ts
@@ -1315,6 +1315,18 @@ describe('Storage Utils', () => {
         });
         expectTypeOf(item).toEqualTypeOf<WxtStorageItem<number | null, {}>>();
       });
+
+      it('should define a non-null value when options are passed with a non-null init function', () => {
+        const item = storage.defineItem(`local:test`, {
+          init: () => 123,
+        });
+        expectTypeOf(item).toEqualTypeOf<WxtStorageItem<number, {}>>();
+
+        const item2 = storage.defineItem(`local:test`, {
+          init: () => Promise.resolve(123),
+        });
+        expectTypeOf(item2).toEqualTypeOf<WxtStorageItem<number, {}>>();
+      });
     });
   });
 

--- a/packages/storage/src/index.ts
+++ b/packages/storage/src/index.ts
@@ -754,6 +754,12 @@ export interface WxtStorage {
   ): WxtStorageItem<TValue, TMetadata>;
   defineItem<TValue, TMetadata extends Record<string, unknown> = {}>(
     key: StorageItemKey,
+    options: WxtStorageItemOptions<TValue> & {
+      init: () => TValue | Promise<TValue>;
+    },
+  ): WxtStorageItem<TValue, TMetadata>;
+  defineItem<TValue, TMetadata extends Record<string, unknown> = {}>(
+    key: StorageItemKey,
     options: WxtStorageItemOptions<TValue>,
   ): WxtStorageItem<TValue | null, TMetadata>;
 }


### PR DESCRIPTION
### Overview

https://github.com/wxt-dev/wxt/pull/1601 adjusted the typing of `defineItem` to examine whether `defaultValue` or `fallback` were passed, and only then, remove the `null` from the possible returned value. However, it did not accommodate the case where an `init` function is passed to prevent a `null` return, which was previously allowed.

Add a new type signature for this case, and add some tests for type expectations to catch the issue.

### Manual Testing

Added type tests that fail before this change, and succeed after.

### Related Issue

* #1601