### PR TITLE
fix: trusted extension switch

### DIFF
--- a/packages/wxt/src/core/runners/web-ext.ts
+++ b/packages/wxt/src/core/runners/web-ext.ts
@@ -56,6 +56,7 @@ export function createWebExtRunner(): ExtensionRunner {
               ),
               args: [
                 '--unsafely-disable-devtools-self-xss-warnings',
+                '--disable-features=DisableLoadExtensionCommandLineSwitch',
                 ...(wxtUserConfig?.chromiumArgs ?? []),
               ],
             }),


### PR DESCRIPTION
### Overview

After @aklinker1 removed the switch `DisableLoadExtensionCommandLineSwitch` in #1879 specific extension apis where gone from the chrome canary instance. 

It seemed this change marked the extension as untrusted. I couldn't find docs, prooving this point, though.

One of these issues has been described in #1898.

### Manual Testing

After testing the change manually the Prompt api where usable again.

### Before

<img width="487" height="108" alt="Screenshot 2026-02-09 at 19 22 19" src="https://github.com/user-attachments/assets/63bafc21-c0ad-4726-9dbc-730a220dcfb2" />

To get additional context check out `chrome://flags`

### After

<img width="410" height="85" alt="Screenshot 2026-02-09 at 19 21 27" src="https://github.com/user-attachments/assets/57efec04-f318-4379-86d4-8d2d485f249d" />

To get additional context check out `chrome://flags`

### Related Issue

This PR closes #1898


 ### Docs

- https://github.com/webmachinelearning/prompt-api
- https://developer.chrome.com/blog/chrome-for-testing/
- https://github.com/mozilla/web-ext/blob/08a71de5d7c03200ac48b3662a0544da81de3a73/tests/functional/test.cli.run-target-chromium.js#L78-L80
- https://winaero.com/google-releases-chrome-137-with-new-features-and-security-enhancements/#Removal_of_--load-extension_CLI_Flag:~:text=This%20change%20does%20not%20affect%20Chromium%20builds%20or%20Chrome%20for%20Testing.

For more context please check out #1898