### PR TITLE
feat: auto-discover Firefox `theme_icons` from public assets

### DIFF
--- a/docs/guide/essentials/config/manifest.md
+++ b/docs/guide/essentials/config/manifest.md
@@ -161,7 +161,9 @@ Alternatively, you can use [`@wxt-dev/auto-icons`](https://www.npmjs.com/package
 
 ### Firefox `theme_icons`
 
-Firefox supports a [`theme_icons`](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/action#theme_icons) field on the toolbar action that swaps between a light and dark variant based on the current browser theme. When building for Firefox, WXT auto-discovers paired light/dark icons in the `public/` directory and attaches them to `action` (MV3) or `browser_action` (MV2). You only need to drop both variants next to your regular icons:
+Firefox supports a [`theme_icons`](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/action#theme_icons) field on the toolbar action that swaps between a light and dark variant based on the current browser theme.
+
+When [targeting Firefox](/guide/essentials/target-different-browsers.md), WXT auto-discovers paired light/dark icons in the `public/` directory and attaches them to `action` (MV3) or `browser_action` (MV2). You only need to drop both variants next to your regular icons:
 
 ```plaintext
 public/
@@ -173,11 +175,15 @@ public/
 └─ icon-dark-32.png
 ```
 
-A size is only included in `theme_icons` if **both** a light and a dark file are present — unpaired files are silently skipped. The following filename patterns are discovered:
+A size is only included in `theme_icons` if **both** a light and a dark file are present. The following filename patterns are discovered:
 
 <<< @/../packages/wxt/src/core/utils/theme-icons.ts#snippet
 
-Auto-discovery is Firefox-only. If you set `manifest.action.theme_icons` (or `manifest.browser_action.theme_icons`) explicitly in `wxt.config.ts`, WXT will not overwrite it.
+If a size has a light file but no matching dark file (or vice versa), WXT logs a warning so you can fix the pair instead of silently dropping it. The same applies if two different naming patterns resolve to the same `(size, variant)` — WXT keeps the first match and warns about the collision.
+
+Only `.png` files are discovered today. Firefox's `theme_icons` also accepts SVG, but WXT doesn't yet support SVG icons for Firefox — follow [#1120](https://github.com/wxt-dev/wxt/issues/1120) for updates.
+
+If you set `manifest.action.theme_icons` (or `manifest.browser_action.theme_icons`) explicitly in `wxt.config.ts`, WXT will not overwrite it.
 
 ## Permissions
 

--- a/docs/guide/essentials/config/manifest.md
+++ b/docs/guide/essentials/config/manifest.md
@@ -179,9 +179,7 @@ A size is only included in `theme_icons` if **both** a light and a dark file are
 
 <<< @/../packages/wxt/src/core/utils/theme-icons.ts#snippet
 
-If a size has a light file but no matching dark file (or vice versa), WXT logs a warning so you can fix the pair instead of silently dropping it. The same applies if two different naming patterns resolve to the same `(size, variant)` — WXT keeps the first match and warns about the collision.
-
-Only `.png` files are discovered today. Firefox's `theme_icons` also accepts SVG, but WXT doesn't yet support SVG icons for Firefox — follow [#1120](https://github.com/wxt-dev/wxt/issues/1120) for updates.
+Only `.png` files are discovered today, even though Firefox supports `.svg` - follow [#1120](https://github.com/wxt-dev/wxt/issues/1120) for updates.
 
 If you set `manifest.action.theme_icons` (or `manifest.browser_action.theme_icons`) explicitly in `wxt.config.ts`, WXT will not overwrite it.
 

--- a/docs/guide/essentials/config/manifest.md
+++ b/docs/guide/essentials/config/manifest.md
@@ -159,6 +159,26 @@ export default defineConfig({
 
 Alternatively, you can use [`@wxt-dev/auto-icons`](https://www.npmjs.com/package/@wxt-dev/auto-icons) to let WXT generate your icon at the required sizes.
 
+### Firefox `theme_icons`
+
+Firefox supports a [`theme_icons`](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/action#theme_icons) field on the toolbar action that swaps between a light and dark variant based on the current browser theme. When building for Firefox, WXT auto-discovers paired light/dark icons in the `public/` directory and attaches them to `action` (MV3) or `browser_action` (MV2). You only need to drop both variants next to your regular icons:
+
+```plaintext
+public/
+├─ icon-16.png         # regular (default_icon)
+├─ icon-light-16.png   # Firefox light theme
+├─ icon-dark-16.png    # Firefox dark theme
+├─ icon-32.png
+├─ icon-light-32.png
+└─ icon-dark-32.png
+```
+
+A size is only included in `theme_icons` if **both** a light and a dark file are present — unpaired files are silently skipped. The following filename patterns are discovered:
+
+<<< @/../packages/wxt/src/core/utils/theme-icons.ts#snippet
+
+Auto-discovery is Firefox-only. If you set `manifest.action.theme_icons` (or `manifest.browser_action.theme_icons`) explicitly in `wxt.config.ts`, WXT will not overwrite it.
+
 ## Permissions
 
 > [Chrome docs](https://developer.chrome.com/docs/extensions/reference/permissions/)

--- a/packages/wxt/src/core/utils/__tests__/manifest.test.ts
+++ b/packages/wxt/src/core/utils/__tests__/manifest.test.ts
@@ -531,6 +531,250 @@ describe('Manifest Utils', () => {
       });
     });
 
+    describe('theme_icons auto-discovery (Firefox)', () => {
+      const firefoxPopup = () =>
+        fakePopupEntrypoint({
+          options: {
+            // @ts-expect-error: Force undefined instead of the random value
+            mv2Key: null,
+          },
+          outputDir: outDir,
+          skipped: false,
+        });
+
+      it('should auto-discover paired light/dark icons and attach them to action in mv3', async () => {
+        const popup = firefoxPopup();
+        const buildOutput = fakeBuildOutput({
+          publicAssets: [
+            { type: 'asset', fileName: 'icon-light-16.png' },
+            { type: 'asset', fileName: 'icon-dark-16.png' },
+            { type: 'asset', fileName: 'icon-light-32.png' },
+            { type: 'asset', fileName: 'icon-dark-32.png' },
+          ],
+        });
+        setFakeWxt({
+          config: {
+            browser: 'firefox',
+            manifestVersion: 3,
+            outDir,
+          },
+        });
+
+        const { manifest: actual } = await generateManifest(
+          [popup],
+          buildOutput,
+        );
+
+        expect((actual.action as any).theme_icons).toEqual([
+          { light: 'icon-light-16.png', dark: 'icon-dark-16.png', size: 16 },
+          { light: 'icon-light-32.png', dark: 'icon-dark-32.png', size: 32 },
+        ]);
+      });
+
+      it('should auto-discover and attach theme_icons to browser_action in mv2', async () => {
+        const popup = firefoxPopup();
+        const buildOutput = fakeBuildOutput({
+          publicAssets: [
+            { type: 'asset', fileName: 'icon/16-light.png' },
+            { type: 'asset', fileName: 'icon/16-dark.png' },
+          ],
+        });
+        setFakeWxt({
+          config: {
+            browser: 'firefox',
+            manifestVersion: 2,
+            outDir,
+          },
+        });
+
+        const { manifest: actual } = await generateManifest(
+          [popup],
+          buildOutput,
+        );
+
+        expect((actual.browser_action as any).theme_icons).toEqual([
+          { light: 'icon/16-light.png', dark: 'icon/16-dark.png', size: 16 },
+        ]);
+      });
+
+      it('should support every naming pattern (suffix, prefix, with/without folder, with/without widthxheight)', async () => {
+        const popup = firefoxPopup();
+        const buildOutput = fakeBuildOutput({
+          publicAssets: [
+            // suffix / no folder
+            { type: 'asset', fileName: 'icon-light-16.png' },
+            { type: 'asset', fileName: 'icon-dark-16.png' },
+            // suffix / WxH / no folder
+            { type: 'asset', fileName: 'icon-light-24x24.png' },
+            { type: 'asset', fileName: 'icon-dark-24x24.png' },
+            // prefix / no folder
+            { type: 'asset', fileName: 'icon-32-light.png' },
+            { type: 'asset', fileName: 'icon-32-dark.png' },
+            // suffix / folder
+            { type: 'asset', fileName: 'icon/light-48.png' },
+            { type: 'asset', fileName: 'icon/dark-48.png' },
+            // prefix / folder
+            { type: 'asset', fileName: 'icons/64-light.png' },
+            { type: 'asset', fileName: 'icons/64-dark.png' },
+            // prefix / WxH / folder
+            { type: 'asset', fileName: 'icon/128x128-light.png' },
+            { type: 'asset', fileName: 'icon/128x128-dark.png' },
+          ],
+        });
+        setFakeWxt({
+          config: {
+            browser: 'firefox',
+            manifestVersion: 3,
+            outDir,
+          },
+        });
+
+        const { manifest: actual } = await generateManifest(
+          [popup],
+          buildOutput,
+        );
+
+        expect((actual.action as any).theme_icons).toEqual([
+          { light: 'icon-light-16.png', dark: 'icon-dark-16.png', size: 16 },
+          {
+            light: 'icon-light-24x24.png',
+            dark: 'icon-dark-24x24.png',
+            size: 24,
+          },
+          { light: 'icon-32-light.png', dark: 'icon-32-dark.png', size: 32 },
+          { light: 'icon/light-48.png', dark: 'icon/dark-48.png', size: 48 },
+          { light: 'icons/64-light.png', dark: 'icons/64-dark.png', size: 64 },
+          {
+            light: 'icon/128x128-light.png',
+            dark: 'icon/128x128-dark.png',
+            size: 128,
+          },
+        ]);
+      });
+
+      it('should skip sizes that are missing a light or dark pair', async () => {
+        const popup = firefoxPopup();
+        const buildOutput = fakeBuildOutput({
+          publicAssets: [
+            // Complete pair — should be kept
+            { type: 'asset', fileName: 'icon-light-16.png' },
+            { type: 'asset', fileName: 'icon-dark-16.png' },
+            // Only light, no dark — should be dropped
+            { type: 'asset', fileName: 'icon-light-32.png' },
+            // Only dark, no light — should be dropped
+            { type: 'asset', fileName: 'icon-dark-48.png' },
+          ],
+        });
+        setFakeWxt({
+          config: {
+            browser: 'firefox',
+            manifestVersion: 3,
+            outDir,
+          },
+        });
+
+        const { manifest: actual } = await generateManifest(
+          [popup],
+          buildOutput,
+        );
+
+        expect((actual.action as any).theme_icons).toEqual([
+          { light: 'icon-light-16.png', dark: 'icon-dark-16.png', size: 16 },
+        ]);
+      });
+
+      it('should not auto-discover theme_icons for non-Firefox browsers', async () => {
+        const popup = firefoxPopup();
+        const buildOutput = fakeBuildOutput({
+          publicAssets: [
+            { type: 'asset', fileName: 'icon-light-16.png' },
+            { type: 'asset', fileName: 'icon-dark-16.png' },
+          ],
+        });
+        setFakeWxt({
+          config: {
+            browser: 'chrome',
+            manifestVersion: 3,
+            outDir,
+          },
+        });
+
+        const { manifest: actual } = await generateManifest(
+          [popup],
+          buildOutput,
+        );
+
+        expect((actual.action as any).theme_icons).toBeUndefined();
+      });
+
+      it('should respect user-provided theme_icons and not overwrite them', async () => {
+        const userThemeIcons = [
+          { light: 'custom-light.png', dark: 'custom-dark.png', size: 16 },
+        ];
+        const popup = fakePopupEntrypoint({
+          options: {
+            // @ts-expect-error: Force undefined
+            mv2Key: null,
+            themeIcons: userThemeIcons,
+          },
+          outputDir: outDir,
+          skipped: false,
+        });
+        const buildOutput = fakeBuildOutput({
+          publicAssets: [
+            { type: 'asset', fileName: 'icon-light-16.png' },
+            { type: 'asset', fileName: 'icon-dark-16.png' },
+            { type: 'asset', fileName: 'icon-light-32.png' },
+            { type: 'asset', fileName: 'icon-dark-32.png' },
+          ],
+        });
+        setFakeWxt({
+          config: {
+            browser: 'firefox',
+            manifestVersion: 3,
+            outDir,
+          },
+        });
+
+        const { manifest: actual } = await generateManifest(
+          [popup],
+          buildOutput,
+        );
+
+        expect((actual.action as any).theme_icons).toEqual(userThemeIcons);
+      });
+
+      it('should not attach theme_icons when there is no action at all', async () => {
+        // A background entrypoint with no popup means no action is
+        // declared, so we have nothing to attach theme_icons to.
+        const background = fakeBackgroundEntrypoint({
+          outputDir: outDir,
+          skipped: false,
+        });
+        const buildOutput = fakeBuildOutput({
+          publicAssets: [
+            { type: 'asset', fileName: 'icon-light-16.png' },
+            { type: 'asset', fileName: 'icon-dark-16.png' },
+          ],
+        });
+        setFakeWxt({
+          config: {
+            browser: 'firefox',
+            manifestVersion: 3,
+            outDir,
+          },
+        });
+
+        const { manifest: actual } = await generateManifest(
+          [background],
+          buildOutput,
+        );
+
+        expect(actual.action).toBeUndefined();
+        expect(actual.browser_action).toBeUndefined();
+      });
+    });
+
     describe('content_scripts', () => {
       it('should group content scripts and styles together based on their manifest properties', async () => {
         const cs1: ContentScriptEntrypoint = {

--- a/packages/wxt/src/core/utils/__tests__/manifest.test.ts
+++ b/packages/wxt/src/core/utils/__tests__/manifest.test.ts
@@ -597,7 +597,7 @@ describe('Manifest Utils', () => {
         ]);
       });
 
-      it('should support every naming pattern (suffix, prefix, with/without folder, with/without widthxheight)', async () => {
+      it('should support every naming pattern (suffix, prefix, with/without folder, with/without WxH)', async () => {
         const popup = firefoxPopup();
         const buildOutput = fakeBuildOutput({
           publicAssets: [
@@ -652,16 +652,16 @@ describe('Manifest Utils', () => {
         ]);
       });
 
-      it('should skip sizes that are missing a light or dark pair', async () => {
+      it('should skip sizes that are missing a light or dark pair and log a warning', async () => {
         const popup = firefoxPopup();
         const buildOutput = fakeBuildOutput({
           publicAssets: [
             // Complete pair — should be kept
             { type: 'asset', fileName: 'icon-light-16.png' },
             { type: 'asset', fileName: 'icon-dark-16.png' },
-            // Only light, no dark — should be dropped
+            // Only light, no dark — should be dropped + warn
             { type: 'asset', fileName: 'icon-light-32.png' },
-            // Only dark, no light — should be dropped
+            // Only dark, no light — should be dropped + warn
             { type: 'asset', fileName: 'icon-dark-48.png' },
           ],
         });
@@ -681,6 +681,50 @@ describe('Manifest Utils', () => {
         expect((actual.action as any).theme_icons).toEqual([
           { light: 'icon-light-16.png', dark: 'icon-dark-16.png', size: 16 },
         ]);
+        expect(wxt.logger.warn).toHaveBeenCalledWith(
+          expect.stringContaining(
+            'Skipping theme icon size 32: found light variant',
+          ),
+        );
+        expect(wxt.logger.warn).toHaveBeenCalledWith(
+          expect.stringContaining(
+            'Skipping theme icon size 48: found dark variant',
+          ),
+        );
+      });
+
+      it('should warn when different naming patterns resolve to the same (size, variant)', async () => {
+        const popup = firefoxPopup();
+        const buildOutput = fakeBuildOutput({
+          publicAssets: [
+            // Both of these match the light/16 slot via different regexes.
+            // WXT should keep the first and warn about the second.
+            { type: 'asset', fileName: 'icon-light-16.png' },
+            { type: 'asset', fileName: 'icon/light-16.png' },
+            { type: 'asset', fileName: 'icon-dark-16.png' },
+          ],
+        });
+        setFakeWxt({
+          config: {
+            browser: 'firefox',
+            manifestVersion: 3,
+            outDir,
+          },
+        });
+
+        const { manifest: actual } = await generateManifest(
+          [popup],
+          buildOutput,
+        );
+
+        expect((actual.action as any).theme_icons).toEqual([
+          { light: 'icon-light-16.png', dark: 'icon-dark-16.png', size: 16 },
+        ]);
+        expect(wxt.logger.warn).toHaveBeenCalledWith(
+          expect.stringContaining(
+            'Multiple theme icon files matched size 16 variant "light"',
+          ),
+        );
       });
 
       it('should not auto-discover theme_icons for non-Firefox browsers', async () => {

--- a/packages/wxt/src/core/utils/manifest.ts
+++ b/packages/wxt/src/core/utils/manifest.ts
@@ -20,6 +20,7 @@ import { normalizePath } from './paths';
 import { writeFileIfDifferent } from './fs';
 import defu from 'defu';
 import { wxt } from '../wxt';
+import { addDiscoveredThemeIcons } from './theme-icons';
 import { ManifestV3WebAccessibleResource } from './types';
 import type { Browser } from '@wxt-dev/browser';
 
@@ -115,6 +116,14 @@ export async function generateManifest(
       : versionName;
 
   addEntrypoints(manifest, entrypoints, buildOutput);
+
+  // Auto-discover Firefox theme_icons from paired `-light`/`-dark`
+  // files in the public assets. Runs after `addEntrypoints` so we can
+  // attach to whichever action the popup entrypoint set up, and before
+  // `build:manifestGenerated` so user hooks can still override.
+  if (wxt.config.browser === 'firefox') {
+    addDiscoveredThemeIcons(manifest, buildOutput);
+  }
 
   if (wxt.config.command === 'serve') addDevModeCsp(manifest);
   if (wxt.config.command === 'serve') addDevModePermissions(manifest);

--- a/packages/wxt/src/core/utils/manifest.ts
+++ b/packages/wxt/src/core/utils/manifest.ts
@@ -117,10 +117,6 @@ export async function generateManifest(
 
   addEntrypoints(manifest, entrypoints, buildOutput);
 
-  // Auto-discover Firefox theme_icons from paired `-light`/`-dark`
-  // files in the public assets. Runs after `addEntrypoints` so we can
-  // attach to whichever action the popup entrypoint set up, and before
-  // `build:manifestGenerated` so user hooks can still override.
   if (wxt.config.browser === 'firefox') {
     addDiscoveredThemeIcons(manifest, buildOutput);
   }

--- a/packages/wxt/src/core/utils/theme-icons.ts
+++ b/packages/wxt/src/core/utils/theme-icons.ts
@@ -1,0 +1,81 @@
+import type { Browser } from '@wxt-dev/browser';
+import type { BuildOutput, ThemeIcon } from '../../types';
+import { normalizePath } from './paths';
+
+/**
+ * If the manifest has an action (or browser/page_action) and the user has not
+ * already set `theme_icons` on it, discover light/dark icon pairs from the
+ * public assets and attach them.
+ *
+ * Firefox-only; the caller gates on `wxt.config.browser`.
+ */
+export function addDiscoveredThemeIcons(
+  manifest: Browser.runtime.Manifest,
+  buildOutput: Omit<BuildOutput, 'manifest'>,
+): void {
+  // The popup entrypoint sets `manifest.action` in MV3 and either
+  // `browser_action` or `page_action` in MV2 (see addEntrypoints in
+  // manifest.ts). Users can also declare any of these via wxt.config.ts.
+  // We attach to the one that already exists — the MV2 conversion step
+  // (convertActionToMv2) later copies `action` → `browser_action` if
+  // needed.
+  const action =
+    manifest.action ?? manifest.browser_action ?? manifest.page_action;
+  if (action == null) return;
+
+  // Respect explicit user config or popup entrypoint option.
+  if ((action as { theme_icons?: ThemeIcon[] }).theme_icons != null) return;
+
+  const themeIcons = discoverThemeIcons(buildOutput);
+  if (themeIcons == null) return;
+
+  (action as { theme_icons?: ThemeIcon[] }).theme_icons = themeIcons;
+}
+
+/**
+ * Scan `publicAssets` for paired `-light`/`-dark` icon files and return the
+ * sizes where both variants exist, sorted ascending. Returns `undefined` if no
+ * complete pairs are found so callers can short-circuit.
+ */
+export function discoverThemeIcons(
+  buildOutput: Omit<BuildOutput, 'manifest'>,
+): ThemeIcon[] | undefined {
+  const bySize = new Map<number, { light?: string; dark?: string }>();
+
+  for (const asset of buildOutput.publicAssets) {
+    for (const regex of themeIconRegex) {
+      const match = asset.fileName.match(regex);
+      if (match?.groups == null) continue;
+      const size = Number(match.groups.size);
+      const variant = match.groups.variant as 'light' | 'dark';
+      const entry = bySize.get(size) ?? {};
+      entry[variant] = normalizePath(asset.fileName);
+      bySize.set(size, entry);
+      break;
+    }
+  }
+
+  const pairs = Array.from(bySize.entries())
+    .filter(
+      (entry): entry is [number, { light: string; dark: string }] =>
+        entry[1].light != null && entry[1].dark != null,
+    )
+    .map(([size, { light, dark }]) => ({ light, dark, size }))
+    .sort((a, b) => a.size - b.size);
+
+  return pairs.length > 0 ? pairs : undefined;
+}
+
+// prettier-ignore
+// #region snippet
+const themeIconRegex = [
+  /^icon-(?<variant>light|dark)-(?<size>[0-9]+)\.png$/,              // icon-light-16.png
+  /^icon-(?<variant>light|dark)-(?<size>[0-9]+)x[0-9]+\.png$/,       // icon-light-16x16.png
+  /^icon-(?<size>[0-9]+)-(?<variant>light|dark)\.png$/,              // icon-16-light.png
+  /^icon-(?<size>[0-9]+)x[0-9]+-(?<variant>light|dark)\.png$/,       // icon-16x16-light.png
+  /^icons?[/\\](?<variant>light|dark)-(?<size>[0-9]+)\.png$/,        // icon/light-16.png | icons/light-16.png
+  /^icons?[/\\](?<variant>light|dark)-(?<size>[0-9]+)x[0-9]+\.png$/, // icon/light-16x16.png
+  /^icons?[/\\](?<size>[0-9]+)-(?<variant>light|dark)\.png$/,        // icon/16-light.png
+  /^icons?[/\\](?<size>[0-9]+)x[0-9]+-(?<variant>light|dark)\.png$/, // icon/16x16-light.png
+];
+// #endregion snippet

--- a/packages/wxt/src/core/utils/theme-icons.ts
+++ b/packages/wxt/src/core/utils/theme-icons.ts
@@ -4,14 +4,11 @@ import { normalizePath } from './paths';
 import { wxt } from '../wxt';
 
 /**
+ * Firefox only.
+ *
  * If the manifest has an `action` (MV3) or `browser_action` (MV2) and the user
  * has not already set `theme_icons` on it, discover light/dark icon pairs from
  * the public assets and attach them.
- *
- * `page_action` is intentionally excluded: Firefox does not honor `theme_icons`
- * on page actions.
- *
- * Firefox-only; the caller gates on `wxt.config.browser`.
  */
 export function addDiscoveredThemeIcons(
   manifest: Browser.runtime.Manifest,
@@ -33,10 +30,6 @@ export function addDiscoveredThemeIcons(
  * Scan `publicAssets` for paired `-light`/`-dark` icon files and return the
  * sizes where both variants exist, sorted ascending. Returns `undefined` if no
  * complete pairs are found so callers can short-circuit.
- *
- * Warnings are logged for mixed-naming collisions and for sizes that are
- * missing a light or dark pair, so users notice misnamed files rather than
- * having them silently dropped.
  */
 export function discoverThemeIcons(
   buildOutput: Omit<BuildOutput, 'manifest'>,
@@ -47,20 +40,20 @@ export function discoverThemeIcons(
     for (const regex of themeIconRegex) {
       const match = asset.fileName.match(regex);
       if (match?.groups == null) continue;
+
       const size = Number(match.groups.size);
       const variant = match.groups.variant as 'light' | 'dark';
       const entry = bySize.get(size) ?? {};
+
       const incoming = normalizePath(asset.fileName);
       const existing = entry[variant];
       if (existing != null && existing !== incoming) {
-        // Multiple files resolved to the same (size, variant) via different
-        // naming conventions — keep the first match and warn so the user
-        // can consolidate to a single pattern.
         wxt.logger.warn(
           `Multiple theme icon files matched size ${size} variant "${variant}": keeping "${existing}", ignoring "${incoming}". Use a single naming pattern per (size, variant).`,
         );
         break;
       }
+
       entry[variant] = incoming;
       bySize.set(size, entry);
       break;
@@ -85,9 +78,6 @@ export function discoverThemeIcons(
   return pairs.length > 0 ? pairs : undefined;
 }
 
-// SVG is not supported yet — Firefox's `theme_icons` accepts SVG, but WXT
-// does not currently discover SVG icons for Firefox in general. Tracked as
-// a follow-up; widen the extension match once SVG icons are supported.
 // prettier-ignore
 // #region snippet
 const themeIconRegex = [

--- a/packages/wxt/src/core/utils/theme-icons.ts
+++ b/packages/wxt/src/core/utils/theme-icons.ts
@@ -1,11 +1,15 @@
 import type { Browser } from '@wxt-dev/browser';
 import type { BuildOutput, ThemeIcon } from '../../types';
 import { normalizePath } from './paths';
+import { wxt } from '../wxt';
 
 /**
- * If the manifest has an action (or browser/page_action) and the user has not
- * already set `theme_icons` on it, discover light/dark icon pairs from the
- * public assets and attach them.
+ * If the manifest has an `action` (MV3) or `browser_action` (MV2) and the user
+ * has not already set `theme_icons` on it, discover light/dark icon pairs from
+ * the public assets and attach them.
+ *
+ * `page_action` is intentionally excluded: Firefox does not honor `theme_icons`
+ * on page actions.
  *
  * Firefox-only; the caller gates on `wxt.config.browser`.
  */
@@ -13,14 +17,7 @@ export function addDiscoveredThemeIcons(
   manifest: Browser.runtime.Manifest,
   buildOutput: Omit<BuildOutput, 'manifest'>,
 ): void {
-  // The popup entrypoint sets `manifest.action` in MV3 and either
-  // `browser_action` or `page_action` in MV2 (see addEntrypoints in
-  // manifest.ts). Users can also declare any of these via wxt.config.ts.
-  // We attach to the one that already exists — the MV2 conversion step
-  // (convertActionToMv2) later copies `action` → `browser_action` if
-  // needed.
-  const action =
-    manifest.action ?? manifest.browser_action ?? manifest.page_action;
+  const action = manifest.action ?? manifest.browser_action;
   if (action == null) return;
 
   // Respect explicit user config or popup entrypoint option.
@@ -36,6 +33,10 @@ export function addDiscoveredThemeIcons(
  * Scan `publicAssets` for paired `-light`/`-dark` icon files and return the
  * sizes where both variants exist, sorted ascending. Returns `undefined` if no
  * complete pairs are found so callers can short-circuit.
+ *
+ * Warnings are logged for mixed-naming collisions and for sizes that are
+ * missing a light or dark pair, so users notice misnamed files rather than
+ * having them silently dropped.
  */
 export function discoverThemeIcons(
   buildOutput: Omit<BuildOutput, 'manifest'>,
@@ -49,23 +50,44 @@ export function discoverThemeIcons(
       const size = Number(match.groups.size);
       const variant = match.groups.variant as 'light' | 'dark';
       const entry = bySize.get(size) ?? {};
-      entry[variant] = normalizePath(asset.fileName);
+      const incoming = normalizePath(asset.fileName);
+      const existing = entry[variant];
+      if (existing != null && existing !== incoming) {
+        // Multiple files resolved to the same (size, variant) via different
+        // naming conventions — keep the first match and warn so the user
+        // can consolidate to a single pattern.
+        wxt.logger.warn(
+          `Multiple theme icon files matched size ${size} variant "${variant}": keeping "${existing}", ignoring "${incoming}". Use a single naming pattern per (size, variant).`,
+        );
+        break;
+      }
+      entry[variant] = incoming;
       bySize.set(size, entry);
       break;
     }
   }
 
-  const pairs = Array.from(bySize.entries())
-    .filter(
-      (entry): entry is [number, { light: string; dark: string }] =>
-        entry[1].light != null && entry[1].dark != null,
-    )
-    .map(([size, { light, dark }]) => ({ light, dark, size }))
-    .sort((a, b) => a.size - b.size);
+  const pairs: ThemeIcon[] = [];
+  for (const [size, entry] of bySize) {
+    if (entry.light != null && entry.dark != null) {
+      pairs.push({ light: entry.light, dark: entry.dark, size });
+      continue;
+    }
+    const present = entry.light != null ? 'light' : 'dark';
+    const missing = entry.light != null ? 'dark' : 'light';
+    const file = entry.light ?? entry.dark;
+    wxt.logger.warn(
+      `Skipping theme icon size ${size}: found ${present} variant ("${file}") but no matching ${missing} variant. Add the missing file to include this size in theme_icons.`,
+    );
+  }
+  pairs.sort((a, b) => a.size - b.size);
 
   return pairs.length > 0 ? pairs : undefined;
 }
 
+// SVG is not supported yet — Firefox's `theme_icons` accepts SVG, but WXT
+// does not currently discover SVG icons for Firefox in general. Tracked as
+// a follow-up; widen the extension match once SVG icons are supported.
 // prettier-ignore
 // #region snippet
 const themeIconRegex = [


### PR DESCRIPTION
## Summary

When building for Firefox, WXT now auto-discovers paired `-light`/`-dark` icons in the public assets and attaches them to the extension action's [`theme_icons`](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/action#theme_icons) field, parallel to how regular icons are already discovered and put on the top-level `icons` field. Users can now drop both variants in `public/` and Firefox will swap the toolbar icon based on the browser theme — no manual manifest entry required.

```plaintext
public/
├─ icon-16.png          # regular (default_icon)
├─ icon-light-16.png    # Firefox light theme
├─ icon-dark-16.png     # Firefox dark theme
├─ icon-32.png
├─ icon-light-32.png
└─ icon-dark-32.png
```

### Behavior

- **Firefox-only.** The discovery call site in `generateManifest` is gated on `wxt.config.browser === 'firefox'`.
- **Attaches wherever the action already lives.** `manifest.action` (MV3), `manifest.browser_action` or `manifest.page_action` (MV2). The existing MV2 conversion (`convertActionToMv2`) handles `action` → `browser_action` copying downstream.
- **Skips when no action exists** — e.g. background-only extensions. Nothing to attach to.
- **Skips unpaired sizes.** A size is only emitted if both `light` and `dark` variants are present.
- **Respects explicit user config.** If `manifest.action.theme_icons` is already set (via `wxt.config.ts` or the popup entrypoint's `themeIcons` option), WXT does not overwrite it.
- **Reuses the existing `ThemeIcon` type** from `packages/wxt/src/types.ts` — no duplicate definition.

### Supported filename patterns

```ts
icon-light-16.png         icon-dark-16.png
icon-light-16x16.png      icon-dark-16x16.png
icon-16-light.png         icon-16-dark.png
icon-16x16-light.png      icon-16x16-dark.png
icon/light-16.png         icon/dark-16.png   (also icons/)
icon/light-16x16.png      icon/dark-16x16.png
icon/16-light.png         icon/16-dark.png
icon/16x16-light.png      icon/16x16-dark.png
```

## Files changed

- **`packages/wxt/src/core/utils/theme-icons.ts`** (new, 81 lines) — topic-specific module parallel to `content-scripts.ts` and `content-security-policy.ts`. Exports `addDiscoveredThemeIcons` and `discoverThemeIcons`.
- **`packages/wxt/src/core/utils/manifest.ts`** (+9 lines) — imports `addDiscoveredThemeIcons` and calls it after `addEntrypoints`, inside the `browser === 'firefox'` gate, before the `build:manifestGenerated` hook so user hooks can still override.
- **`packages/wxt/src/core/utils/__tests__/manifest.test.ts`** (+236 lines, +7 integration tests).
- **`docs/guide/essentials/config/manifest.md`** (+20 lines) — new `Firefox theme_icons` subsection with directory-layout example and a snippet include of the regex table.

Closes #1120

## Test plan

New integration tests in `packages/wxt/src/core/utils/__tests__/manifest.test.ts` under `describe('theme_icons auto-discovery (Firefox)')`:

- [x] MV3: discovers paired icons, attaches to `action.theme_icons`
- [x] MV2: attaches to `browser_action.theme_icons`
- [x] Supports all 8 naming patterns (suffix/prefix × folder/no-folder × `size`/`WxH`)
- [x] Skips sizes missing a light or dark pair
- [x] Does not auto-discover for non-Firefox browsers
- [x] Respects user-provided `theme_icons` (via popup `options.themeIcons`) and does not overwrite
- [x] Skips when no action exists (background-only extension)

- [x] `pnpm -F wxt run check` — ESLint, Oxlint, Publint, TypeScript all green
- [x] `pnpm -F wxt exec vitest run src/core/utils/__tests__/manifest` — 82 passed (75 existing + 7 new)

## Follow-ups not in this PR

The issue also mentions extending [`@wxt-dev/auto-icons`](https://github.com/wxt-dev/wxt/tree/main/packages/auto-icons) to auto-**generate** theme variants from a single `light.png` / `dark.png` source (via `sharp`, like the existing `sizes` generation). Happy to open a follow-up for that — kept out of this PR to keep the scope tight and reviewable.