### PR TITLE
fix: Correct `actionKey` for Firefox in MV3

### DIFF
--- a/packages/wxt/src/core/utils/__tests__/manifest.test.ts
+++ b/packages/wxt/src/core/utils/__tests__/manifest.test.ts
@@ -107,29 +107,39 @@ describe('Manifest Utils', () => {
         },
       );
 
-      it('should allow converting action to page_action for Firefox MV3', async () => {
-        const popup = popupEntrypoint('page_action');
-        const buildOutput = fakeBuildOutput();
-        setFakeWxt({
-          config: {
-            manifestVersion: 3,
-            outDir,
-            browser: 'firefox',
-          },
-        });
-        const expected = {
-          default_icon: popup.options.defaultIcon,
-          default_title: popup.options.defaultTitle,
-          default_popup: 'popup.html',
-        };
+      it.each<{
+        inputType: ActionType | undefined;
+        expectedType: ActionType;
+      }>([
+        { inputType: undefined, expectedType: 'action' },
+        { inputType: 'browser_action', expectedType: 'action' },
+        { inputType: 'page_action', expectedType: 'page_action' },
+      ])(
+        'should use the correct action for Firefox in mv3: %j',
+        async ({ inputType, expectedType }) => {
+          const popup = popupEntrypoint(inputType);
+          const buildOutput = fakeBuildOutput();
+          setFakeWxt({
+            config: {
+              manifestVersion: 3,
+              outDir,
+              browser: 'firefox',
+            },
+          });
+          const expected = {
+            default_icon: popup.options.defaultIcon,
+            default_title: popup.options.defaultTitle,
+            default_popup: 'popup.html',
+          };
 
-        const { manifest: actual } = await generateManifest(
-          [popup],
-          buildOutput,
-        );
+          const { manifest: actual } = await generateManifest(
+            [popup],
+            buildOutput,
+          );
 
-        expect(actual.page_action).toEqual(expected);
-      });
+          expect(actual[expectedType]).toEqual(expected);
+        },
+      );
 
       it('should include default_area for Firefox in mv3', async () => {
         const popup = fakePopupEntrypoint({

--- a/packages/wxt/src/core/utils/__tests__/manifest.test.ts
+++ b/packages/wxt/src/core/utils/__tests__/manifest.test.ts
@@ -34,6 +34,7 @@ describe('Manifest Utils', () => {
   describe('generateManifest', () => {
     describe('popup', () => {
       type ActionType = 'browser_action' | 'page_action';
+      type Mv3ActionType = 'action' | 'page_action';
       const popupEntrypoint = (type?: ActionType) =>
         fakePopupEntrypoint({
           options: {
@@ -109,7 +110,7 @@ describe('Manifest Utils', () => {
 
       it.each<{
         inputType: ActionType | undefined;
-        expectedType: ActionType;
+        expectedType: Mv3ActionType;
       }>([
         { inputType: undefined, expectedType: 'action' },
         { inputType: 'browser_action', expectedType: 'action' },

--- a/packages/wxt/src/core/utils/manifest.ts
+++ b/packages/wxt/src/core/utils/manifest.ts
@@ -307,8 +307,9 @@ function addEntrypoints(
     const actionKey =
       manifest.manifest_version === 2
         ? (popup.options.actionType ?? 'browser_action')
-        : wxt.config.browser === 'firefox'
-          ? (popup.options.actionType ?? 'action')
+        : wxt.config.browser === 'firefox' &&
+            popup.options.actionType === 'page_action'
+          ? 'page_action'
           : 'action';
 
     manifest[actionKey] = {


### PR DESCRIPTION
### Overview

For Firefox MV3, the `actionType` was not converted to `"action"` but remained `"browser_action"` and was subsequently removed from the final manifest, preventing the popup from working properly. Add a check for `"page_action"` to make it work correctly.

### Manual Testing

Modified the original test used to test page_action.
```bash
cd packages/wxt && bun test manifest
```

```
✓ Manifest Utils > generateManifest > popup > should use the correct action for Firefox in mv3: {"expectedType":"action"} [2.00ms]
✓ Manifest Utils > generateManifest > popup > should use the correct action for Firefox in mv3: {"inputType":"browser_action","expectedType":"action"} [2.00ms]
✓ Manifest Utils > generateManifest > popup > should use the correct action for Firefox in mv3: {"inputType":"page_action","expectedType":"page_action"} [2.00ms]
```

### Related Issue

Follow-up from #2249 and #2200 
