### PR TITLE
docs: correct entrypoints icon example code

### DIFF
--- a/docs/guide/essentials/entrypoints.md
+++ b/docs/guide/essentials/entrypoints.md
@@ -463,8 +463,8 @@ When you define a Newtab entrypoint, WXT will automatically update the manifest 
     <meta
       name="manifest.default_icon"
       content="{
-        16: '/icon-16.png',
-        24: '/icon-24.png',
+        '16': '/icon-16.png',
+        '24': '/icon-24.png',
         ...
       }"
     />
@@ -554,8 +554,8 @@ Firefox does not support sandboxed pages.
     <meta
       name="manifest.default_icon"
       content="{
-        16: '/icon-16.png',
-        24: '/icon-24.png',
+        '16': '/icon-16.png',
+        '24': '/icon-24.png',
         ...
       }"
     />


### PR DESCRIPTION
### Overview

Added missing quotes in the Entrypoints documentation under the default_icon meta. Without the quotes the value is resolved to a string instead of a object in the manifest