### PR TITLE
docs: Revert #2380 - locationWatcher

### DIFF
--- a/docs/guide/essentials/content-scripts.md
+++ b/docs/guide/essentials/content-scripts.md
@@ -734,7 +734,6 @@ const watchPattern = new MatchPattern('*://*.youtube.com/watch*');
 export default defineContentScript({
   matches: ['*://*.youtube.com/*'],
   main(ctx) {
-    ctx.locationWatcher.run();
     ctx.addEventListener(window, 'wxt:locationchange', ({ newUrl }) => {
       if (watchPattern.includes(newUrl)) mainWatch(ctx);
     });


### PR DESCRIPTION
### Overview

This reverts: https://github.com/wxt-dev/wxt/pull/2380

Reference: https://wxt.dev/guide/essentials/content-scripts.html#dealing-with-spas

The `locationWatcher` is clearly marked as private here.
https://github.com/wxt-dev/wxt/blob/main/packages/wxt/src/utils/content-script-context.ts#L50

And initially started here.
https://github.com/wxt-dev/wxt/blob/main/packages/wxt/src/utils/content-script-context.ts#L227

So it cant be used as noted in the docs, unless some other changes are made...