### PR TITLE
feat: prefix content script names

### DIFF
--- a/docs/guide/essentials/entrypoints.md
+++ b/docs/guide/essentials/entrypoints.md
@@ -262,6 +262,8 @@ When you define a Bookmarks entrypoint, WXT will automatically update the manife
   :patterns="[
     ['content.[jt]sx?', 'content-scripts/content.js'],
     ['content/index.[jt]sx?', 'content-scripts/content.js'],
+    ['content.{name}.[jt]sx?', 'content-scripts/{name}.js'],
+    ['content.{name}/index.[jt]sx?', 'content-scripts/{name}.js'],
     ['{name}.content.[jt]sx?', 'content-scripts/{name}.js'],
     ['{name}.content/index.[jt]sx?', 'content-scripts/{name}.js'],
   ]"

--- a/packages/wxt/src/core/builders/vite/index.ts
+++ b/packages/wxt/src/core/builders/vite/index.ts
@@ -267,7 +267,13 @@ export async function createViteBuilder(
   const requireDefaultExport = (path: string, mod: any) => {
     const relativePath = relative(wxtConfig.root, path);
     if (mod?.default == null) {
-      const defineFn = relativePath.includes('.content')
+      const isContentScript =
+        relativePath.includes('.content') ||
+        relativePath.includes('/content.') ||
+        relativePath.includes('\\content.') ||
+        relativePath.includes('/content/') ||
+        relativePath.includes('\\content\\');
+      const defineFn = isContentScript
         ? 'defineContentScript'
         : relativePath.includes('background')
           ? 'defineBackground'

--- a/packages/wxt/src/core/utils/__tests__/entrypoints.test.ts
+++ b/packages/wxt/src/core/utils/__tests__/entrypoints.test.ts
@@ -17,6 +17,8 @@ describe('Entrypoint Utils', () => {
       [resolve(entrypointsDir, 'example.sandbox/index.html'), 'example'],
       [resolve(entrypointsDir, 'some.content/index.ts'), 'some'],
       [resolve(entrypointsDir, 'overlay.content.ts'), 'overlay'],
+      [resolve(entrypointsDir, 'content.overlay.ts'), 'overlay'],
+      [resolve(entrypointsDir, 'content.overlay/index.ts'), 'overlay'],
     ])('should convert %s to %s', (inputPath, expected) => {
       const actual = getEntrypointName(entrypointsDir, inputPath);
       expect(actual).toBe(expected);

--- a/packages/wxt/src/core/utils/building/__tests__/find-entrypoints.test.ts
+++ b/packages/wxt/src/core/utils/building/__tests__/find-entrypoints.test.ts
@@ -165,6 +165,16 @@ describe('findEntrypoints', () => {
       },
     ],
     [
+      'content.overlay.ts',
+      {
+        type: 'content-script',
+        name: 'overlay',
+        inputPath: resolve(config.entrypointsDir, 'content.overlay.ts'),
+        outputDir: resolve(config.outDir, 'content-scripts'),
+        skipped: false,
+      },
+    ],
+    [
       'overlay.content.ts',
       {
         type: 'content-script',
@@ -180,6 +190,16 @@ describe('findEntrypoints', () => {
         type: 'content-script',
         name: 'content',
         inputPath: resolve(config.entrypointsDir, 'content/index.ts'),
+        outputDir: resolve(config.outDir, 'content-scripts'),
+        skipped: false,
+      },
+    ],
+    [
+      'content.overlay/index.ts',
+      {
+        type: 'content-script',
+        name: 'overlay',
+        inputPath: resolve(config.entrypointsDir, 'content.overlay/index.ts'),
         outputDir: resolve(config.outDir, 'content-scripts'),
         skipped: false,
       },
@@ -627,6 +647,17 @@ describe('findEntrypoints', () => {
       },
     ],
     [
+      'content.overlay.css',
+      {
+        type: 'content-script-style',
+        name: 'overlay',
+        inputPath: resolve(config.entrypointsDir, 'content.overlay.css'),
+        outputDir: resolve(config.outDir, 'content-scripts'),
+        options: {},
+        skipped: false,
+      },
+    ],
+    [
       'overlay.content.css',
       {
         type: 'content-script-style',
@@ -643,6 +674,17 @@ describe('findEntrypoints', () => {
         type: 'content-script-style',
         name: 'content',
         inputPath: resolve(config.entrypointsDir, 'content/index.css'),
+        outputDir: resolve(config.outDir, 'content-scripts'),
+        options: {},
+        skipped: false,
+      },
+    ],
+    [
+      'content.overlay/index.css',
+      {
+        type: 'content-script-style',
+        name: 'overlay',
+        inputPath: resolve(config.entrypointsDir, 'content.overlay/index.css'),
         outputDir: resolve(config.outDir, 'content-scripts'),
         options: {},
         skipped: false,

--- a/packages/wxt/src/core/utils/building/find-entrypoints.ts
+++ b/packages/wxt/src/core/utils/building/find-entrypoints.ts
@@ -469,11 +469,15 @@ const PATH_GLOB_TO_TYPE_MAP: Record<string, Entrypoint['type']> = {
 
   'content.[jt]s?(x)': 'content-script',
   'content/index.[jt]s?(x)': 'content-script',
+  'content.*.[jt]s?(x)': 'content-script',
+  'content.*/index.[jt]s?(x)': 'content-script',
   '*.content.[jt]s?(x)': 'content-script',
   '*.content/index.[jt]s?(x)': 'content-script',
   [`content.${CSS_EXTENSIONS_PATTERN}`]: 'content-script-style',
+  [`content.*.${CSS_EXTENSIONS_PATTERN}`]: 'content-script-style',
   [`*.content.${CSS_EXTENSIONS_PATTERN}`]: 'content-script-style',
   [`content/index.${CSS_EXTENSIONS_PATTERN}`]: 'content-script-style',
+  [`content.*/index.${CSS_EXTENSIONS_PATTERN}`]: 'content-script-style',
   [`*.content/index.${CSS_EXTENSIONS_PATTERN}`]: 'content-script-style',
 
   'popup.html': 'popup',

--- a/packages/wxt/src/core/utils/entrypoints.ts
+++ b/packages/wxt/src/core/utils/entrypoints.ts
@@ -13,6 +13,12 @@ export function getEntrypointName(
   // type: Entrypoint['type'],
 ): string {
   const relativePath = path.relative(entrypointsDir, inputPath);
+  if (relativePath.startsWith('content.')) {
+    const rest = relativePath.slice('content.'.length);
+    const [first, second] = rest.split(/[/\\]/, 2);
+    if (second != null || first.includes('.')) return first.split('.', 2)[0];
+  }
+
   // Grab the string up to the first . or / or \\
   const name = relativePath.split(/[./\\]/, 2)[0];
 

--- a/packages/wxt/src/types.ts
+++ b/packages/wxt/src/types.ts
@@ -691,6 +691,8 @@ export interface BaseEntrypoint {
    * - `sandbox/index.html` &rarr; `sandbox`
    * - `overlay.content.ts` &rarr; `overlay`
    * - `overlay.content/index.ts` &rarr; `overlay`
+   * - `content.overlay.ts` &rarr; `overlay`
+   * - `content.overlay/index.ts` &rarr; `overlay`
    *
    * The name is used when generating an output file:
    * `<entrypoint.outputDir>/<entrypoint.name>.<ext>`


### PR DESCRIPTION
### Overview

Currently, only `unique-name.content` can be used for naming content scripts. This results in inconvenient sorting in IDEs, such as:

```
- entrypoints
  - google.content
  - popup
  - safari.content
```

This PR allows to use `content.unique-name` format, so we would have
```
- entrypoints
  - content.google
  - content.safari
  - popup
```
which essentially groups content scripts in places such as IDE file viewers

### Manual Testing

Create any content script at `entrypoints/content.name/index.ts` or `entrypoints/content.name.ts`

### Related Issue

N/A

This PR closes #2043
