### PR TITLE
fix: rename and make firefoxPrefs in web-ext.config.ts work

### DIFF
--- a/packages/wxt/src/core/runners/web-ext.ts
+++ b/packages/wxt/src/core/runners/web-ext.ts
@@ -44,7 +44,7 @@ export function createWebExtRunner(): ExtensionRunner {
           ? {
               firefox: wxtUserConfig?.binaries?.firefox,
               firefoxProfile: wxtUserConfig?.firefoxProfile,
-              prefs: wxtUserConfig?.firefoxPrefs,
+              pref: wxtUserConfig?.firefoxPref,
               args: wxtUserConfig?.firefoxArgs,
             }
           : {

--- a/packages/wxt/src/types.ts
+++ b/packages/wxt/src/types.ts
@@ -992,7 +992,7 @@ export interface WebExtConfig {
   /**
    * @see https://extensionworkshop.com/documentation/develop/web-ext-command-reference/#pref
    */
-  firefoxPrefs?: Record<string, string>;
+  firefoxPref?: Record<string, boolean | number | string>;
   /**
    * @see https://extensionworkshop.com/documentation/develop/web-ext-command-reference/#args
    */


### PR DESCRIPTION
### Overview

- The correct option in web-ext-run is pref, not prefs. See: https://github.com/mozilla/web-ext/blob/08a71de5d7c03200ac48b3662a0544da81de3a73/src/cmd/run.js#L27
- Update types, you need to use the correct type for the pref value (and in `about:config`, you can create a value of one of three types: boolean, number or string, so that’s what I used)
- Rename field to firefoxPref, it’s consistent with chromiumPref (and with `web-ext`’s Node interface)

Maybe 

### Manual Testing

I used it in my personal project and it works well, in particular with:

```ts
export default defineWebExtConfig({
  firefoxPref: {
    "browser.newtabpage.enabled": false,
  },
});
```

### Related Issue

I don’t think there’s an issue about that.
