### PR TITLE
docs: fix Read Frog Firefox showcase link

### DIFF
--- a/docs/assets/extension-showcase.yml
+++ b/docs/assets/extension-showcase.yml
@@ -260,9 +260,9 @@
 - # CanCopy - A web extension that allow you to copy any content from website
   chromeId: ggcfemmoabhhelfkhknhbnkmeahloiod
 
-- # Language Learning with AI
+- # Read Frog
   chromeId: modkelfkcfjpgbfmnbnllalkiogfofhb
-  firefoxSlug: intersub
+  firefoxSlug: read-frog-open-ai-translator
 
 - # Bilibili Feed History Helper
   chromeId: npfopljnjbamegincfjelhjhnonnjloo


### PR DESCRIPTION
## Summary
- fix the Read Frog showcase entry in `docs/assets/extension-showcase.yml`
- replace the incorrect Firefox Add-ons slug (`intersub`) with the official Read Frog slug from readfrog.app
- rename the internal YAML comment to `Read Frog` so the entry is easier to identify

## Validation
- confirmed the current wxt.dev Read Frog card links Firefox to `https://addons.mozilla.org/en-US/firefox/addon/intersub/?utm_source=wxt.dev`
- confirmed `https://www.readfrog.app/en` exposes the Firefox link `https://addons.mozilla.org/firefox/addon/read-frog-open-ai-translator`
- verified the edited YAML entry now maps `modkelfkcfjpgbfmnbnllalkiogfofhb` to `read-frog-open-ai-translator`
- ran `ruby -e 'require "yaml"; ...'` to parse the YAML and confirm the updated slug
- ran `git diff --check`
