### PR TITLE
feat(wxt-demo): add rem-to-px postcss example for Shadow Root UI

### DIFF
--- a/packages/wxt-demo/package.json
+++ b/packages/wxt-demo/package.json
@@ -35,6 +35,7 @@
     "typescript": "^5.9.3",
     "unocss": "^0.64.0 || ^0.65.0 || ^65.0.0 || ^66.0.0",
     "vitest": "^4.0.18",
+    "postcss-rem-to-responsive-pixel": "^7.0.4",
     "vitest-plugin-random-seed": "^1.1.2",
     "wxt": "workspace:*"
   },

--- a/packages/wxt-demo/package.json
+++ b/packages/wxt-demo/package.json
@@ -35,6 +35,7 @@
     "typescript": "^5.9.3",
     "unocss": "^0.64.0 || ^0.65.0 || ^65.0.0 || ^66.0.0",
     "vitest": "^4.0.18",
+    "postcss": "^8.5.13",
     "postcss-rem-to-responsive-pixel": "^7.0.4",
     "vitest-plugin-random-seed": "^1.1.2",
     "wxt": "workspace:*"

--- a/packages/wxt-demo/postcss.config.mjs
+++ b/packages/wxt-demo/postcss.config.mjs
@@ -1,0 +1,11 @@
+import postcssRemToResponsivePx from 'postcss-rem-to-responsive-pixel';
+
+export default {
+  plugins: [
+    postcssRemToResponsivePx({
+      rootValue: 16,
+      propList: ['*'],
+      transformUnit: 'px',
+    }),
+  ],
+};

--- a/packages/wxt-demo/src/entrypoints/rem-fix.content/index.ts
+++ b/packages/wxt-demo/src/entrypoints/rem-fix.content/index.ts
@@ -1,0 +1,32 @@
+import './style.css';
+
+export default defineContentScript({
+  matches: ['<all_urls>'],
+  cssInjectionMode: 'ui',
+
+  async main(ctx) {
+    const ui = await createShadowRootUi(ctx, {
+      name: 'rem-fix-demo',
+      position: 'inline',
+      anchor: 'body',
+      append: 'first',
+      onMount(container) {
+        const card = document.createElement('div');
+        card.classList.add('rem-fix-card');
+
+        const title = document.createElement('h3');
+        title.textContent = 'rem → px Demo';
+
+        const desc = document.createElement('p');
+        desc.textContent =
+          'This UI uses rem units in CSS, converted to px at build time by postcss-rem-to-responsive-pixel. ' +
+          'It will render at the same size regardless of the host page\'s root font-size.';
+
+        card.append(title, desc);
+        container.append(card);
+      },
+    });
+
+    ui.mount();
+  },
+});

--- a/packages/wxt-demo/src/entrypoints/rem-fix.content/index.ts
+++ b/packages/wxt-demo/src/entrypoints/rem-fix.content/index.ts
@@ -20,7 +20,7 @@ export default defineContentScript({
         const desc = document.createElement('p');
         desc.textContent =
           'This UI uses rem units in CSS, converted to px at build time by postcss-rem-to-responsive-pixel. ' +
-          'It will render at the same size regardless of the host page\'s root font-size.';
+          'It will render at the same size regardless of the host pages root font-size.';
 
         card.append(title, desc);
         container.append(card);

--- a/packages/wxt-demo/src/entrypoints/rem-fix.content/index.ts
+++ b/packages/wxt-demo/src/entrypoints/rem-fix.content/index.ts
@@ -18,9 +18,8 @@ export default defineContentScript({
         title.textContent = 'rem → px Demo';
 
         const desc = document.createElement('p');
-        desc.textContent =
-          'This UI uses rem units in CSS, converted to px at build time by postcss-rem-to-responsive-pixel. ' +
-          'It will render at the same size regardless of the host pages root font-size.';
+desc.textContent = `This UI uses 'rem' units in CSS, converted to 'px' at build time by 'postcss-rem-to-responsive-pixel'.
+          It will render at the same size regardless of the host pages root 'font-size'.`;
 
         card.append(title, desc);
         container.append(card);

--- a/packages/wxt-demo/src/entrypoints/rem-fix.content/style.css
+++ b/packages/wxt-demo/src/entrypoints/rem-fix.content/style.css
@@ -14,17 +14,17 @@
   border: 1px solid #45475a;
   max-width: 20rem;
   box-shadow: 0 0.25rem 0.75rem rgba(0, 0, 0, 0.3);
+
+  h3 {
+    margin-right:0.5rem;
+    font-size: 1rem;
+    font-weight: 600;
+    color: #a6e3a1;
+  }
+
+  p {
+    font-size: 0.75rem;
+    color: #a6adc8;
+  }
 }
 
-.rem-fix-card h3 {
-  margin: 0 0 0.5rem 0;
-  font-size: 1rem;
-  font-weight: 600;
-  color: #a6e3a1;
-}
-
-.rem-fix-card p {
-  margin: 0;
-  font-size: 0.75rem;
-  color: #a6adc8;
-}

--- a/packages/wxt-demo/src/entrypoints/rem-fix.content/style.css
+++ b/packages/wxt-demo/src/entrypoints/rem-fix.content/style.css
@@ -1,0 +1,30 @@
+/*
+ * These rem values will be converted to px at build time
+ * by postcss-rem-to-responsive-pixel, making this UI immune
+ * to host page font-size overrides.
+ */
+.rem-fix-card {
+  padding: 1rem;
+  border-radius: 0.5rem;
+  background-color: #1e1e2e;
+  color: #cdd6f4;
+  font-family: system-ui, -apple-system, sans-serif;
+  font-size: 0.875rem;
+  line-height: 1.5;
+  border: 1px solid #45475a;
+  max-width: 20rem;
+  box-shadow: 0 0.25rem 0.75rem rgba(0, 0, 0, 0.3);
+}
+
+.rem-fix-card h3 {
+  margin: 0 0 0.5rem 0;
+  font-size: 1rem;
+  font-weight: 600;
+  color: #a6e3a1;
+}
+
+.rem-fix-card p {
+  margin: 0;
+  font-size: 0.75rem;
+  color: #a6adc8;
+}

--- a/packages/wxt-demo/wxt.config.ts
+++ b/packages/wxt-demo/wxt.config.ts
@@ -38,6 +38,7 @@ export default defineConfig({
       'iframe',
       'location-change',
       'main-world',
+      'rem-fix',
       'sandbox',
       'sidepanel',
       'unlisted',


### PR DESCRIPTION
### Overview

Adds a `rem-fix.content` example to `wxt-demo` that demonstrates how to use [`postcss-rem-to-responsive-pixel`](https://www.npmjs.com/package/postcss-rem-to-responsive-pixel) to convert `rem` units to `px` at build time inside a `createShadowRootUi` content script.

This prevents host page `font-size` overrides (e.g., Reddit's `font-size: 10px` on `<html>`) from breaking the extension UI's sizing inside the Shadow DOM.

### Manual Testing

1. Run `bun install` then `bun run --filter wxt-demo dev`
2. Visit any website — the demo card should appear at the top of the page
3. Visit a site that overrides root `font-size` (e.g., Reddit) — the card should render at the **same size** as on other sites
4. Inspect the Shadow Root's CSS — confirm all `rem` values have been converted to `px`

### Related Issue

Follow-up to #2330 (docs: add warning about rem unit inheritance in Shadow Root UI), as [requested by @PatrykKuniczak](https://github.com/wxt-dev/wxt/pull/2330#issuecomment-4365871806).

This PR addresses #678
