### PR TITLE
fix: Port change in dev server on reload

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -91,7 +91,7 @@
         "@types/har-format": "*",
       },
       "devDependencies": {
-        "@types/chrome": "^0.1.40",
+        "@types/chrome": "0.1.40",
         "@types/node": "^20.0.0",
         "nano-spawn": "^2.0.0",
         "typescript": "^5.9.3",

--- a/packages/wxt/e2e/tests/dev.test.ts
+++ b/packages/wxt/e2e/tests/dev.test.ts
@@ -1,17 +1,5 @@
-import { describe, it, expect } from 'vitest';
-import { TestProject } from '../utils';
-import { createServer as createNetServer } from 'node:net';
-
-/** Starts a TCP server on the given port and returns a cleanup function. */
-function occupyPort(port: number): Promise<() => Promise<void>> {
-  return new Promise((resolve, reject) => {
-    const srv = createNetServer();
-    srv.listen(port, 'localhost', () => {
-      resolve(() => new Promise<void>((res) => srv.close(() => res())));
-    });
-    srv.on('error', reject);
-  });
-}
+import { describe, expect, it } from 'vitest';
+import { TestProject, occupyPort } from '../utils';
 
 describe('Dev Mode', () => {
   it('should not change ports when restarting the server', async () => {

--- a/packages/wxt/e2e/tests/wxt.test.ts
+++ b/packages/wxt/e2e/tests/wxt.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest';
+import { registerWxt, wxt } from '../../src/core/wxt';
+import { TestProject, occupyPort } from '../utils';
+
+describe('WXT Global', () => {
+  describe('reloadConfig', () => {
+    it('should not change dev server ports when reloading config, even if the port is in-use', async () => {
+      const project = new TestProject();
+
+      await registerWxt('serve', { root: project.root });
+
+      const firstPort = wxt.config.dev.server!.port;
+      expect(firstPort).toBeDefined();
+
+      const cleanup = await occupyPort(firstPort);
+      try {
+        await wxt.reloadConfig();
+        const secondPort = wxt.config.dev.server?.port;
+        expect(secondPort).toBe(firstPort);
+      } finally {
+        cleanup();
+      }
+    });
+  });
+});

--- a/packages/wxt/e2e/utils.ts
+++ b/packages/wxt/e2e/utils.ts
@@ -1,6 +1,7 @@
 import merge from 'lodash.merge';
 import spawn, { Subprocess } from 'nano-spawn';
 import { mkdir, readFile, writeFile } from 'node:fs/promises';
+import { createServer as createNetServer } from 'node:net';
 import { dirname, relative, resolve } from 'path';
 import { glob } from 'tinyglobby';
 import {
@@ -203,4 +204,15 @@ export class TestProject {
       cwd: this.root,
     });
   }
+}
+
+/** Starts a TCP server on the given port and returns a cleanup function. */
+export function occupyPort(port: number): Promise<() => Promise<void>> {
+  return new Promise((resolve, reject) => {
+    const srv = createNetServer();
+    srv.listen(port, 'localhost', () => {
+      resolve(() => new Promise<void>((res) => srv.close(() => res())));
+    });
+    srv.on('error', reject);
+  });
 }

--- a/packages/wxt/src/core/wxt.ts
+++ b/packages/wxt/src/core/wxt.ts
@@ -1,10 +1,10 @@
-import { InlineConfig, Wxt, WxtCommand, WxtHooks, WxtModule } from '../types';
-import { resolveConfig } from './resolve-config';
 import { createHooks } from 'hookable';
-import { createWxtPackageManager } from './package-managers';
-import { createViteBuilder } from './builders/vite';
-import { builtinModules } from '../builtin-modules';
 import { relative } from 'path';
+import { builtinModules } from '../builtin-modules';
+import { InlineConfig, Wxt, WxtCommand, WxtHooks, WxtModule } from '../types';
+import { createViteBuilder } from './builders/vite';
+import { createWxtPackageManager } from './package-managers';
+import { resolveConfig } from './resolve-config';
 
 /**
  * Global variable set once `createWxt` is called once. Since this variable is
@@ -47,6 +47,7 @@ export async function registerWxt(
         inlineConfig.dev ??= {};
         inlineConfig.dev.server ??= {};
         inlineConfig.dev.server.port = wxt.config.dev.server.port;
+        inlineConfig.dev.server.strictPort = true;
       }
 
       wxt.config = await resolveConfig(inlineConfig, command);


### PR DESCRIPTION
### Overview

Fix yet another regression introduced in v0.20.22... This time we need to modify the config to enforce a consistent port in dev so background changes and server restarts don't change the port.

There [was a test covering this case](https://github.com/wxt-dev/wxt/blob/5da6e4ff757701388456c6c37371ad1521998fdf/packages/wxt/e2e/tests/dev.test.ts#L17-L35), but it only really tested vite, not the new login in `resolveConfig` when called a second time... So I added a new one, confirming that it was failing on `main`.

https://github.com/wxt-dev/wxt/blob/13527eca54f381c8dd86ebeea5f6a29c69aba9dc/packages/wxt/e2e/tests/wxt.test.ts#L7-L23

### Manual Testing

```sh
cd packages/wxt-demo
bun dev
```

Then save the background file. Before, it would try to connect to a new port, now it keeps the same port.

### Related Issue

This closes #2282
