### PR TITLE
docs: Change `manifest.title` to `manifest.name` in `build:manifestGenerated` hook example

### DIFF
--- a/docs/guide/essentials/config/hooks.md
+++ b/docs/guide/essentials/config/hooks.md
@@ -11,7 +11,7 @@ export default defineConfig({
   hooks: {
     'build:manifestGenerated': (wxt, manifest) => {
       if (wxt.config.mode === 'development') {
-        manifest.title += ' (DEV)';
+        manifest.name += ' (DEV)';
       }
     },
   },


### PR DESCRIPTION
### Overview
Updated the `build:manifestGenerated` hook to use `manifest.name` instead of `manifest.title`. The Chrome Extension manifest doesn't have a `title` property - the correct property for the extension name is `name`. This fix ensures the "(DEV)" suffix is properly applied to the extension name in development mode.
