### PR TITLE
test: skip yarn package manager test if not present

### DIFF
--- a/packages/wxt/src/core/package-managers/__tests__/yarn.test.ts
+++ b/packages/wxt/src/core/package-managers/__tests__/yarn.test.ts
@@ -1,8 +1,10 @@
 import { describe, expect, it } from 'vitest';
 import path from 'node:path';
-import { yarn } from '../yarn';
+import { isYarnInstalled, yarn } from '../yarn';
 
-describe('Yarn Package Management Utils', () => {
+const shouldSkip = !(await isYarnInstalled());
+
+describe.skipIf(shouldSkip)('Yarn Package Management Utils', () => {
   describe('listDependencies', () => {
     const cwd = path.resolve(__dirname, 'fixtures/simple-yarn-project');
 

--- a/packages/wxt/src/core/package-managers/yarn.ts
+++ b/packages/wxt/src/core/package-managers/yarn.ts
@@ -5,8 +5,9 @@ import spawn from 'nano-spawn';
 
 export async function isYarnInstalled(): Promise<boolean> {
   try {
-    await spawn('yarn', ['--version']);
-    return true;
+    const { stdout } = await spawn('yarn', ['--version']);
+    const version = stdout.trim();
+    return version !== '' && /^\d+\.\d+\.\d+/.test(version);
   } catch {
     return false;
   }

--- a/packages/wxt/src/core/package-managers/yarn.ts
+++ b/packages/wxt/src/core/package-managers/yarn.ts
@@ -3,6 +3,15 @@ import { WxtPackageManagerImpl } from './types';
 import { dedupeDependencies, npm } from './npm';
 import spawn from 'nano-spawn';
 
+export async function isYarnInstalled(): Promise<boolean> {
+  try {
+    await spawn('yarn', ['--version']);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 export const yarn: WxtPackageManagerImpl = {
   overridesKey: 'resolutions',
   downloadDependency(...args) {


### PR DESCRIPTION
### Overview

- Skips `yarn` package manager test when `yarn` is not present.
- Added `isYarnInstalled` util to check `yarn` presence. 

### Manual Testing

<!-- Describe how to test your changes to make sure the PR works as intended -->
1. Without `yarn` installed, run `bun run --filter wxt test yarn`
```bash
wxt test $ buildc --deps-only -- vitest
│ [5 lines elided]
│ 
│  RUN  v4.1.5 /Users/suveshmoza/oss/wxt/packages/wxt
│ 
│  ↓ src/core/package-managers/__tests__/yarn.test.ts (2 tests | 2 skipped)
│ 
│  Test Files  1 skipped (1)
│       Tests  2 skipped (2)
│    Start at  15:49:37
│    Duration  118ms (transform 10ms, setup 10ms, import 13ms, tests 0ms, environment 0ms)
└─ Done in 470 ms
```   
2. With `yarn` installed, run `bun run --filter wxt test yarn`
```bash
wxt test $ buildc --deps-only -- vitest
│ [5 lines elided]
│ 
│  RUN  v4.1.5 /Users/suveshmoza/oss/wxt/packages/wxt
│ 
│  ✓ src/core/package-managers/__tests__/yarn.test.ts (2 tests) 246ms
│ 
│  Test Files  1 passed (1)
│       Tests  2 passed (2)
│    Start at  15:50:48
│    Duration  852ms (transform 10ms, setup 10ms, import 501ms, tests 246ms, environment 0ms)
└─ Done in 1.16 s
```


<!-- If this PR is related to an issue, please link it here -->

This PR closes #2371 
