### PR TITLE
fix: unlisted script return values broken with Vite 8 sourcemaps

### DIFF
--- a/packages/wxt/src/core/builders/vite/plugins/__tests__/iifeFooter.test.ts
+++ b/packages/wxt/src/core/builders/vite/plugins/__tests__/iifeFooter.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, it } from 'vitest';
+import { iifeFooter } from '../iifeFooter';
+
+interface OutputChunk {
+  type: 'chunk';
+  code: string;
+  isEntry: boolean;
+}
+
+interface OutputAsset {
+  type: 'asset';
+  source: string;
+}
+
+type OutputBundle = Record<string, OutputChunk | OutputAsset>;
+
+function dedent(code: string) {
+  const lines = code.trim().split('\n');
+  return lines.map((line) => line.trimStart()).join('\n');
+}
+
+function createBundle(code: string): OutputBundle {
+  return {
+    'entry.js': {
+      type: 'chunk',
+      code: dedent(code),
+      isEntry: true,
+    },
+  };
+}
+
+function getCode(bundle: OutputBundle): string {
+  const entry = bundle['entry.js'];
+
+  if (entry.type !== 'chunk') {
+    throw new Error('expected chunk');
+  }
+
+  return entry.code;
+}
+
+function runPlugin(name: string, bundle: OutputBundle) {
+  const plugin = iifeFooter(name);
+  // @ts-expect-error -- calling the hook directly
+  plugin.generateBundle(undefined, bundle);
+}
+
+describe('IIFE return value plugin', () => {
+  it('should append return value when no sourcemap comment', () => {
+    const bundle = createBundle(`
+      var foo = (function(){return 1})();
+    `);
+
+    runPlugin('foo', bundle);
+
+    expect(getCode(bundle)).toBe(
+      dedent(`
+        var foo = (function(){return 1})();
+        foo;
+      `),
+    );
+  });
+
+  it('should insert return value before sourcemap comment', () => {
+    const bundle = createBundle(`
+      var foo = (function(){return 1})();
+      //# ${'sourceMappingURL'}=foo.js.map
+    `);
+
+    runPlugin('foo', bundle);
+
+    expect(getCode(bundle)).toBe(
+      dedent(`
+        var foo = (function(){return 1})();
+        foo;
+        //# ${'sourceMappingURL'}=foo.js.map
+      `),
+    );
+  });
+
+  it('should insert return value before inline sourcemap', () => {
+    const bundle = createBundle(`
+      var foo = (function(){return 1})();
+      //# ${'sourceMappingURL'}=data:application/json;base64,abc123
+    `);
+
+    runPlugin('foo', bundle);
+
+    expect(getCode(bundle)).toBe(
+      dedent(`
+        var foo = (function(){return 1})();
+        foo;
+        //# ${'sourceMappingURL'}=data:application/json;base64,abc123
+      `),
+    );
+  });
+
+  it('should skip non-entry chunks', () => {
+    const bundle = createBundle('var x = 1;');
+    (bundle['entry.js'] as OutputChunk).isEntry = false;
+
+    runPlugin('x', bundle);
+
+    expect(getCode(bundle)).toBe('var x = 1;');
+  });
+
+  it('should skip assets', () => {
+    const bundle: OutputBundle = {
+      'style.css': {
+        type: 'asset',
+        source: 'body {}',
+      } satisfies OutputAsset,
+    };
+
+    runPlugin('style', bundle);
+
+    expect((bundle['style.css'] as OutputAsset).source).toBe('body {}');
+  });
+});

--- a/packages/wxt/src/core/builders/vite/plugins/iifeFooter.ts
+++ b/packages/wxt/src/core/builders/vite/plugins/iifeFooter.ts
@@ -13,7 +13,20 @@ export function iifeFooter(iifeReturnValueName: string): Plugin {
     generateBundle(_, bundle) {
       for (const chunk of Object.values(bundle)) {
         if (chunk.type === 'chunk' && chunk.isEntry) {
-          chunk.code += `${iifeReturnValueName};`;
+          const code = chunk.code;
+          const marker = '\n//# sourceMappingURL=';
+          const returnValue = `${iifeReturnValueName};`;
+
+          const index = code.indexOf(marker);
+
+          if (index >= 0) {
+            chunk.code =
+              code.slice(0, index + 1) +
+              `${returnValue}\n` +
+              code.slice(index + 1);
+          } else {
+            chunk.code += `\n${returnValue}`;
+          }
         }
       }
     },


### PR DESCRIPTION
### Overview

After trying to upgraded to Vite 8 the extension I was working on broke. After some debugging it turns out that there is now an extra sourcemapping url at the bottom of chunks and this breaks the `iifeFooter` plugin. It always appends the return value statement directly after `chunk.code` and with Vite 8 it ends up on the same line as the `//` comment. So it is being commented out, resulting in `null` being the result of every script invocation.

The fix inserts the footer before the sourcemap comment when one is present and I also added a few tests that verifies it is working as expected (and they fail without the fix) 🙂

Screenshots of bundled script in dev mode:
| Before | After |
| --- | --- |
| <img width="360" height="90" alt="Screenshot 2026-03-17 at 11 47 56" src="https://github.com/user-attachments/assets/8472e135-a832-40a5-96bb-8d4a7f61e6d5" /> | <img width="290" height="94" alt="Screenshot 2026-03-17 at 11 48 22" src="https://github.com/user-attachments/assets/38935d4b-232b-4331-833d-a9e032680732" /> |

### Manual Testing

  1. Create a project and install Vite 8
  2. Create an unlisted script that returns a value 
  3. Run `wxt dev`
  4. Call `browser.scripting.executeScript` with the unlisted script
  5. Verify the return value is captured, without the fix it will always be `null`