### PR TITLE
docs: add missing import in code sample for configuration

### DIFF
--- a/docs/guide/essentials/config/browser-startup.md
+++ b/docs/guide/essentials/config/browser-startup.md
@@ -32,6 +32,8 @@ You can configure browser startup in 3 places:
 To set or customize the browser opened during development:
 
 ```ts [web-ext.config.ts]
+import { defineWebExtConfig } from 'wxt';
+
 export default defineWebExtConfig({
   binaries: {
     chrome: '/path/to/chrome-beta', // Use Chrome Beta instead of regular Chrome
@@ -67,6 +69,7 @@ To persist data, set the `--user-data-dir` flag in any of the config files menti
 
 ```ts [Mac/Linux]
 import { defineWebExtConfig } from 'wxt';
+
 export default defineWebExtConfig({
   chromiumArgs: ['--user-data-dir=./.wxt/chrome-data'],
 });
@@ -96,6 +99,8 @@ You can use any directory you'd like for `--user-data-dir`, the examples above c
 If you prefer to load the extension into your browser manually, you can disable the auto-open behavior:
 
 ```ts [web-ext.config.ts]
+import { defineWebExtConfig } from 'wxt';
+
 export default defineWebExtConfig({
   disabled: true,
 });


### PR DESCRIPTION
### Overview

Added missing import on browser start up configuration docs. The current code sample would throw ReferenceError on copy pasting.