### PR TITLE
chore: Fix typo of `manifest.test.ts`

### DIFF
--- a/packages/wxt/src/core/utils/__tests__/manifest.test.ts
+++ b/packages/wxt/src/core/utils/__tests__/manifest.test.ts
@@ -37,7 +37,8 @@ describe('Manifest Utils', () => {
       const popupEntrypoint = (type?: ActionType) =>
         fakePopupEntrypoint({
           options: {
-            mv2Key: type,
+            // @ts-expect-error: Force this to be undefined instead of inheriting the random value
+            mv2Key: type ?? null,
             defaultIcon: {
               '16': '/icon/16.png',
             },


### PR DESCRIPTION
### Overview

I've removed it because `mv2Key` can be `undefined`