### PR TITLE
fix: content script is incorrectly invalidated when injected multiple times

### DIFF
--- a/packages/wxt/src/utils/content-script-context.ts
+++ b/packages/wxt/src/utils/content-script-context.ts
@@ -247,6 +247,17 @@ export class ContentScriptContext implements AbortController {
         },
       }),
     );
+
+    // Send message using `window.postMessage` for backwards compatibility to invalidate old versions before WXT changed to `document.dispatchEvent`
+    // TODO: Remove this once WXT version using `document.dispatchEvent` has been released for a while
+    window.postMessage(
+      {
+        type: ContentScriptContext.SCRIPT_STARTED_MESSAGE_TYPE,
+        contentScriptName: this.contentScriptName,
+        messageId: this.id,
+      },
+      '*',
+    );
   }
 
   verifyScriptStartedEvent(event: CustomEvent) {


### PR DESCRIPTION
### Overview

Video of issue and fix: https://www.loom.com/share/97983e5d38904af594d5f486bbf9f1f4?sid=e588c652-c868-4cb0-8db2-521650726919

This PR replaces `window.postMessage` with `document.dispatchEvent` in order to avoid race conditions when invalidating content scripts.

Since [`document.dispatchEvent`](https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/dispatchEvent) invokes event handlers synchronously, it prevents issues with invalidation due to the asynchronous nature of `window.postMessage`.

I cleaned up related code in `ContentScriptContext` that followed as a result of this change:
- Due to the removal of the race condition, the logic of ignoring the first event used to resolve #884 is no longer necessary.
- The premature invalidation in #1359 should not happen, but to handle the case of a rogue website that somehow replays the custom event, the content script context ignores messages from itself. However, it should not ignore messages from other instances of the same script being injected, so the comparison was changed to simply check the message ID against its own context ID.
- Since `document.dispatchEvent` operates within its frame, `stopOldScripts` is called in all cases, not just in the top frame so that duplicate content scripts are invalidated when they're injected into a frame.

### Related Issue

This PR closes #1937
