### PR TITLE
ci: use --frozen-lockfile in action.yml for bun

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -18,4 +18,4 @@ runs:
     - name: 📦 Install Dependencies
       if: ${{ inputs.install == 'true' }}
       shell: bash
-      run: bun ci ${{ inputs.installArgs }}
+      run: bun ci ${{ inputs.installArgs }} --frozen-lockfile


### PR DESCRIPTION
To avoid conflicts between `.lock` and `.json` of package, we need to have that.

Now there's a problem on `main` because there's versions mismatch.

Blocked by #2299 