### PR TITLE
docs: base icon path configuration for auto-icons

### DIFF
--- a/packages/auto-icons/README.md
+++ b/packages/auto-icons/README.md
@@ -29,6 +29,19 @@ export default defineConfig({
 
 And finally, save the base icon to `<srcDir>/assets/icon.png`.
 
+To use another path, configure `autoIcons.baseIconPath` in your `wxt.config.ts`:
+
+```ts
+import { resolve } from 'node:path'
+
+export default defineConfig({
+  ...,
+  autoIcons: {
+    baseIconPath: resolve('public/icon.svg'),
+  },
+}
+```
+
 ## Configuration
 
 The module can be configured via the `autoIcons` config:


### PR DESCRIPTION
### Overview

Added instructions for configuring base icon path in wxt.config.ts.

```ts
import { resolve } from 'node:path'
import { defineConfig } from 'wxt'

export default defineConfig({
  modules: ['@wxt-dev/module-react', '@wxt-dev/auto-icons'],
  autoIcons: {
    baseIconPath: resolve('public/icon.svg'),
  },
}
```

### Manual Testing

None

### Related Issue

None
