### PR TITLE
docs: Add note about reviewing project structure in migration guide

### DIFF
--- a/docs/guide/resources/migrate.md
+++ b/docs/guide/resources/migrate.md
@@ -15,6 +15,11 @@ cd path/to/your/project
 pnpm dlx wxt@latest init example-wxt --template vanilla
 ```
 
+:::tip
+We recommend reviewing [project structure](/guide/essentials/project-structure.md) before you get started.
+You can customize directory names in `wxt.config.ts` to match your project's needs.
+:::
+
 In general, you'll need to:
 
 &ensp;<input type="checkbox" /> Install `wxt`<br />


### PR DESCRIPTION
### Overview

Hello! I'm currently migrating a project from Plasmo to WXT.
While going through the migration guide, I felt that the process becomes much smoother when you review the [Project Structure page](https://wxt.dev/guide/essentials/project-structure.html) beforehand to understand the directory layout.

This PR adds a tip to help future users follow that flow more easily.

Thanks in advance for your consideration.

#### Target page

https://wxt.dev/guide/resources/migrate.html
