### PR TITLE
docs: Add `CopyApes` to extension-showcase.yml

### DIFF
--- a/docs/assets/extension-showcase.yml
+++ b/docs/assets/extension-showcase.yml
@@ -509,3 +509,6 @@
 - # Hayami: Anime comments & discussions
   chromeId: nhkggpiaeaeeeimohfpchnjobbamfcbg
   firefoxSlug: hayami
+
+- # CopyApes Assistant
+  chromeId: affmjifigldmicnbgpghddaneomejmfo


### PR DESCRIPTION
Overview
Added CopyApes Assistant to the showcase, a WXT-powered enhancement plugin for web3 exchange contract copy-trading, designed to retrieve the exchange's cookie information.

Manual Testing
NA

Related Issue
NA