### PR TITLE
docs: Add `wxt-local-analytics` to community resources

### DIFF
--- a/docs/guide/resources/community.md
+++ b/docs/guide/resources/community.md
@@ -13,3 +13,4 @@ This page is dedicated to all the awesome people how have made something for WXT
 
 - [`@webext-core/*`](https://webext-core.aklinker1.io/): Easy-to-use utilities for writing and testing web extensions that work on all browsers.
 - [`Comctx`](https://github.com/molvqingtai/comctx): Cross-context RPC solution with type safety and flexible adapters.
+- [`wxt-local-analytics`](https://github.com/HaNdTriX/wxt-local-analytics): Local analytics provider for [`@wxt-dev/analytics`](https://wxt.dev/analytics)


### PR DESCRIPTION
### Overview

Added [wxt-local-analytics](https://github.com/HaNdTriX/wxt-local-analytics) to the Community Resources page. This package provides a local analytics provider compatible with @wxt-dev/analytics.

### Resources

- https://www.npmjs.com/package/wxt-local-analytics
- https://github.com/HaNdTriX/wxt-local-analytics

-----------


@aklinker1 if you like to add the logic directly to the wxt repository I can create a PR and deprecate the community package.