### PR TITLE
fix: Modify command to support variadic positional args

### DIFF
--- a/cspell.yml
+++ b/cspell.yml
@@ -11,6 +11,7 @@ ignorePaths:
   - patches/**
   - '**/*.snap'
   - docs/assets/extension-showcase.yml
+  - packages/*/stats.html
 words:
   - Aabid
   - aabidk
@@ -21,6 +22,7 @@ words:
   - buildc
   - bunx
   - cachable
+  - cacjs
   - charmbracelet
   - chromedriver
   - Cira

--- a/packages/wxt/src/cli/cli-utils.ts
+++ b/packages/wxt/src/cli/cli-utils.ts
@@ -82,8 +82,12 @@ export function createAliasedCommand(
   bin: string,
   docsUrl: string,
 ) {
+  // Declare a variadic positional arg so cac forwards subcommands like `wxt
+  // submit init` instead of rejecting them as unused args. `.allowUnknownOptions`
+  // only relaxes flag checks, not positional args. Required since cac@7, which
+  // throws on unused positional args (see cacjs/cac#135).
   const aliasedCommand = base
-    .command(name, `Alias for ${alias} (${docsUrl})`)
+    .command(`${name} [...args]`, `Alias for ${alias} (${docsUrl})`)
     .allowUnknownOptions()
     .action(async () => {
       try {


### PR DESCRIPTION
Updated command registration to allow variadic positional arguments for subcommands.

### Overview

`wxt submit <subcommand>` (e.g. `wxt submit init`) currently fails with:

```
CACError: Unused args: init at Command.checkUnusedArgs (node_modules/cac/dist/index.js:394:54) at CAC.runMatchedCommand (node_modules/cac/dist/index.js:619:11) at file:.../node_modules/wxt/dist/cli/index.mjs:11:11
```

Ref: https://github.com/wxt-dev/wxt/issues/2286


`createAliasedCommand` registers the alias as `cli.command(name)` (no positional arg spec) and then forwards `process.argv` to the underlying CLI. `.allowUnknownOptions()` only relaxes _flag_ checks, not positional args. This worked by accident on `cac@6`, but `wxt`'s declared range `^6.7.14 || ^7.0.0` now resolves to `cac@7.0.0`, which added a strict `checkUnusedArgs` (cacjs/cac#135) that throws before the action ever runs.

The fix is one line: declare the alias as `` `${name} [...args]` `` so cac treats positional args as variadic and forwards them through.

### Manual Testing

Before:
```sh
$ bun wxt submit init
CACError: Unused args: `init`
```

After:

```
$ pnpm wxt submit init
publish-extension/4.0.5
Usage: $ publish-extension init
...
```

### Related Issue

This PR closes: 

- #2286
- #2129 (the wxt submit init failure that was previously misdiagnosed as a publish-browser-extension v3→v4 issue but reproduces cleanly with cac@7 + publish-browser-extension@4.0.4)
```
╰─>$ bun why publish-browser-extension
publish-browser-extension@4.0.5
  └─ wxt@0.20.25 (requires ^2.3.0 || ^3.0.2 || ^4.0.4)
     ├─ dev wxt-react-starter (requires ^0.20.25)
     ├─ peer @wxt-dev/auto-icons@1.1.1 (requires >=0.19.0)
     │  └─ dev wxt-react-starter (requires ^1.1.1)
     └─ peer @wxt-dev/module-react@1.2.2 (requires >=0.19.16)
        └─ dev wxt-react-starter (requires ^1.2.2)
```
