### PR TITLE
fix(zip): make includeSources use allowlist behavior

### DIFF
--- a/packages/wxt/e2e/tests/zip.test.ts
+++ b/packages/wxt/e2e/tests/zip.test.ts
@@ -181,6 +181,42 @@ describe('Zipping', () => {
     );
   });
 
+  it('should only include specified files when includeSources is provided (allowlist behavior)', async () => {
+    const project = new TestProject({
+      name: 'test',
+      version: '1.0.0',
+    });
+    project.addFile(
+      'entrypoints/background.ts',
+      'export default defineBackground(() => {});',
+    );
+    project.addFile('src/utils.ts', 'export const x = 1;');
+    project.addFile('secrets/api-key.txt', 'supersecret');
+    project.addFile('cache/data.json', '{}');
+    const unzipDir = project.resolvePath('.output/test-1.0.0-sources');
+    const sourcesZip = project.resolvePath('.output/test-1.0.0-sources.zip');
+
+    await project.zip({
+      browser: 'firefox',
+      zip: {
+        includeSources: ['entrypoints/**', 'src/**'],
+      },
+    });
+    await extract(sourcesZip, { dir: unzipDir });
+
+    // Included files should be present
+    expect(
+      await project.pathExists(unzipDir, 'entrypoints/background.ts'),
+    ).toBe(true);
+    expect(await project.pathExists(unzipDir, 'src/utils.ts')).toBe(true);
+
+    // Non-included files should NOT be present (allowlist behavior)
+    expect(await project.pathExists(unzipDir, 'secrets/api-key.txt')).toBe(
+      false,
+    );
+    expect(await project.pathExists(unzipDir, 'cache/data.json')).toBe(false);
+  });
+
   it('should exclude skipped entrypoints from respective browser sources zip', async () => {
     const project = new TestProject({
       name: 'test',

--- a/packages/wxt/src/types.ts
+++ b/packages/wxt/src/types.ts
@@ -196,11 +196,19 @@ export interface InlineConfig {
      * creating a ZIP of all your source code for Firefox. Patterns are relative to your
      * `config.zip.sourcesRoot`.
      *
-     * This setting overrides `excludeSources`. So if a file matches both lists, it is included in the ZIP.
+     * When specified, ONLY files matching these patterns will be included (allowlist behavior).
+     * This prevents accidental inclusion of sensitive files like secrets or credentials.
+     * Files matching `excludeSources` patterns are still excluded.
+     *
+     * When not specified, all files are included by default (except hidden files, node_modules,
+     * and files matching `excludeSources`).
      *
      * @example
      * [
-     *   "coverage", // Include the coverage directory in the `sourcesRoot`
+     *   "entrypoints/**",
+     *   "wxt.config.ts",
+     *   "package.json",
+     *   "tsconfig.json",
      * ]
      */
     includeSources?: string[];


### PR DESCRIPTION
## Summary

When `includeSources` patterns are provided, only files matching those patterns should be included in the sources ZIP. Previously, `includeSources` patterns were added to the default `**/*` glob, which could leak sensitive files that weren't explicitly excluded.

## Problem

As described in #2059, the current behavior is unintuitive and can lead to data leaks:

```ts
// wxt.config.ts
export default defineConfig({
  zip: {
    includeSources: ['entrypoints/**'],
  },
})
```

**Expected:** Only `entrypoints/**` files are included
**Actual:** ALL files are included, plus the entrypoints patterns override excludeSources

This means sensitive files like `secrets/api-key.txt` or `cache/credentials.json` could accidentally be included in the sources ZIP submitted to Firefox.

## Solution

This change makes `includeSources` behave as an allowlist:
- When `includeSources` is provided: only matching files are included
- When `includeSources` is not provided: all files are included (current behavior)
- `excludeSources` still applies on top of include patterns

## Changes

1. **`packages/wxt/src/core/zip.ts`**: When `include` patterns are provided, use only those patterns for globbing instead of combining with `**/*`
2. **`packages/wxt/src/types.ts`**: Updated documentation to clarify the allowlist behavior
3. **`packages/wxt/e2e/tests/zip.test.ts`**: Added test to verify non-included files are excluded

## Breaking Change

If you were using `includeSources` to add specific files to the default set (e.g., hidden files), you now need to include all files you want in the ZIP:

```ts
// Before (old behavior: hidden files added to default)
zip: {
  includeSources: ['.env'],
}

// After (new behavior: explicit allowlist)
zip: {
  includeSources: ['**/*', '.env'],
}
```

Fixes #2059