### PR TITLE
fix(storage): resolve workspace protocol in published package

### DIFF
--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -30,7 +30,7 @@
     "test": "buildc --deps-only -- vitest"
   },
   "dependencies": {
-    "@wxt-dev/browser": "workspace:^",
+    "@wxt-dev/browser": "^0.1.4",
     "async-mutex": "^0.5.0",
     "dequal": "^2.0.3"
   },


### PR DESCRIPTION
### Overview

The latest version of `@wxt-dev/storage` (`v1.2.5`) was published with an internal `"@wxt-dev/browser": "workspace:^"` dependency. This breaks the installation for end-users, as it's an unresolved workspace protocol.

This PR directly replaces the `workspace:^` protocol in the source `package.json` with a concrete version range (`^0.1.4`). This ensures that the `unbuild` process generates a correct `package.json` for publishing, resolving the installation error.

### Manual Testing

I have verified this fix locally by running `pnpm pack` and inspecting the resulting `package.json` in the tarball to confirm the protocol was correctly replaced. All project tests (`pnpm test`) also pass.

### Related Issue

This PR closes #1933