### PR TITLE
chore: remove ts-expect-error that are no longer needed

### DIFF
--- a/packages/wxt/src/core/utils/content-scripts.ts
+++ b/packages/wxt/src/core/utils/content-scripts.ts
@@ -31,7 +31,6 @@ export function hashContentScriptOptions(
     match_about_blank: false,
     run_at: 'document_idle',
     all_frames: false,
-    // @ts-expect-error: Untyped
     match_origin_as_fallback: false,
     world: 'ISOLATED',
     ...simplifiedOptions,
@@ -63,7 +62,6 @@ export function mapWxtOptionsToContentScript(
     run_at: options.runAt,
     css,
     js,
-    // @ts-expect-error: Untyped
     match_origin_as_fallback: options.matchOriginAsFallback,
     world: options.world,
   };


### PR DESCRIPTION
### Overview

Fixing build error by removing remove ts-expect-error that are no longer needed
https://app.netlify.com/projects/creative-fairy-df92c4/deploys/69feb77bd1a56a00087fbb1c
