### PR TITLE
chore(security): Reverse tabnabbing risk from `target="_blank"` links without `rel` protections

### DIFF
--- a/templates/react/entrypoints/popup/App.tsx
+++ b/templates/react/entrypoints/popup/App.tsx
@@ -9,10 +9,10 @@ function App() {
   return (
     <>
       <div>
-        <a href="https://wxt.dev" target="_blank">
+        <a href="https://wxt.dev" target="_blank" rel="noopener noreferrer">
           <img src={wxtLogo} className="logo" alt="WXT logo" />
         </a>
-        <a href="https://react.dev" target="_blank">
+        <a href="https://react.dev" target="_blank" rel="noopener noreferrer">
           <img src={reactLogo} className="logo react" alt="React logo" />
         </a>
       </div>

--- a/templates/solid/entrypoints/popup/App.tsx
+++ b/templates/solid/entrypoints/popup/App.tsx
@@ -9,10 +9,10 @@ function App() {
   return (
     <>
       <div>
-        <a href="https://wxt.dev" target="_blank">
+        <a href="https://wxt.dev" target="_blank" rel="noopener noreferrer">
           <img src={wxtLogo} class="logo" alt="WXT logo" />
         </a>
-        <a href="https://solidjs.com" target="_blank">
+        <a href="https://solidjs.com" target="_blank" rel="noopener noreferrer">
           <img src={solidLogo} class="logo solid" alt="Solid logo" />
         </a>
       </div>

--- a/templates/svelte/src/entrypoints/popup/App.svelte
+++ b/templates/svelte/src/entrypoints/popup/App.svelte
@@ -5,10 +5,10 @@
 
 <main>
   <div>
-    <a href="https://wxt.dev" target="_blank" rel="noreferrer">
+    <a href="https://wxt.dev" target="_blank" rel="noopener noreferrer">
       <img src="/wxt.svg" class="logo" alt="WXT Logo" />
     </a>
-    <a href="https://svelte.dev" target="_blank" rel="noreferrer">
+    <a href="https://svelte.dev" target="_blank" rel="noopener noreferrer">
       <img src={svelteLogo} class="logo svelte" alt="Svelte Logo" />
     </a>
   </div>

--- a/templates/vanilla/entrypoints/popup/main.ts
+++ b/templates/vanilla/entrypoints/popup/main.ts
@@ -5,10 +5,10 @@ import { setupCounter } from '@/components/counter';
 
 document.querySelector<HTMLDivElement>('#app')!.innerHTML = `
   <div>
-    <a href="https://wxt.dev" target="_blank">
+    <a href="https://wxt.dev" target="_blank" rel="noopener noreferrer">
       <img src="${wxtLogo}" class="logo" alt="WXT logo" />
     </a>
-    <a href="https://www.typescriptlang.org/" target="_blank">
+    <a href="https://www.typescriptlang.org/" target="_blank" rel="noopener noreferrer">
       <img src="${typescriptLogo}" class="logo vanilla" alt="TypeScript logo" />
     </a>
     <h1>WXT + TypeScript</h1>

--- a/templates/vue/components/HelloWorld.vue
+++ b/templates/vue/components/HelloWorld.vue
@@ -21,7 +21,12 @@ const count = ref(0);
 
   <p>
     Install
-    <a href="https://github.com/vuejs/language-tools" target="_blank">Volar</a>
+    <a
+      href="https://github.com/vuejs/language-tools"
+      target="_blank"
+      rel="noopener noreferrer"
+      >Volar</a
+    >
     in your IDE for a better DX
   </p>
   <p class="read-the-docs">Click on the WXT and Vue logos to learn more</p>

--- a/templates/vue/entrypoints/popup/App.vue
+++ b/templates/vue/entrypoints/popup/App.vue
@@ -4,10 +4,10 @@ import HelloWorld from '@/components/HelloWorld.vue';
 
 <template>
   <div>
-    <a href="https://wxt.dev" target="_blank">
+    <a href="https://wxt.dev" target="_blank" rel="noopener noreferrer">
       <img src="/wxt.svg" class="logo" alt="WXT logo" />
     </a>
-    <a href="https://vuejs.org/" target="_blank">
+    <a href="https://vuejs.org/" target="_blank" rel="noopener noreferrer">
       <img src="@/assets/vue.svg" class="logo vue" alt="Vue logo" />
     </a>
   </div>


### PR DESCRIPTION
## Problem

Multiple templates open external sites in new tabs with `target="_blank"` but without `rel="noopener noreferrer"`. Opened pages can access `window.opener` and potentially navigate the originating extension page.

**Severity**: `low`
**File**: `templates/react/entrypoints/popup/App.tsx`

## Solution

Add `rel="noopener noreferrer"` to all external links using `target="_blank"` across templates and docs components.

## Changes

- `templates/react/entrypoints/popup/App.tsx` (modified)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced
