### PR TITLE
docs: rename keys name of getMetas() to be proper

### DIFF
--- a/packages/storage/src/index.ts
+++ b/packages/storage/src/index.ts
@@ -708,7 +708,7 @@ export interface WxtStorage {
   /**
    * Get the metadata of multiple storage items.
    *
-   * @param items List of keys or items to get the metadata of.
+   * @param keys List of keys or items to get the metadata of.
    * @returns An array containing storage keys and their metadata.
    */
   getMetas(
@@ -755,7 +755,7 @@ export interface WxtStorage {
   /**
    * Set the metadata of multiple storage items.
    *
-   * @param items List of storage keys or items and metadata to set for each.
+   * @param metas List of storage keys or items and metadata to set for each.
    */
   setMetas(
     metas: Array<


### PR DESCRIPTION
### Overview

I've renamed keys in jsdocs, to have the same names as func has indeed