### PR TITLE
docs: document content script per-browser options

### DIFF
--- a/docs/guide/essentials/entrypoints.md
+++ b/docs/guide/essentials/entrypoints.md
@@ -296,6 +296,30 @@ export default defineContentScript({
 });
 ```
 
+Some entrypoint options can also be specified per-browser by passing an object of browser-specific values. This is useful for targeting different match patterns, run timings, or execution modes across browsers.
+
+```ts
+export default defineContentScript({
+  matches: {
+    chrome: ['*://chrome.example.com/*'],
+    firefox: ['*://firefox.example.com/*'],
+  },
+  runAt: {
+    chrome: 'document_start',
+    firefox: 'document_end',
+  },
+
+  // Optional: use main world only in Firefox
+  world: {
+    firefox: 'MAIN',
+  },
+
+  main(ctx) {
+    // Executed when content script is loaded, can be async
+  },
+});
+```
+
 When defining content script entrypoints, keep in mind that WXT will import this file in a NodeJS environment during the build process. That means you cannot place any runtime code outside the `main` function.
 
 <!-- prettier-ignore -->


### PR DESCRIPTION
## Overview

This PR adds a concise docs example for `defineContentScript` showing per-browser configuration objects for supported options.

It demonstrates how fields like `matches`, `runAt`, and `world` can vary by browser in entrypoints (for example `chrome` vs `firefox` mappings).

This addresses issue #2304 by documenting existing `PerBrowser` support.

## Manual Testing

- `npm run check` (root) was executed in this repo context, but it fails in this environment due `scripts/check-format.js` attempting to read a 2+GiB file (`ERR_FS_FILE_TOO_LARGE`) before completion.
- `npm run check` in `wxt` was executed and completed the initial shared checks, but fails due pre-existing workspace issues:
  - `wxt-demo` TypeScript problems in unrelated sample/demo files.
  - package-level `tsdown` configuration expects a generated `./.wxt/tsconfig.json` in certain package contexts.

No code changes beyond this docs update are included.

## Related Issue

Closes #2304
