### PR TITLE
fix: enable mv3 dev mode with firefox 147

### DIFF
--- a/packages/wxt/src/core/runners/web-ext.ts
+++ b/packages/wxt/src/core/runners/web-ext.ts
@@ -17,15 +17,6 @@ export function createWebExtRunner(): ExtensionRunner {
     async openBrowser() {
       const startTime = Date.now();
 
-      if (
-        wxt.config.browser === 'firefox' &&
-        wxt.config.manifestVersion === 3
-      ) {
-        throw Error(
-          'Dev mode does not support Firefox MV3. For alternatives, see https://github.com/wxt-dev/wxt/issues/230#issuecomment-1806881653',
-        );
-      }
-
       // Use WXT's logger instead of web-ext's built-in one.
       const webExtLogger = await import('web-ext-run/util/logger');
       webExtLogger.consoleStream.write = ({ level, msg, name }) => {


### PR DESCRIPTION
### Overview

Enables dev mode when targeting firefox with mv3

### Manual Testing

```bash
wxt --mv3 --browser firefox
```

### Related Issue

This PR closes #1626
