### PR TITLE
Security: Build-time remote code download lacks integrity verification

### DIFF
--- a/packages/wxt/src/core/builders/vite/plugins/download.ts
+++ b/packages/wxt/src/core/builders/vite/plugins/download.ts
@@ -1,3 +1,4 @@
+import { createHash } from 'node:crypto';
 import type { Plugin } from 'vite';
 import type { ResolvedConfig } from '../../../../types';
 import { fetchCached } from '../../../utils/network';
@@ -28,8 +29,26 @@ export function download(config: ResolvedConfig): Plugin {
         id: /^\x00url:/,
       },
       handler(id) {
-        const url = id.replace('\0url:', '');
-        return fetchCached(url, config);
+        const urlImport = id.replace('\0url:', '');
+        const integrityPrefix = '#sha256=';
+        const integrityIndex = urlImport.lastIndexOf(integrityPrefix);
+        if (integrityIndex === -1) {
+          throw new Error(`Missing integrity for URL import: ${urlImport}`);
+        }
+
+        const url = urlImport.slice(0, integrityIndex);
+        const expectedHash = urlImport.slice(integrityIndex + integrityPrefix.length).toLowerCase();
+        if (!expectedHash) {
+          throw new Error(`Missing SHA-256 digest for URL import: ${urlImport}`);
+        }
+
+        return fetchCached(url, config).then((content) => {
+          const actualHash = createHash('sha256').update(content).digest('hex');
+          if (actualHash !== expectedHash) {
+            throw new Error(`SHA-256 mismatch for URL import: ${url}`);
+          }
+          return content;
+        });
       },
     },
   };


### PR DESCRIPTION
## Problem

The `url:` import mechanism downloads arbitrary remote JavaScript and bundles it into the extension build. This creates a supply-chain risk if the remote source is compromised or unexpectedly changed, since no checksum/signature verification is enforced before inclusion.

**Severity**: `medium`
**File**: `packages/wxt/src/core/builders/vite/plugins/download.ts`

## Solution

Require integrity metadata (e.g., SHA-256) for `url:` imports, verify content hash before caching/bundling, and optionally enforce an allowlist of approved domains.

## Changes

- `packages/wxt/src/core/builders/vite/plugins/download.ts` (modified)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced
