### PR TITLE
fix: Use `manifestVersion` from CLI during manifest generation

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -91,7 +91,7 @@
         "@types/har-format": "*",
       },
       "devDependencies": {
-        "@types/chrome": "^0.1.40",
+        "@types/chrome": "0.1.40",
         "@types/node": "^20.0.0",
         "nano-spawn": "^2.0.0",
         "typescript": "^5.9.3",

--- a/packages/wxt/src/core/utils/manifest.ts
+++ b/packages/wxt/src/core/utils/manifest.ts
@@ -308,7 +308,7 @@ function addEntrypoints(
       options.theme_icons = popup.options.themeIcons;
 
     const actionKey =
-      manifest.manifest_version === 2
+      wxt.config.manifestVersion === 2
         ? (popup.options.actionType ?? 'browser_action')
         : wxt.config.browser === 'firefox' &&
             popup.options.actionType === 'page_action'
@@ -493,7 +493,7 @@ function addDevModeCsp(manifest: Browser.runtime.Manifest): void {
   const permission = `${permissionUrl}*`;
   const allowedCsp = wxt.server?.origin ?? 'http://localhost:*';
 
-  if (manifest.manifest_version === 3) {
+  if (wxt.config.manifestVersion === 3) {
     addHostPermission(manifest, permission);
   } else {
     addPermission(manifest, permission);
@@ -502,7 +502,7 @@ function addDevModeCsp(manifest: Browser.runtime.Manifest): void {
   const extensionPagesCsp = new ContentSecurityPolicy(
     // @ts-expect-error: extension_pages exists, we convert MV2 CSPs to this earlier in the process
     manifest.content_security_policy?.extension_pages ??
-      (manifest.manifest_version === 3
+      (wxt.config.manifestVersion === 3
         ? DEFAULT_MV3_EXTENSION_PAGES_CSP
         : DEFAULT_MV2_CSP),
   );


### PR DESCRIPTION
### Overview

During manifest generation, `wxt.config.maniifestVersion` is the source of truth - if an extension uses `wxt --mv3`, but has `manifest: { manifest_version: 2 }` in their config file, we should always use the manifest version from the `wxt.config` object, not the `manifest` object we're in the middle of generating.

In theory, they should always be the same, but I could see some funky edge case where someone is modifying the `manifest.version` through hooks.

### Manual Testing

Run tests:

```sh
bun run --cwd packages/wxt test
```

### Related Issue

Noticed we were using different sources for the manifest version while reviewing https://github.com/wxt-dev/wxt/pull/2010 today.
