### PR TITLE
fix: `wxt clean` removes `.wxt/` directory at project root

### DIFF
--- a/packages/wxt/src/core/clean.ts
+++ b/packages/wxt/src/core/clean.ts
@@ -39,7 +39,7 @@ export async function clean(config?: string | InlineConfig) {
   const tempDirs = [
     'node_modules/.vite',
     'node_modules/.cache',
-    '**/.wxt',
+    '{,**/}.wxt',
     `${path.relative(root, wxt.config.outBaseDir)}/*`,
   ];
   wxt.logger.debug(


### PR DESCRIPTION
### Overview
`wxt clean` never deleted a `.wxt` directory located at the project root. The `**/.wxt` line requires at least one parent path, so only nested `.wxt` directories matched. Replace it with `{,**/}.wxt`, which matches both root and nested `.wxt`. 

(The same result is achievable by adding `'.wxt'` alongside `'**/.wxt'`, but that takes an extra line.)

### Manual Testing

Create a directory '.wxt' in the project root. By running 'wxt clean', the .wxt directory gets deleted, along with any nested `.wxt` directory. Before this change, the root '.wxt' directory would not be deleted, and now it does along with the other files.

### Related Issue

This PR closes #2413 
