### PR TITLE
fix: use git ls-files for sources zip to respect .gitignore

### DIFF
--- a/packages/wxt/src/core/zip.ts
+++ b/packages/wxt/src/core/zip.ts
@@ -77,7 +77,6 @@ export async function zip(config?: InlineConfig): Promise<string[]> {
     await zipDir(wxt.config.zip.sourcesRoot, sourcesZipPath, {
       include: wxt.config.zip.includeSources,
       exclude: excludeSources,
-      useGit: true,
       transform(absolutePath, zipPath, content) {
         if (zipPath.endsWith('package.json')) {
           return addOverridesToPackageJson(absolutePath, content, overrides);
@@ -107,7 +106,6 @@ async function zipDir(
   options?: {
     include?: string[];
     exclude?: string[];
-    useGit?: boolean;
     transform?: (
       absolutePath: string,
       zipPath: string,
@@ -129,18 +127,17 @@ async function zipDir(
     });
 
   let allFiles: string[];
-  if (options?.useGit) {
-    try {
-      allFiles = execSync('git ls-files --recurse-submodules', {
-        cwd: directory,
-        encoding: 'utf-8',
-      })
-        .split('\n')
-        .filter(Boolean);
-    } catch {
-      allFiles = await globFiles();
-    }
-  } else {
+  try {
+    allFiles = execSync('git ls-files --recurse-submodules', {
+      cwd: directory,
+      encoding: 'utf-8',
+    })
+      .split('\n')
+      .filter(Boolean);
+  } catch {
+    allFiles = [];
+  }
+  if (allFiles.length === 0) {
     allFiles = await globFiles();
   }
 

--- a/packages/wxt/src/core/zip.ts
+++ b/packages/wxt/src/core/zip.ts
@@ -1,5 +1,6 @@
 import { InlineConfig } from '../types';
 import path from 'node:path';
+import { execSync } from 'node:child_process';
 import { mkdir, readFile } from 'node:fs/promises';
 import { createWriteStream } from 'node:fs';
 import { safeFilename } from './utils/strings';
@@ -76,6 +77,7 @@ export async function zip(config?: InlineConfig): Promise<string[]> {
     await zipDir(wxt.config.zip.sourcesRoot, sourcesZipPath, {
       include: wxt.config.zip.includeSources,
       exclude: excludeSources,
+      useGit: true,
       transform(absolutePath, zipPath, content) {
         if (zipPath.endsWith('package.json')) {
           return addOverridesToPackageJson(absolutePath, content, overrides);
@@ -105,6 +107,7 @@ async function zipDir(
   options?: {
     include?: string[];
     exclude?: string[];
+    useGit?: boolean;
     transform?: (
       absolutePath: string,
       zipPath: string,
@@ -115,15 +118,33 @@ async function zipDir(
   },
 ): Promise<void> {
   const archive = new JSZip();
-  const files = (
-    await glob(['**/*', ...(options?.include || [])], {
+
+  const globFiles = () =>
+    glob(['**/*', ...(options?.include || [])], {
       cwd: directory,
       // Ignore node_modules, otherwise this glob step takes forever
       ignore: ['**/node_modules'],
       onlyFiles: true,
       expandDirectories: false,
-    })
-  ).filter((relativePath) => {
+    });
+
+  let allFiles: string[];
+  if (options?.useGit) {
+    try {
+      allFiles = execSync('git ls-files --recurse-submodules', {
+        cwd: directory,
+        encoding: 'utf-8',
+      })
+        .split('\n')
+        .filter(Boolean);
+    } catch {
+      allFiles = await globFiles();
+    }
+  } else {
+    allFiles = await globFiles();
+  }
+
+  const files = allFiles.filter((relativePath) => {
     return (
       picomatchMultiple(relativePath, options?.include) ||
       !picomatchMultiple(relativePath, options?.exclude)


### PR DESCRIPTION
### Overview

Sources ZIP uses tinyglobby which traverses the full directory tree before filtering, causing it to hang or balloon when gitignored directories like Rust's target/ exist locally. Switch to git ls-files --recurse-submodules for the sources ZIP since it should only contain what git tracks anyway. Falls back to the existing glob behavior if git is unavailable.

### Manual Testing

1. Have a project with large gitignored directories (e.g. a built Rust submodule with a target/ dir)
2. Run wxt zip -b firefox
3. Before: Produces a bloated ZIP. After: Completes quickly with only git-tracked files.
