### PR TITLE
fix: opening the browser issue in windows.

### DIFF
--- a/packages/wxt/src/core/create-server.ts
+++ b/packages/wxt/src/core/create-server.ts
@@ -93,14 +93,6 @@ async function createServerInternal(): Promise<WxtDevServer> {
       const reloadOnChange = createFileReloader(server);
       server.watcher.on('all', async (...args) => {
         await reloadOnChange(args[0], args[1]);
-
-        // Restart keyboard shortcuts after file is changed - for some reason they stop working.
-        keyboardShortcuts.start();
-      });
-
-      keyboardShortcuts.printHelp({
-        canReopenBrowser:
-          !wxt.config.runnerConfig.config.disabled && !!runner.canOpen?.(),
       });
     },
 
@@ -137,6 +129,10 @@ async function createServerInternal(): Promise<WxtDevServer> {
       runner = await createExtensionRunner();
       await runner.openBrowser();
       keyboardShortcuts.start();
+      keyboardShortcuts.printHelp({
+        canReopenBrowser:
+          !wxt.config.runnerConfig.config.disabled && !!runner.canOpen?.(),
+      });
     },
   };
   const keyboardShortcuts = createKeyboardShortcuts(server);
@@ -172,6 +168,11 @@ async function createServerInternal(): Promise<WxtDevServer> {
 
     // Open browser after everything is ready to go.
     await runner.openBrowser();
+    keyboardShortcuts.start();
+    keyboardShortcuts.printHelp({
+      canReopenBrowser:
+        !wxt.config.runnerConfig.config.disabled && !!runner.canOpen?.(),
+    });
   };
 
   builderServer.on?.('close', () => keyboardShortcuts.stop());


### PR DESCRIPTION
### Overview
**_Problem_**: Press o + enter to reopen the browser doesn't work on Windows.

**_Fix_**: While opening the browser calling the start function was missed.

_PS: I've checked it in Linux as well, it is working fine there too._
_Finally this issue is fixed._

### Manual Testing

1. cd into `packages/wxt-demo` and run bun dev.
2. Try different scenario for pressing `o + Enter`.

### Related Issue

<!-- If this PR is related to an issue, please link it here -->

This PR closes #2294 

https://github.com/user-attachments/assets/f08bf14c-615e-438b-9ea3-b899e4c2812d

