### PR TITLE
docs: Added NiceTab firefoxslug to extension showcase

### DIFF
--- a/docs/assets/extension-showcase.yml
+++ b/docs/assets/extension-showcase.yml
@@ -105,6 +105,7 @@
 
 - # NiceTab - https://github.com/web-dahuyou/NiceTab
   chromeId: fonflmjnjbkigocpoommgmhljdpljain
+  firefoxSlug: nice-tab-manager
 
 - # Draftly for LinkedIn
   chromeId: fcffekbnfcfdemeekijbbmgmkognnmkd


### PR DESCRIPTION
### Overview

Added NiceTab firefoxslug to extension showcase
- chromeId: fonflmjnjbkigocpoommgmhljdpljain
- firefoxSlug: nice-tab-manager


Additionally, does it support adding Edge Addons
