### PR TITLE
type(storage): when having `init` option, the value type should not contain `null`

### DIFF
--- a/packages/storage/src/index.ts
+++ b/packages/storage/src/index.ts
@@ -751,6 +751,12 @@ export interface WxtStorage {
   ): WxtStorageItem<TValue, TMetadata>;
   defineItem<TValue, TMetadata extends Record<string, unknown> = {}>(
     key: StorageItemKey,
+    options: WxtStorageItemOptions<TValue> & {
+      init: () => TValue | Promise<TValue>;
+    },
+  ): WxtStorageItem<TValue, TMetadata>;
+  defineItem<TValue, TMetadata extends Record<string, unknown> = {}>(
+    key: StorageItemKey,
     options: WxtStorageItemOptions<TValue>,
   ): WxtStorageItem<TValue | null, TMetadata>;
 }


### PR DESCRIPTION
### Overview

<!-- Describe your changes and why you made them -->

### Manual Testing

<!-- Describe how to test your changes to make sure the PR works as intended -->

### Related Issue

<!-- If this PR is related to an issue, please link it here -->

This PR closes #<issue_number>
