### PR TITLE
More robust way of checking the browser type to fix Chrome 144+ issues

### DIFF
--- a/packages/browser/src/index.mjs
+++ b/packages/browser/src/index.mjs
@@ -1,5 +1,6 @@
 // #region snippet
-export const browser = globalThis.browser?.runtime?.id
-  ? globalThis.browser
-  : globalThis.chrome;
+export const browser =
+  import.meta.env.FIREFOX || import.meta.env.SAFARI
+    ? globalThis.browser
+    : globalThis.chrome
 // #endregion snippet


### PR DESCRIPTION
### Overview

<!-- Describe your changes and why you made them -->

Introduce more robust way of checking browser type, based on variables set during the build, instead of the runtime checks, to address the problems reported in #2039

### Manual Testing

<!-- Describe how to test your changes to make sure the PR works as intended -->
```
console.log(browser.devtools)
```
shouldn't return `undefined` in Chrome 144+

### Related Issue

<!-- If this PR is related to an issue, please link it here -->
#2039

This PR closes #2039
