### PR TITLE
fix(browser): add IOS to PlatformOs enum

### DIFF
--- a/packages/browser/src/gen/index.d.ts
+++ b/packages/browser/src/gen/index.d.ts
@@ -8888,6 +8888,8 @@ export namespace Browser {
             OPENBSD = "openbsd",
             /** Specifies the Fuchsia operating system. */
             FUCHSIA = "fuchsia",
+            /** Specifies the iOS operating system. */
+            IOS = "ios",
         }
 
         /**


### PR DESCRIPTION
## Summary
- Add `IOS = "ios"` to `Runtime.PlatformOs` enum in `@wxt-dev/browser` type definitions
- Safari on iOS/iPadOS reports `runtime.getPlatformInfo().os` as `"ios"`, but the type was missing this value, causing TypeScript errors when comparing against it

## Reference
- [MDN: runtime.PlatformOs - ios](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/runtime/PlatformOs#ios)

🤖 Generated with [Claude Code](https://claude.com/claude-code)