### PR TITLE
chore: Add example of `env` usage to `wxt-demo`

### DIFF
--- a/packages/wxt-demo/src/app.config.ts
+++ b/packages/wxt-demo/src/app.config.ts
@@ -2,10 +2,10 @@ import { defineAppConfig } from '#imports';
 
 declare module 'wxt/utils/define-app-config' {
   export interface WxtAppConfig {
-    example: string;
+    EXAMPLE: string;
   }
 }
 
 export default defineAppConfig({
-  example: 'value',
+  EXAMPLE: 'Example Env Value',
 });

--- a/packages/wxt-demo/src/entrypoints/background.ts
+++ b/packages/wxt-demo/src/entrypoints/background.ts
@@ -2,8 +2,9 @@ export default defineBackground({
   // type: 'module',
 
   main() {
-    console.log(browser.runtime.id);
     logId();
+    logEnv();
+
     console.log({
       url: import.meta.url,
       browser: import.meta.env.BROWSER,

--- a/packages/wxt-demo/src/entrypoints/example-tsx.content.tsx
+++ b/packages/wxt-demo/src/entrypoints/example-tsx.content.tsx
@@ -3,8 +3,8 @@ import ReactDOM from 'react-dom/client';
 export default defineContentScript({
   matches: ['<all_urls>'],
   async main(ctx) {
-    console.log(browser.runtime.id);
     logId();
+    logEnv();
 
     console.log('WXT MODE:', {
       MODE: import.meta.env.MODE,

--- a/packages/wxt-demo/src/entrypoints/options/main.ts
+++ b/packages/wxt-demo/src/entrypoints/options/main.ts
@@ -1,8 +1,7 @@
 import 'url:https://code.jquery.com/jquery-3.7.1.slim.min.js';
 
-console.log(browser.runtime.id);
 logId();
-console.log(2);
+logEnv();
 
 console.log('WXT MODE:', {
   MODE: import.meta.env.MODE,

--- a/packages/wxt-demo/src/utils/logger.ts
+++ b/packages/wxt-demo/src/utils/logger.ts
@@ -3,3 +3,8 @@ export default console;
 export function logId() {
   console.log('logId', browser.runtime.id);
 }
+
+export function logEnv() {
+  const { EXAMPLE } = useAppConfig();
+  console.log(EXAMPLE);
+}


### PR DESCRIPTION

### Overview

I've added a little example, how to use `env` in code, here `background` was used

I want to add this, because it can be quicker to take a look in code(during initial run, e.g as a new maintainer), than checking it in `docs` :)