### PR TITLE
chore: remove useDefineForClassFields from svelte/tsconfig.json

### DIFF
--- a/templates/svelte/tsconfig.json
+++ b/templates/svelte/tsconfig.json
@@ -1,6 +1,3 @@
 {
-  "extends": "./.wxt/tsconfig.json",
-  "compilerOptions": {
-    "useDefineForClassFields": true
-  }
+  "extends": "./.wxt/tsconfig.json"
 }


### PR DESCRIPTION
### Overview

As https://www.typescriptlang.org/tsconfig/#useDefineForClassFields says, `useDefineForClassFields` will default to `true` when [target](https://www.typescriptlang.org/tsconfig/#target) is ES2022 or higher, including ESNext.

Since wxt uses `target: ESNext` by default, we can omit this option.

### Manual Testing

Removed it and tested in my project.

### Related Issue

None.
