### PR TITLE
feat(wxt): expose file watcher options

### DIFF
--- a/packages/wxt/e2e/tests/dev.test.ts
+++ b/packages/wxt/e2e/tests/dev.test.ts
@@ -1,3 +1,4 @@
+import type { InlineConfig } from 'vite';
 import { describe, expect, it } from 'vitest';
 import { TestProject, occupyPort } from '../utils';
 
@@ -82,6 +83,58 @@ describe('Dev Mode', () => {
       ).rejects.toThrow();
     } finally {
       await freePort();
+    }
+  });
+  it('should pass watchOptions to the Vite dev server watcher', async () => {
+    let watcherOptions: NonNullable<InlineConfig['server']>['watch'];
+
+    const project = new TestProject();
+    project.addFile(
+      'entrypoints/background.ts',
+      'export default defineBackground(() => {})',
+    );
+
+    const server = await project.startServer({
+      runner: { disabled: true },
+      vite: () => ({
+        server: {
+          watch: {
+            awaitWriteFinish: true,
+            ignored: ['vite-ignore/**'],
+          },
+        },
+      }),
+      watchOptions: {
+        usePolling: true,
+        interval: 1000,
+        ignored: ['custom-ignore/**'],
+      },
+      hooks: {
+        'vite:devServer:extendConfig': (config) => {
+          watcherOptions = config.server?.watch;
+        },
+      },
+    });
+
+    try {
+      expect(watcherOptions).toMatchObject({
+        awaitWriteFinish: true,
+        usePolling: true,
+        interval: 1000,
+      });
+
+      expect(watcherOptions).toEqual(
+        expect.objectContaining({
+          ignored: expect.arrayContaining([
+            expect.stringContaining('.output'),
+            expect.stringContaining('.wxt'),
+            'vite-ignore/**',
+            'custom-ignore/**',
+          ]),
+        }),
+      );
+    } finally {
+      await server.stop();
     }
   });
 });

--- a/packages/wxt/src/core/builders/vite/index.ts
+++ b/packages/wxt/src/core/builders/vite/index.ts
@@ -28,6 +28,7 @@ import {
   VirtualModuleId,
 } from '../../utils/virtual-modules';
 import * as wxtPlugins from './plugins';
