### PR TITLE
chore: Keep lockfile in sync when generating `@wxt-dev/browser`

### DIFF
--- a/packages/browser/scripts/generate.ts
+++ b/packages/browser/scripts/generate.ts
@@ -58,6 +58,8 @@ for (const { file, srcPath, destPath } of declarationFileMapping) {
   console.log(`  ${styleText('dim', '-')} ${styleText('cyan', file)}`);
 }
 
+await Bun.$`bun install --ignore-scripts`;
+
 // Done!
 
 console.log(


### PR DESCRIPTION
### Overview

Without the added line, the lockfile ends up out-of-sync... not sure why. But running a second install after the package is generated solves the out-of-sync lockfile.

I had a similar issue with the release workflow leaving the lockfile out-of-date after the bun migration. Running another install also resolved it in that case.

### Manual Testing

```sh
bun run --cwd packages/browser gen
```

Run it on `main` and you'll see an change in the `bun.lock` file. Run it on this branch and it's all good.

### Related Issue

Replaces https://github.com/wxt-dev/wxt/pull/2299
