### PR TITLE
fix: add Firefox action manifest typings

### DIFF
--- a/packages/wxt/src/types.ts
+++ b/packages/wxt/src/types.ts
@@ -965,10 +965,13 @@ export type UserManifest = {
 } & {
   // Add any Browser-specific or MV2 properties that WXT supports here
   action?: Browser.runtime.ManifestV3['action'] & {
-    browser_style?: boolean;
+    default_area?: 'navbar' | 'menupanel' | 'tabstrip' | 'personaltoolbar';
+    theme_icons?: ThemeIcon[];
   };
   browser_action?: Browser.runtime.ManifestV2['browser_action'] & {
     browser_style?: boolean;
+    default_area?: 'navbar' | 'menupanel' | 'tabstrip' | 'personaltoolbar';
+    theme_icons?: ThemeIcon[];
   };
   page_action?: Browser.runtime.ManifestV2['page_action'] & {
     browser_style?: boolean;


### PR DESCRIPTION
### Overview

Added FirefoxActionManifestOptions interface with browser_style, default_area, and theme_icons, and applied it to action, browser_action, and page_action in UserManifest.

### Manual Testing

- pnpm test run manifest passes

- Added default_area and theme_icons to wxt-demo/wxt.config.ts — no type errors, and the values appeared in the built manifest.json

### Related Issue

This PR closes #2096
