### PR TITLE
fix: Add `.jsonc` support for locale files to match docs

### DIFF
--- a/packages/i18n/src/module.ts
+++ b/packages/i18n/src/module.ts
@@ -88,7 +88,7 @@ export default defineWxtModule<I18nOptions>({
       )!;
       if (defaultLocaleFile == null) {
         throw Error(
-          `\`[i18n]\` Required localization file does not exist: \`<localesDir>/${wxt.config.manifest.default_locale}.{json|json5|yml|yaml|toml}\``,
+          `\`[i18n]\` Required localization file does not exist: \`<localesDir>/${wxt.config.manifest.default_locale}.{json|json5|jsonc|yml|yaml|toml}\``,
         );
       }
 


### PR DESCRIPTION
### Overview

Added jsonc to allowed locale extensions. It was mentioned in documentation that jsonc extensions is supported but in reality there is an error. Looks like just missed [here](https://github.com/wxt-dev/wxt/pull/1109)

### Manual Testing

Create a locale in `<srcDir>/locales/<default_locale>.jsonc` and you will notice that it simply crashes during `prepare` step with `ERROR  [i18n] Required localization file does not exist: <localesDir>/en.{json|json5|yml|yaml|toml}`. After fix it works as intended
