### PR TITLE
docs: remove horizontal scrollbar in Chrome on homepage

### DIFF
--- a/docs/.vitepress/theme/custom.css
+++ b/docs/.vitepress/theme/custom.css
@@ -33,6 +33,10 @@
   border: 1px solid var(--vp-c-divider);
 }
 
+html {
+  scrollbar-gutter: stable;
+}
+
 body {
   overflow-y: scroll;
 }


### PR DESCRIPTION
### Overview

Removed the horizontal scrollbar in Chrome on the homepage which was caused by using `width: 100vw;` on the background picture
https://www.bram.us/2026/01/15/100vw-horizontal-overflow-no-more/

Fixes #2318