### PR TITLE
chore: Remove unnecessary `@ts-ignore` of `builders/vite` index.ts

### DIFF
--- a/packages/wxt/src/core/builders/vite/index.ts
+++ b/packages/wxt/src/core/builders/vite/index.ts
@@ -241,10 +241,7 @@ export async function createViteBuilder(
     const config = vite.mergeConfig(baseConfig, envConfig);
     const server = await vite.createServer(config);
     await server.pluginContainer.buildStart({});
-    const node = new ViteNodeServer(
-      // @ts-ignore: Some weird type error...
-      server,
-    );
+    const node = new ViteNodeServer(server);
     installSourcemapsSupport({
       getSourceMap: (source) => node.getSourceMap(source),
     });


### PR DESCRIPTION
### Overview

I've removed it, because it's unnecessary, maybe this need to be placed in the past, but not now.