### PR TITLE
fix: updating the alignment of the blue text in auto-mount-ui.

### DIFF
--- a/packages/wxt-demo/src/entrypoints/automount.content/index.ts
+++ b/packages/wxt-demo/src/entrypoints/automount.content/index.ts
@@ -28,9 +28,10 @@ export default defineContentScript({
       append: 'after',
       anchor: '#automount-anchor',
       onMount: (container) => {
+        container.classList.add('flex', 'items-start', 'justify-start');
         const app = document.createElement('div');
         app.id = 'automount-ui';
-        app.classList.add('m-0', 'text-center', 'text-blue-500');
+        app.classList.add('m-8', 'text-center', 'text-blue-500');
         app.textContent = `Hello, I'm automount UI.`;
         container.append(app);
       },

--- a/packages/wxt-demo/src/entrypoints/automount.content/index.ts
+++ b/packages/wxt-demo/src/entrypoints/automount.content/index.ts
@@ -28,10 +28,15 @@ export default defineContentScript({
       append: 'after',
       anchor: '#automount-anchor',
       onMount: (container) => {
-        container.classList.add('flex', 'items-start', 'justify-start');
+        container.classList.add(
+          'flex',
+          '-ml-9',
+          'items-start',
+          'justify-start',
+        );
         const app = document.createElement('div');
         app.id = 'automount-ui';
-        app.classList.add('m-8', 'text-center', 'text-blue-500');
+        app.classList.add('mt-9', 'text-center', 'text-blue-500');
         app.textContent = `Hello, I'm automount UI.`;
         container.append(app);
       },


### PR DESCRIPTION
### Overview

In the Issue, it was said that the blue text was being cut off, so I decided to shift the alignment of the text to the left side of the button.

### Manual Testing

1. Run pnpm -F wxt-demo dev and see

### Related Issue

This PR closes #2338 
