### PR TITLE
fix: Rename `ManifestPermissions` to `ManifestPermission` of types.ts in `wxt` package

### DIFF
--- a/packages/wxt/src/types.ts
+++ b/packages/wxt/src/types.ts
@@ -1085,7 +1085,7 @@ export type UserManifest = {
     };
   };
   permissions?: (
-    | Browser.runtime.ManifestPermissions
+    | Browser.runtime.ManifestPermission
     | (string & Record<never, never>)
   )[];
   web_accessible_resources?:


### PR DESCRIPTION
### Overview

Because of https://github.com/wxt-dev/wxt/commit/c8e93b15dbb024c0a5f8132a2c492649938ee7de#diff-10fb6419eef9cf3c6b16b7a274e0f2fd6494dcc98b025e413a622f9e5471aafeL9228-L9232