### PR TITLE
chore: Change browser tests to fix deprecated warning

### DIFF
--- a/packages/browser/src/__tests__/index.test.ts
+++ b/packages/browser/src/__tests__/index.test.ts
@@ -11,7 +11,7 @@ describe('browser', () => {
     });
 
     it('should provide values via the browser import', () => {
-      expectTypeOf<typeof browser.runtime.id>().toEqualTypeOf<string>();
+      expectTypeOf(browser.runtime.id).toEqualTypeOf<string>();
       expectTypeOf<
         typeof browser.storage.local
       >().toEqualTypeOf<Browser.storage.LocalStorageArea>();


### PR DESCRIPTION
### Overview

I've changed tests a little to fit new method instead of deprecated one

### Manual Testing

Let's see if CI pass

### Related Issue

This is part of #2022