### PR TITLE
fix: rename `name` to `names` prop of `rollup` to fix deprecated warning

### DIFF
--- a/packages/wxt/src/core/builders/vite/index.ts
+++ b/packages/wxt/src/core/builders/vite/index.ts
@@ -146,10 +146,10 @@ export async function createViteBuilder(
             ),
             // Output content script CSS to `content-scripts/`, but all other scripts are written to
             // `assets/`.
-            assetFileNames: ({ name }) => {
+            assetFileNames: ({ names }) => {
               if (
                 entrypoint.type === 'content-script' &&
-                name?.endsWith('css')
+                names[0].endsWith('css')
               ) {
                 return `content-scripts/${entrypoint.name}.[ext]`;
               } else {


### PR DESCRIPTION
### Overview

I've simply rename it and use first element of array, because i'll have only 1, if i'm right :)