### PR TITLE
docs: Add TF2 Trader to the list of extensions

### DIFF
--- a/docs/assets/extension-showcase.yml
+++ b/docs/assets/extension-showcase.yml
@@ -433,3 +433,6 @@
 
 - # AlarmBot: ULTIMATE Web Monitoring & Smart Price Alerts
   chromeId: mpckalcodookackleecihhnngdibelif
+
+- # TF2 Trader - TF2 & Steam Trading Extension - https://github.com/offish/tf2-trader
+  chromeId: gmicpekfpbikhibodgokfpghadkclhoe


### PR DESCRIPTION
### Overview

Added [TF2 Trader](https://github.com/offish/tf2-trader) to the "Who's Using WXT?" section
