### PR TITLE
docs: Update `permissions` section with per-browser warning

### DIFF
--- a/docs/guide/essentials/config/manifest.md
+++ b/docs/guide/essentials/config/manifest.md
@@ -200,6 +200,23 @@ export default defineConfig({
 });
 ```
 
+:::warning
+
+Different browsers support different permissions. You are responsible for passing only the permissions required for each browser:
+
+```ts
+export default defineConfig({
+  manifest: ({ browser }) => ({
+    permissions:
+      browser === 'chrome'
+        ? ['storage', 'favicon', 'declarativeNetRequest']
+        : ['storage', 'webRequest'],
+  }),
+});
+```
+
+:::
+
 ## Host Permissions
 
 > [Chrome docs](https://developer.chrome.com/docs/extensions/develop/concepts/declare-permissions#host-permissions)


### PR DESCRIPTION
### Overview

Based on feedback from https://github.com/wxt-dev/wxt/issues/2271#issuecomment-4270448920

### Manual Testing

See docs preview: https://deploy-preview-2284--creative-fairy-df92c4.netlify.app/guide/essentials/config/manifest.html#permissions

### Related Issue

This PR closes #2271
