### PR TITLE
chore: simplify imports of `cli/__tests__/index.ts`

### DIFF
--- a/packages/wxt/src/cli/__tests__/index.test.ts
+++ b/packages/wxt/src/cli/__tests__/index.test.ts
@@ -1,10 +1,12 @@
 import { describe, it, vi, beforeEach, expect } from 'vitest';
-import { build } from '../../core/build';
-import { createServer } from '../../core/create-server';
-import { zip } from '../../core/zip';
-import { prepare } from '../../core/prepare';
-import { clean } from '../../core/clean';
-import { initialize } from '../../core/initialize';
+import {
+  build,
+  createServer,
+  zip,
+  prepare,
+  clean,
+  initialize,
+} from '../../core';
 import { mock } from 'vitest-mock-extended';
 import consola from 'consola';
 


### PR DESCRIPTION
### Overview

I've simplified imports