### PR TITLE
docs: Fix `undefined` issue for `ExampleSearch.vue`

### DIFF
--- a/docs/.vitepress/components/ExampleSearch.vue
+++ b/docs/.vitepress/components/ExampleSearch.vue
@@ -8,7 +8,12 @@ defineProps<{
   tag?: string;
 }>();
 
-const exampleMetadata = ref<ExamplesMetadata>();
+const exampleMetadata = ref<ExamplesMetadata>({
+  allApis: [],
+  allPackages: [],
+  allPermissions: [],
+  examples: [],
+});
 onMounted(async () => {
   const res = await fetch(
     'https://raw.githubusercontent.com/wxt-dev/examples/main/metadata.json',


### PR DESCRIPTION
### Overview
To fix:
<img width="465" height="179" alt="Zrzut ekranu 2026-05-12 173115" src="https://github.com/user-attachments/assets/0b8fde83-66b7-4943-ad71-ed7483e5d35f" />

Added default values for `exampleMetadata` to fix `undefined` issue.
If you don't like this change we can do:
`filteredExamples?.length === 0`