### PR TITLE
fix: normalize path for createAnalytics of analytics/index.ts

### DIFF
--- a/packages/analytics/modules/analytics/index.ts
+++ b/packages/analytics/modules/analytics/index.ts
@@ -8,6 +8,7 @@ import {
 } from 'wxt/modules';
 import { relative, resolve } from 'node:path';
 import type { AnalyticsConfig } from './types';
+import { normalizePath } from 'wxt';
 
 declare module 'wxt/utils/define-app-config' {
   export interface WxtAppConfig {
@@ -42,7 +43,7 @@ export default defineWxtModule({
       `import { createAnalytics } from '${
         process.env.NPM
           ? clientModuleId
-          : relative(wxtAnalyticsFolder, clientModuleId)
+          : normalizePath(relative(wxtAnalyticsFolder, clientModuleId))
       }';`,
       `import { useAppConfig } from '#imports';`,
       ``,


### PR DESCRIPTION
### Overview

I've use normalize path for `createAnalysis` func in output.

### Manual Testing

Let's run `pnpm -F analytics prepare` and see new output of `.wxt/analytics/index.ts`, should be valid independent of OS.

### Related Issue

This PR closes #2008
