### PR TITLE
ci: Fix `scripts/list_unreleased_commits.sh`

### DIFF
--- a/.github/workflows/notify-unreleased-commits.yml
+++ b/.github/workflows/notify-unreleased-commits.yml
@@ -17,7 +17,6 @@ jobs:
       - name: List Commits
         id: list-commits
         run: |
-          ./scripts/list-unreleased-commits.sh
           ./scripts/list-unreleased-commits.sh > summary.txt
 
       - name: Discord notification


### PR DESCRIPTION
### Overview

Grep was exiting with code 1 when it couldn't find any matches for the `is-background` package.