+import { resolveWatchOptions } from '../../utils/watch-options';
 
 export async function createViteBuilder(
   wxtConfig: ResolvedConfig,
@@ -66,9 +67,8 @@ export async function createViteBuilder(
     }
 
     config.server ??= {};
-    config.server.watch = {
-      ignored: [`${wxtConfig.outBaseDir}/**`, `${wxtConfig.wxtDir}/**`],
-    };
+
+    config.server.watch = resolveWatchOptions(wxtConfig, config.server.watch);
 
     // TODO: Remove once https://github.com/wxt-dev/wxt/pull/1411 is merged
     config.legacy ??= {};

--- a/packages/wxt/src/core/create-server.ts
+++ b/packages/wxt/src/core/create-server.ts
@@ -10,6 +10,7 @@ import {
   createFileReloader,
   reloadContentScripts,
 } from './utils/create-file-reloader';
+import { resolveWatchOptions } from './utils/watch-options';
 
 /**
  * Creates a dev server and pre-builds all the files that need to exist before
@@ -152,7 +153,10 @@ async function createServerInternal(): Promise<WxtDevServer> {
       logBabelSyntaxError(err);
       wxt.logger.info('Waiting for syntax error to be fixed...');
       await new Promise<void>((resolve) => {
-        const watcher = chokidar.watch(err.id, { ignoreInitial: true });
+        const watcher = chokidar.watch(err.id, {
+          ...resolveWatchOptions(wxt.config),
+          ignoreInitial: true,
+        });
         watcher.on('all', () => {
           watcher.close();
           wxt.logger.info('Syntax error resolved, rebuilding...');

--- a/packages/wxt/src/core/resolve-config.ts
+++ b/packages/wxt/src/core/resolve-config.ts
@@ -244,6 +244,7 @@ export async function resolveConfig(
     builtinModules,
     userModules,
     plugins: [],
+    watchOptions: mergedConfig.watchOptions,
     ...moduleOptions,
   };
 }

--- a/packages/wxt/src/core/utils/watch-options.ts
+++ b/packages/wxt/src/core/utils/watch-options.ts
@@ -1,0 +1,25 @@
+import type { AnymatchPattern } from 'vite';
+import type { ResolvedConfig, WxtWatchOptions } from '../../types';
+
+export function resolveWatchOptions(
+  config: ResolvedConfig,
+  viteWatchOptions?: WxtWatchOptions | null,
+): WxtWatchOptions {
+  return {
+    ...viteWatchOptions,
+    ...config.watchOptions,
+    ignored: [
+      `${config.outBaseDir}/**`,
+      `${config.wxtDir}/**`,
+      ...normalizeIgnored(viteWatchOptions?.ignored),
+      ...normalizeIgnored(config.watchOptions?.ignored),
+    ],
+  };
+}
+
+function normalizeIgnored(
+  ignored: WxtWatchOptions['ignored'] | undefined,
+): AnymatchPattern[] {
+  if (ignored == null) return [];
+  return Array.isArray(ignored) ? ignored : [ignored];
+}

--- a/packages/wxt/src/types.ts
+++ b/packages/wxt/src/types.ts
@@ -429,6 +429,12 @@ export interface InlineConfig {
    * "wxt-module-analytics").
    */
   modules?: string[];
+
+  /**
+   * Configure file watching behavior during development. These options are
+   * passed to Vite's dev server watcher.
+   */
+  watchOptions?: WxtWatchOptions;
 }
 
 // TODO: Extract to @wxt/vite-builder and use module augmentation to include the vite field
@@ -1571,6 +1577,7 @@ export interface ResolvedConfig {
   hooks: NestedHooks<WxtHooks>;
   builtinModules: WxtModule<any>[];
   userModules: WxtModuleWithMetadata<any>[];
+  watchOptions?: WxtWatchOptions;
   /**
    * An array of string to import plugins from. These paths should be resolvable
    * by vite, and they should `export default defineWxtPlugin(...)`.
@@ -1801,3 +1808,5 @@ export interface WxtDirFileEntry {
   /** Set to `true` to add a reference to this file in `.wxt/wxt.d.ts`. */
   tsReference?: boolean;
 }
+
+export type WxtWatchOptions = NonNullable<vite.ServerOptions['watch']>;


### PR DESCRIPTION
### Overview

Adds a `watchOptions` config option to `wxt.config.ts` so users can configure file watching behavior.

This is intended for environments where native file events may not be delivered reliably, such as Docker, devcontainers, WSL mounts, or network filesystems. In those cases, users can opt into polling with `watchOptions: { usePolling: true }` instead of relying on `CHOKIDAR_USEPOLLING=1`.

The options are forwarded to Vite's dev server watcher while preserving WXT's default ignored paths.

### Manual Testing

#### Run the dev server e2e test

```sh
bun run --filter wxt test -- --run e2e/tests/dev.test.ts
```

This verifies that `watchOptions` is forwarded to Vite's dev server watcher while preserving `usePolling`, `interval`, WXT's default ignored paths, existing `vite.server.watch`, and custom ignored entries.

#### Docker & Dev Container manual checks

To manually verify the behavior, run a WXT project with:

```ts
export default defineConfig({
  watchOptions: {
    usePolling: true,
    interval: 1000,
  },
});
```

inside a Docker container or devcontainer, edit a mounted source file from inside the same container, and confirm that WXT logs the change and reloads the extension.

I also tested this branch in both a Docker container and a VS Code devcontainer with `packages/wxt-demo` using a temporary `watchOptions: { usePolling: true, interval: 1000 }` config. Editing an entrypoint file from inside the same container triggered reload in both cases.

### Related Issue

This PR closes #2342