### PR TITLE
chore: Add Google Cloud Skills Boost - Helper extension to showcase

### DIFF
--- a/docs/assets/extension-showcase.yml
+++ b/docs/assets/extension-showcase.yml
@@ -469,3 +469,7 @@
 
 - # Link Later
   chromeId: gpehbbegbcpjmipphokcmfhkchhcpfam
+
+- # Google Cloud Skills Boost - Helper
+  chromeId: lmbhjioadhcoebhgapaidogodllonbgg
+  firefoxSlug: cloud-skills-boost-helper


### PR DESCRIPTION
### Overview

- add Google Cloud Skills Boost - Helper to showcase

<img width="1200" height="750" alt="_caEZuOHTHokFJZy-GoiG" src="https://github.com/user-attachments/assets/b6b27981-3419-4e4e-bb10-611f78291ec2" />

