### PR TITLE
fix(content-script-context): handle undefined browser.runtime

### DIFF
--- a/packages/wxt/src/utils/__tests__/content-script-context.test.ts
+++ b/packages/wxt/src/utils/__tests__/content-script-context.test.ts
@@ -32,6 +32,25 @@ describe('Content Script Context', () => {
     expect(isValid).toBe(false);
   });
 
+  it('should not throw when browser.runtime is undefined (extension context fully invalidated)', () => {
+    const ctx = new ContentScriptContext('test');
+    const onInvalidated = vi.fn();
+
+    ctx.onInvalidated(onInvalidated);
+    // Simulate complete extension context invalidation where browser.runtime becomes undefined
+    const originalRuntime = fakeBrowser.runtime;
+    // @ts-ignore
+    fakeBrowser.runtime = undefined;
+
+    // Should not throw, and should mark as invalid
+    expect(() => ctx.isInvalid).not.toThrow();
+    expect(ctx.isInvalid).toBe(true);
+    expect(onInvalidated).toBeCalled();
+
+    // Restore for other tests
+    fakeBrowser.runtime = originalRuntime;
+  });
+
   it('should invalidate the current content script when a new context is created', async () => {
     const name = 'test';
     const onInvalidated = vi.fn();

--- a/packages/wxt/src/utils/content-script-context.ts
+++ b/packages/wxt/src/utils/content-script-context.ts
@@ -71,7 +71,7 @@ export class ContentScriptContext implements AbortController {
   }
 
   get isInvalid(): boolean {
-    if (browser.runtime.id == null) {
+    if (browser.runtime?.id == null) {
       this.notifyInvalidated(); // Sets `signal.aborted` to true
     }
     return this.signal.aborted;


### PR DESCRIPTION
### Overview

When a browser extension context is fully invalidated (e.g., during extension update, reload, or disable), the `browser.runtime` object itself can become `undefined`, not just `browser.runtime.id`. This causes a runtime error when the `isInvalid` getter tries to access `browser.runtime.id`.

This change adds optional chaining to safely handle the case where `browser.runtime` is undefined, preventing the error and allowing the content script to properly detect and handle context invalidation.

### Manual Testing

Added automated tests for this scenario.

### Related Issue

https://github.com/wxt-dev/wxt/issues/1676

This PR closes #1676
