### PR TITLE
feat: Add `dev.server.strictPort` option

### DIFF
--- a/packages/wxt/e2e/tests/dev.test.ts
+++ b/packages/wxt/e2e/tests/dev.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { TestProject } from '../utils';
-import { createServer as createNetServer, AddressInfo } from 'node:net';
+import { createServer as createNetServer } from 'node:net';
 
 /** Starts a TCP server on the given port and returns a cleanup function. */
 function occupyPort(port: number): Promise<() => Promise<void>> {

--- a/packages/wxt/e2e/tests/dev.test.ts
+++ b/packages/wxt/e2e/tests/dev.test.ts
@@ -6,7 +6,7 @@ import { createServer as createNetServer } from 'node:net';
 function occupyPort(port: number): Promise<() => Promise<void>> {
   return new Promise((resolve, reject) => {
     const srv = createNetServer();
-    srv.listen(port, () => {
+    srv.listen(port, 'localhost', () => {
       resolve(() => new Promise<void>((res) => srv.close(() => res())));
     });
     srv.on('error', reject);

--- a/packages/wxt/e2e/tests/dev.test.ts
+++ b/packages/wxt/e2e/tests/dev.test.ts
@@ -1,5 +1,17 @@
 import { describe, it, expect } from 'vitest';
 import { TestProject } from '../utils';
+import { createServer as createNetServer, AddressInfo } from 'node:net';
+
+/** Starts a TCP server on the given port and returns a cleanup function. */
+function occupyPort(port: number): Promise<() => Promise<void>> {
+  return new Promise((resolve, reject) => {
+    const srv = createNetServer();
+    srv.listen(port, () => {
+      resolve(() => new Promise<void>((res) => srv.close(() => res())));
+    });
+    srv.on('error', reject);
+  });
+}
 
 describe('Dev Mode', () => {
   it('should not change ports when restarting the server', async () => {
@@ -20,5 +32,69 @@ describe('Dev Mode', () => {
     await server.stop();
 
     expect(finalPort).toBe(initialPort);
+  });
+
+  it('should use the specified port when it is available', async () => {
+    const project = new TestProject();
+    project.addFile(
+      'entrypoints/background.ts',
+      'export default defineBackground(() => {})',
+    );
+
+    const server = await project.startServer({
+      runner: { disabled: true },
+      dev: { server: { port: 4400 } },
+    });
+    try {
+      expect(server.port).toBe(4400);
+    } finally {
+      await server.stop();
+    }
+  });
+
+  it('should fall back to the next available port when strictPort is false and the port is occupied', async () => {
+    const port = 4500;
+    const freePort = await occupyPort(port);
+
+    const project = new TestProject();
+    project.addFile(
+      'entrypoints/background.ts',
+      'export default defineBackground(() => {})',
+    );
+
+    const server = await project.startServer({
+      runner: { disabled: true },
+      dev: { server: { port, strictPort: false } },
+    });
+    try {
+      expect(server.port).not.toBe(port);
+      expect(server.port).toBeGreaterThan(port);
+    } finally {
+      await server.stop();
+      await freePort();
+    }
+  });
+
+  it('should fall back to the next available port by default when the port is occupied', async () => {
+    const port = 4600;
+    const freePort = await occupyPort(port);
+
+    const project = new TestProject();
+    project.addFile(
+      'entrypoints/background.ts',
+      'export default defineBackground(() => {})',
+    );
+
+    const server = await project.startServer({
+      runner: { disabled: true },
+      dev: { server: { port } },
+    });
+    try {
+      expect(server.port).not.toBe(port);
+      expect(server.port).toBeGreaterThan(port);
+    } finally {
+      await server.stop();
+      await freePort();
+    }
   });
 });

--- a/packages/wxt/e2e/tests/dev.test.ts
+++ b/packages/wxt/e2e/tests/dev.test.ts
@@ -52,31 +52,8 @@ describe('Dev Mode', () => {
     }
   });
 
-  it('should fall back to the next available port when strictPort is false and the port is occupied', async () => {
-    const port = 4500;
-    const freePort = await occupyPort(port);
-
-    const project = new TestProject();
-    project.addFile(
-      'entrypoints/background.ts',
-      'export default defineBackground(() => {})',
-    );
-
-    const server = await project.startServer({
-      runner: { disabled: true },
-      dev: { server: { port, strictPort: false } },
-    });
-    try {
-      expect(server.port).not.toBe(port);
-      expect(server.port).toBeGreaterThan(port);
-    } finally {
-      await server.stop();
-      await freePort();
-    }
-  });
-
   it('should fall back to the next available port by default when the port is occupied', async () => {
-    const port = 4600;
+    const port = 4500;
     const freePort = await occupyPort(port);
 
     const project = new TestProject();
@@ -94,6 +71,28 @@ describe('Dev Mode', () => {
       expect(server.port).toBeGreaterThan(port);
     } finally {
       await server.stop();
+      await freePort();
+    }
+  });
+
+  it('should throw an error when strictPort is true and the port is occupied', async () => {
+    const port = 4600;
+    const freePort = await occupyPort(port);
+
+    const project = new TestProject();
+    project.addFile(
+      'entrypoints/background.ts',
+      'export default defineBackground(() => {})',
+    );
+
+    try {
+      await expect(
+        project.startServer({
+          runner: { disabled: true },
+          dev: { server: { port, strictPort: true } },
+        }),
+      ).rejects.toThrow();
+    } finally {
       await freePort();
     }
   });

--- a/packages/wxt/src/core/builders/vite/index.ts
+++ b/packages/wxt/src/core/builders/vite/index.ts
@@ -348,6 +348,8 @@ export async function createViteBuilder(
         server: {
           host: info.host,
           port: info.port,
+          // The port is already resolved to an available one during config
+          // resolution, and vite needs to use the port the rest of WXT uses.
           strictPort: true,
           origin: info.origin,
         },

--- a/packages/wxt/src/core/resolve-config.ts
+++ b/packages/wxt/src/core/resolve-config.ts
@@ -160,12 +160,18 @@ export async function resolveConfig(
       mergedConfig.dev?.server?.origin ??
       mergedConfig.dev?.server?.hostname ??
       'localhost';
+    const strictPort = mergedConfig.dev?.server?.strictPort ?? false;
     if (port == null || !isFinite(port)) {
       port = await getPort({
         // Passing host required for Mac, unsure of Windows/Linux
         host,
         port: 3000,
         portRange: [3001, 3010],
+      });
+    } else if (!strictPort) {
+      port = await getPort({
+        host,
+        port,
       });
     }
     const originWithProtocolAndPort = [
@@ -177,6 +183,7 @@ export async function resolveConfig(
       host,
       port,
       origin: originWithProtocolAndPort,
+      strictPort,
       watchDebounce: safeStringToNumber(process.env.WXT_WATCH_DEBOUNCE) ?? 800,
     };
   }

--- a/packages/wxt/src/types.ts
+++ b/packages/wxt/src/types.ts
@@ -388,6 +388,14 @@ export interface InlineConfig {
        */
       origin?: string;
       /**
+       * Whether the dev server should fail if the specified port is already in
+       * use. When `false` and a `port` is specified, the next available port
+       * will be used instead of throwing an error.
+       *
+       * @default false
+       */
+      strictPort?: boolean;
+      /**
        * Hostname to run the dev server on.
        *
        * @deprecated Use `host` to specify the interface to bind to, or use
@@ -1509,6 +1517,7 @@ export interface ResolvedConfig {
       host: string;
       port: number;
       origin: string;
+      strictPort: boolean;
       /**
        * The milliseconds to debounce when a file is saved before reloading. The
        * only way to set this option is to set the `WXT_WATCH_DEBOUNCE`


### PR DESCRIPTION
### Overview

Does two things:
1. Adds `strictPort` option
2. Allows custom ports to act as the starting point for looking for an open port when `strictPort` is false

### TODO

- [x] Implement
- [x] Add tests

### Manual Testing

Run the demo extension multiiple times to take up different ports.

### Related Issue

<!-- If this PR is related to an issue, please link it here -->

This PR closes #1979
