### PR TITLE
refactor: make vite a default peer

### DIFF
--- a/packages/wxt/package.json
+++ b/packages/wxt/package.json
@@ -58,7 +58,6 @@
     "publish-browser-extension": "^2.3.0 || ^3.0.0",
     "scule": "^1.3.0",
     "unimport": "^3.13.1 || ^4.0.0 || ^5.0.0",
-    "vite": "^5.4.19 || ^6.3.4 || ^7.0.0",
     "vite-node": "^2.1.4 || ^3.1.2",
     "web-ext-run": "^0.2.3"
   },
@@ -80,6 +79,7 @@
     "publint": "^0.3.12",
     "typescript": "^5.8.3",
     "unbuild": "^3.5.0",
+    "vite": "^6.3.5",
     "vitest": "^3.1.2",
     "vitest-plugin-random-seed": "^1.1.1"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -578,9 +578,6 @@ importers:
       unimport:
         specifier: ^3.13.1 || ^4.0.0 || ^5.0.0
         version: 3.13.1(rollup@4.34.9)(webpack-sources@3.2.3)
-      vite:
-        specifier: ^5.4.19 || ^6.3.4 || ^7.0.0
-        version: 6.3.5(@types/node@20.17.30)(jiti@2.4.2)(sass@1.89.1)(tsx@4.19.4)(yaml@2.7.0)
       vite-node:
         specifier: ^2.1.4 || ^3.1.2
         version: 3.2.0(@types/node@20.17.30)(jiti@2.4.2)(sass@1.89.1)(tsx@4.19.4)(yaml@2.7.0)
@@ -630,6 +627,9 @@ importers:
       unbuild:
         specifier: ^3.5.0
         version: 3.5.0(sass@1.89.1)(typescript@5.8.3)(vue@3.5.13(typescript@5.8.3))
+      vite:
+        specifier: ^6.3.5
+        version: 6.3.5(@types/node@20.17.30)(jiti@2.4.2)(sass@1.89.1)(tsx@4.19.4)(yaml@2.7.0)
       vitest:
         specifier: ^3.1.2
         version: 3.2.0(@types/debug@4.1.12)(@types/node@20.17.30)(happy-dom@17.5.6)(jiti@2.4.2)(sass@1.89.1)(tsx@4.19.4)(yaml@2.7.0)


### PR DESCRIPTION
### Overview

I think this could be breaking in theory, but...
- If you're using the default setup, you're already good.
- If you've customized your Vite version, you probably thought it was a peer.


### Manual Testing

Make some projects and ensure the correct versions are installed.

### Related Issue

This PR closes https://github.com/wxt-dev/wxt/issues/1631
