### PR TITLE
fix: alignment of 2 last comments of regex patterns

### DIFF
--- a/packages/wxt/src/core/utils/manifest.ts
+++ b/packages/wxt/src/core/utils/manifest.ts
@@ -436,8 +436,8 @@ function discoverIcons(
     /^icon@([0-9]+)w\.png$/,                // icon@16w.png
     /^icon@([0-9]+)h\.png$/,                // icon@16h.png
     /^icon@([0-9]+)\.png$/,                 // icon@16.png
-    /^icons?[/\\]([0-9]+)\.png$/,          // icon/16.png | icons/16.png
-    /^icons?[/\\]([0-9]+)x[0-9]+\.png$/,   // icon/16x16.png | icons/16x16.png
+    /^icons?[/\\]([0-9]+)\.png$/,           // icon/16.png | icons/16.png
+    /^icons?[/\\]([0-9]+)x[0-9]+\.png$/,    // icon/16x16.png | icons/16x16.png
   ];
   // #endregion snippet
 


### PR DESCRIPTION
### Overview

For docs purposes :)
https://wxt.dev/guide/essentials/config/manifest.html#icons
