### PR TITLE
ci: use latest pnpm in validate workflow

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -76,7 +76,7 @@ jobs:
       - name: Setup PNPM
         uses: pnpm/action-setup@739bfe42ca9233c5e6aca07c1a25a9d34aca49b0 # v6.0.7
         with:
-          version: 10.33.0
+          version: latest
 
       - name: Run Tests
         if: ${{ ! matrix.coverage }}


### PR DESCRIPTION
### Overview

The failing workflow was using `v5` of `pnpm/action-setup` , which does not support `PNPM v11`.

Support for `PNPM v11` was added in `pnpm/action-setup@v6` via #2324 , so this updates the workflow to use the newer version and enables using `version: latest`.

<img width="830" height="492" alt="Screenshot 2026-05-21 at 13 06 59" src="https://github.com/user-attachments/assets/3d897b0c-f8a0-4f44-8b94-029ee5af49c6" />

### Testing

Verified that the workflow passes successfully with `version: latest`:

https://github.com/suveshmoza/wxt/actions/runs/26161466789/job/76954150555#step:6:980

### Related Issue

This PR closes #2347 
