### PR TITLE
fix: surface errors for aliased CLI commands

### DIFF
--- a/packages/wxt/src/cli/cli-utils.ts
+++ b/packages/wxt/src/cli/cli-utils.ts
@@ -94,8 +94,11 @@ export function createAliasedCommand(
         await spawn(bin, args, {
           stdio: 'inherit',
         });
-      } catch {
-        // Let the other aliased CLI log errors, just exit
+      } catch (err) {
+        consola.fail('Command failed');
+        if (!(err instanceof ValidationError)) {
+          consola.error(err);
+        }
         process.exit(1);
       }
     });


### PR DESCRIPTION
### Overview

This PR improves error visibility for aliased CLI commands (specifically `wxt submit ...`).

Previously, `createAliasedCommand` swallowed all thrown errors and exited with code `1`, which could result in a silent failure (for example: `wxt submit init` exiting without a useful error).  
Now it follows the same error handling pattern as other WXT CLI actions by:

- Logging a failure message via `consola.fail('Command failed')`
- Logging non-validation errors with `consola.error(err)`
- Exiting with code `1`

This makes submit-related failures diagnosable instead of opaque.

### Manual Testing

1. From `packages/wxt`, run a submit command that fails (for example, in an env missing required submit config/secrets):
   - `pnpm wxt submit init`
2. Confirm output now includes:
   - `Command failed`
   - The underlying error details (for non-`ValidationError` failures)
3. Confirm process still exits with code `1`.
4. Confirm non-submit commands are unaffected.

### 🔗 Related Issues

- Fix [#2129](https://github.com/wxt-dev/wxt/issues/2129)
