### PR TITLE
fix: Change deprecated function `presetUno` to `presetWind3`

### DIFF
--- a/packages/wxt-demo/wxt.config.ts
+++ b/packages/wxt-demo/wxt.config.ts
@@ -1,5 +1,5 @@
 import { defineConfig } from 'wxt';
-import { presetUno } from 'unocss';
+import { presetWind3 } from 'unocss';
 
 export default defineConfig({
   srcDir: 'src',
@@ -53,7 +53,7 @@ export default defineConfig({
           ],
         },
       },
-      presets: [presetUno()],
+      presets: [presetWind3()],
     },
   },
 });


### PR DESCRIPTION
### Overview

I've rename it, because only name was changed

### Manual Testing

Not necessary, if CI pass it'll be OK