### PR TITLE
chore: Remove `zipdir` of `packages/wxt`

### DIFF
--- a/packages/wxt/src/@types/modules.d.ts
+++ b/packages/wxt/src/@types/modules.d.ts
@@ -1,22 +1,5 @@
 // Custom TS definitions for non-TS packages
 
-declare module 'zip-dir' {
-  // Represents the options object for zipDir function
-  interface ZipDirOptions {
-    saveTo?: string;
-    filter?: (path: string, stat: import('fs').Stats) => boolean;
-    each?: (path: string) => void;
-  }
-
-  function zipDir(
-    dirPath: string,
-    options?: ZipDirOptions,
-    callback?: (error: Error | null, buffer: Buffer) => void,
-  ): Promise<Buffer>;
-
-  export = zipDir;
-}
-
 declare module 'web-ext-run' {
   export interface WebExtRunInstance {
     reloadAllExtensions(): Promise<void>;


### PR DESCRIPTION
### Overview

I want to rename it, to match JS most common `cammelCase`.

I know this is breaking changes, we can't merge it now, but i think this can helps dev to have unified syntax for our methods, because most of that have `cammelCase`.

Migration will be veeery easy.

I hope this can go 😄 