### PR TITLE
fix: `@types/chrome` version of `browser`

### DIFF
--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -25,7 +25,7 @@
     "src"
   ],
   "devDependencies": {
-    "@types/chrome": "0.1.40",
+    "@types/chrome": "^0.1.40",
     "@types/node": "^20.0.0",
     "nano-spawn": "^2.0.0",
     "typescript": "^5.9.3",


### PR DESCRIPTION
### Overview

Add `^` to `@chrome/types` of `browser` package.json, to match bun.lock file.
Or if you really want without `^` i need to run `bun i` and let's merge new version of that file.