### PR TITLE
docs: clarify SPA navigation setup with locationWatcher.run()

### DIFF
--- a/docs/guide/essentials/content-scripts.md
+++ b/docs/guide/essentials/content-scripts.md
@@ -734,7 +734,7 @@ const watchPattern = new MatchPattern('*://*.youtube.com/watch*');
 export default defineContentScript({
   matches: ['*://*.youtube.com/*'],
   main(ctx) {
-    ctx.locationWatcher.run()
+    ctx.locationWatcher.run();
     ctx.addEventListener(window, 'wxt:locationchange', ({ newUrl }) => {
       if (watchPattern.includes(newUrl)) mainWatch(ctx);
     });

--- a/docs/guide/essentials/content-scripts.md
+++ b/docs/guide/essentials/content-scripts.md
@@ -734,6 +734,7 @@ const watchPattern = new MatchPattern('*://*.youtube.com/watch*');
 export default defineContentScript({
   matches: ['*://*.youtube.com/*'],
   main(ctx) {
+    ctx.locationWatcher.run()
     ctx.addEventListener(window, 'wxt:locationchange', ({ newUrl }) => {
       if (watchPattern.includes(newUrl)) mainWatch(ctx);
     });


### PR DESCRIPTION
Added the missing `ctx.locationWatcher.run()` call to the SPA navigation example.

The `wxt:locationchange` event only fires after the location watcher is started, which was not previously shown in the documentation.

### Overview

Adds the missing `ctx.locationWatcher.run()` call to the SPA navigation documentation and examples.

Previously, the docs showed how to listen for the `wxt:locationchange` event, but did not mention that the location watcher must first be started with `ctx.locationWatcher.run()`. Without this call, the event is never dispatched.

### Manual Testing

1. Follow the updated SPA documentation example.
2. Add a `console.log` inside the `wxt:locationchange` listener.
3. Navigate between routes in an SPA site.
4. Verify that the event fires correctly after calling `ctx.locationWatcher.run()`.

### Related Issue

N/A

