### PR TITLE
fix: Skip applying `esbuild.charset=ascii` vite 8

### DIFF
--- a/packages/wxt/src/core/builders/vite/index.ts
+++ b/packages/wxt/src/core/builders/vite/index.ts
@@ -76,8 +76,12 @@ export async function createViteBuilder(
     config.legacy.skipWebSocketTokenCheck = true;
 
     // Solves https://github.com/wxt-dev/wxt/issues/353
-    config.esbuild ??= {};
-    if (config.esbuild) config.esbuild.charset = 'ascii';
+    if (isRolldownVersion(vite.version)) {
+      // TODO: Add charset ascii when supported by oxc
+    } else {
+      config.esbuild ??= {};
+      if (config.esbuild) config.esbuild.charset = 'ascii';
+    }
 
     const server = getWxtDevServer?.();
 
@@ -493,4 +497,8 @@ export async function removeEmptyDirs(dir: string): Promise<void> {
   } catch {
     // noop on failure - this means the directory was not empty.
   }
+}
+
+function isRolldownVersion(version: string): boolean {
+  return Number(version.split('.')[0]) >= 8;
 }


### PR DESCRIPTION
### Overview

Fixes warning from vite when you set esbuild config when using rolldown/oxc

https://github.com/vitejs/vite/blob/bc5c6a7a498845dff20dc410c395355b79a4b753/packages/vite/src/node/config.ts#L1848

### Related Issue

- https://github.com/wxt-dev/wxt/issues/353#issuecomment-4239554378
- https://github.com/wxt-dev/wxt/commit/c528361d0719be1655b4da83ca62ccaef438aae8#commitcomment-182304286
