### PR TITLE
fix: support spread properties in defineContentScript

### DIFF
--- a/packages/wxt/src/core/utils/__tests__/transform.test.ts
+++ b/packages/wxt/src/core/utils/__tests__/transform.test.ts
@@ -170,5 +170,20 @@ export default defineBackground();`;
       const actual = removeMainFunctionCode(input).code;
       expect(actual).toEqual(expected);
     });
+
+    it('should remove main field when object contains spread properties', () => {
+      const input = `
+        export default defineContentScript({
+        ...SHARED_CONFIG,
+        main: () => {},
+      })
+      `;
+
+      const actual = removeMainFunctionCode(input).code;
+
+      expect(actual).toContain('...SHARED_CONFIG');
+      expect(actual).not.toContain('main:');
+    });
+
   });
 });

--- a/packages/wxt/src/core/utils/transform.ts
+++ b/packages/wxt/src/core/utils/transform.ts
@@ -41,7 +41,7 @@ function emptyMainFunction(mod: ProxifiedModule): void {
       // ex: "fn({ ..., main: () => {} })" to "fn({ ... })"
       mod.exports.default.$ast.arguments[0].properties =
         mod.exports.default.$ast.arguments[0].properties.filter(
-          (prop: any) => prop.key.name !== 'main',
+          (prop: any) => prop.key?.name !== 'main',
         );
     }
   }


### PR DESCRIPTION
## Summary

Fixes #2400.

When `defineContentScript` contains spread properties, the transform code crashes because spread elements do not have a `key` property.

This change safely handles spread properties and adds a regression test to verify that spread properties are preserved while the `main` field is removed.
