### PR TITLE
fix: Fix build @wxt-dev/browser 

### DIFF
--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -26,9 +26,9 @@
     "@types/chrome": "0.1.32",
     "fs-extra": "^11.3.1",
     "nano-spawn": "^1.0.2",
-    "tsx": "4.19.4",
+    "tsx": "4.20.5",
     "typescript": "^5.9.2",
-    "vitest": "^3.1.2"
+    "vitest": "^3.2.4"
   },
   "dependencies": {
     "@types/filesystem": "*",


### PR DESCRIPTION
### Overview

In this PR fixed build error in `@wxt-dev/browser ` package.

```
  Failure reason:
  specifiers in the lockfile don't match specifiers in package.json:
* 2 dependencies are mismatched:
  - tsx (lockfile: 4.20.5, manifest: 4.19.4)
  - vitest (lockfile: ^3.2.4, manifest: ^3.1.2)
```
