### PR TITLE
feat: use Navigation API for location change detection with polling fallback

### DIFF
--- a/packages/wxt/src/utils/internal/location-watcher.ts
+++ b/packages/wxt/src/utils/internal/location-watcher.ts
@@ -2,8 +2,7 @@ import { ContentScriptContext } from '../content-script-context';
 import { WxtLocationChangeEvent } from './custom-events';
 
 const supportsNavigationApi =
-  (globalThis as any).navigation !== 'undefined' &&
-  (globalThis as any).navigation.addEventListener === 'function';
+  typeof (globalThis as any).navigation?.addEventListener === 'function';
 
 /**
  * Create a util that watches for URL changes, dispatching the custom event when detected. Stops


### PR DESCRIPTION
### Overview

`wxt:locationchange` used to rely on polling `location.href` every second, so URL updates (e.g. SPA navigations) were detected with up to 1s delay. This change uses the [Navigation API](https://developer.mozilla.org/en-US/docs/Web/API/Navigation_API) when available: we subscribe to the navigate event so URL changes are handled immediately and no timer is used. In environments where the Navigation API is not available (e.g. older Firefox or Safari), behavior is unchanged and we keep the existing 1s polling. No new APIs for extension authors and no breaking changes.

### Manual Testing

1. Build WXT and the demo: `pnpm --filter wxt build` then `pnpm --filter wxt-demo build`.
2. Load the unpacked extension from `packages/wxt-demo/.output/chrome-mv3` (or equivalent for your build).
3. Open a site that uses client-side navigation (e.g. the demo’s `*://*.crunchyroll.com/*`), open DevTools → Console.
4. Navigate within the site (links that change the URL without full reload). You should see `Location changed: <newUrl> <oldUrl>` and `Watching for location change...`.
5. (Optional) In a Navigation API–capable browser the event fires immediately; with the polling fallback (e.g. force it by disabling the API in code or using an older browser) the same log appears within ~1s.

### Related Issue

This PR closes #1567
