### PR TITLE
refactor!: move to module-runner

### DIFF
--- a/packages/wxt/package.json
+++ b/packages/wxt/package.json
@@ -58,11 +58,10 @@
     "publish-browser-extension": "^2.3.0 || ^3.0.2",
     "scule": "^1.3.0",
     "unimport": "^3.13.1 || ^4.0.0 || ^5.0.0",
-    "vite-node": "^2.1.4 || ^3.1.2",
     "web-ext-run": "^0.2.4"
   },
   "peerDependencies": {
-    "vite": "^5.4.19 || ^6.3.4 || ^7.0.0"
+    "vite": "^6.3.4 || ^7.0.0"
   },
   "devDependencies": {
     "@aklinker1/check": "^2.1.0",

--- a/packages/wxt/src/core/builders/vite/plugins/removeEntrypointMainFunction.ts
+++ b/packages/wxt/src/core/builders/vite/plugins/removeEntrypointMainFunction.ts
@@ -19,7 +19,7 @@ export function removeEntrypointMainFunction(
       handler(code, id) {
         if (id === absPath) {
           const newCode = removeMainFunctionCode(code);
-          config.logger.debug('vite-node transformed entrypoint', path);
+          config.logger.debug('transformed entrypoint', path);
           config.logger.debug(`Original:\n---\n${code}\n---`);
           config.logger.debug(`Transformed:\n---\n${newCode.code}\n---`);
           return newCode;

--- a/packages/wxt/src/types.ts
+++ b/packages/wxt/src/types.ts
@@ -1029,7 +1029,7 @@ export interface WxtBuilder {
   /**
    * Import a JS entrypoint file, returning the default export containing the options.
    */
-  importEntrypoint<T>(path: string): Promise<T>;
+  importEntrypoint<T>(this: WxtBuilder, path: string): Promise<T>;
   /**
    * Import a list of JS entrypoint files, returning their options.
    */

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -584,9 +584,6 @@ importers:
       unimport:
         specifier: ^3.13.1 || ^4.0.0 || ^5.0.0
         version: 5.2.0
-      vite-node:
-        specifier: ^2.1.4 || ^3.1.2
-        version: 3.2.4(@types/node@20.19.13)(jiti@2.5.1)(sass@1.92.0)(tsx@4.20.5)(yaml@2.8.1)
       web-ext-run:
         specifier: ^0.2.4
         version: 0.2.4


### PR DESCRIPTION
> [!WARNING]
>
> **Breaking Change**
>
> Drop support for Vite <6

### Overview

Drop `vite-node` in favor of Vite-native `runnerImport`, which is based on `ModuleRunner`.

### Manual Testing

<!-- Describe how to test your changes to make sure the PR works as intended -->

Good question... not entirely sure what fails the treeshake in the first place, but all the tests pass so I assume it loads the entrypoints at least. 🤷🏻‍♂️

### Related Issue

<!-- If this PR is related to an issue, please link it here -->

Stacked on #1945.
Supersedes/closes #1884.
