### PR TITLE
fix: use uiContainer to apply position when creating shadow root ui

### DIFF
--- a/packages/wxt/src/utils/content-script-ui/shadow-root.ts
+++ b/packages/wxt/src/utils/content-script-ui/shadow-root.ts
@@ -55,7 +55,7 @@ export async function createShadowRootUi<TMounted>(
   const mount = () => {
     // Add shadow root element to DOM
     mountUi(shadowHost, options);
-    applyPosition(shadowHost, shadow.querySelector('html'), options);
+    applyPosition(shadowHost, uiContainer, options);
 
     // Add document CSS
     if (


### PR DESCRIPTION
### Overview

This is a companion PR for https://github.com/aklinker1/webext-core/pull/118

Once the shadow DOM uses a `<div>` instead of constructing a full HTML document, the current approach of finding the `<html>` element won't work. Instead, the `uiContainer` will be used to position the content script UI.

### Manual Testing

How to test this change:

1. Create a new WXT extension using `pnpm dlx wxt@latest init`
2. Use modified `wxt`
    - Clone `wxt` repo
    - Check out this PR
    - Run `pnpm build` in `wxt/packages/wxt`
    - In the extension directory, run `pnpm link <path-to-wxt/packages/wxt>` to use modified version of `wxt`
3. Use modified `webext-core`
    - Clone `webext-core` repo
    - Check out https://github.com/aklinker1/webext-core/pull/118
    - Run `bun run build` in `webext-core/packages/isolated-element`
    - In the `wxt` directory, run `pnpm link <path-to-webext-core/packages/isolated-element>` to use modified version of `@webext-core/isolated-element`
4. Use `createShadowRootUi` with position `overlay` or `modal` to verify that the element is position as desired

Example code for testing:
```typescript
export default defineContentScript({
  matches: ["<all_urls>"],
  cssInjectionMode: "ui",

  async main(ctx) {
    const ui = await createShadowRootUi(ctx, {
      name: "example-ui",
      position: "overlay", // <-- change between "inline", "overlay", "modal"
      anchor: "body",
      onMount(container) {
        const app = document.createElement("div");
        app.textContent = "Hello world!";
        app.style.padding = "8px";
        app.style.border = "2px solid red";
        container.append(app);
      },
    });

    ui.mount();
  },
});
```
