### PR TITLE
fix: publish using `pnpm` instead of npm

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,8 +62,7 @@ jobs:
       - name: Publish to NPM
         working-directory: packages/${{ inputs.package }}
         run: |
-          sudo npm i -g npm@latest
-          /usr/local/bin/npm publish
+          pnpm publish
 
       - name: Create GitHub release
         run: pnpm tsx scripts/create-github-release.ts ${{ inputs.package }}


### PR DESCRIPTION
### Overview

`npm` does not know how to resolve the `workspace:^` protocol, but `pnpm` does and changes it to a valid semver version. The 0.2.5 version of wxt/storage was published as is, so it is breaking a bunch of workflows.


### Manual Testing

Publish a new version of WXT Storage

### Related Issue

https://github.com/wxt-dev/wxt/issues/1933

This PR closes #1933
