### PR TITLE
fix: resolve `url:` imports in Vite 8

### DIFF
--- a/packages/wxt/src/core/builders/vite/plugins/download.ts
+++ b/packages/wxt/src/core/builders/vite/plugins/download.ts
@@ -13,6 +13,7 @@ import { fetchCached } from '../../../utils/network';
 export function download(config: ResolvedConfig): Plugin {
   return {
     name: 'wxt:download',
+    enforce: 'pre',
     resolveId: {
       filter: {
         id: /^url:/,


### PR DESCRIPTION
### Overview

In Vite 8 (Rolldown), core plugins externalize `url:` prefixed imports before the `wxt:download` plugin's `resolveId` hook runs. The existing e2e test (`remote-code.test.ts`) passes on Vite 7 but fails on Vite 8 — the `url:` import appears verbatim in the built output instead of being downloaded and bundled. The fix is a single line: `enforce: 'pre'` on the download plugin, which moves it ahead of Vite's core plugins in the resolution order.

### Manual Testing

If you make the test suit target Vite 8, the tests will fail and catch that. I kept it out of this MR though since that feels out of scope.

### Related Issue

This PR closes #2216
