### PR TITLE
fix: preserve matchOriginAsFallback in dev scripts

### DIFF
--- a/packages/wxt/src/core/utils/__tests__/content-scripts.test.ts
+++ b/packages/wxt/src/core/utils/__tests__/content-scripts.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it, beforeEach } from 'vitest';
-import { hashContentScriptOptions } from '../content-scripts';
+import {
+  hashContentScriptOptions,
+  mapWxtOptionsToRegisteredContentScript,
+} from '../content-scripts';
 import { setFakeWxt } from '../testing/fake-objects';
 
 describe('Content Script Utils', () => {
@@ -28,6 +31,46 @@ describe('Content Script Utils', () => {
       });
 
       expect(hash1).toBe(hash2);
+    });
+  });
+
+  describe('mapWxtOptionsToRegisteredContentScript', () => {
+    it('preserves matchOriginAsFallback for dynamic registration', () => {
+      const contentScript = mapWxtOptionsToRegisteredContentScript(
+        {
+          matches: ['*://example.com/*'],
+          matchOriginAsFallback: true,
+          allFrames: true,
+          runAt: 'document_start',
+          world: 'MAIN',
+        },
+        ['content-scripts/example.js'],
+        undefined,
+      );
+
+      expect(contentScript).toEqual({
+        allFrames: true,
+        excludeMatches: undefined,
+        matchOriginAsFallback: true,
+        matches: ['*://example.com/*'],
+        runAt: 'document_start',
+        js: ['content-scripts/example.js'],
+        css: undefined,
+        world: 'MAIN',
+      });
+    });
+
+    it('preserves false matchOriginAsFallback values', () => {
+      const contentScript = mapWxtOptionsToRegisteredContentScript(
+        {
+          matches: ['*://example.com/*'],
+          matchOriginAsFallback: false,
+        },
+        ['content-scripts/example.js'],
+        [],
+      );
+
+      expect(contentScript.matchOriginAsFallback).toBe(false);
     });
   });
 });

--- a/packages/wxt/src/core/utils/content-scripts.ts
+++ b/packages/wxt/src/core/utils/content-scripts.ts
@@ -75,6 +75,7 @@ export function mapWxtOptionsToRegisteredContentScript(
   return {
     allFrames: options.allFrames,
     excludeMatches: options.excludeMatches,
+    matchOriginAsFallback: options.matchOriginAsFallback,
     matches: options.matches,
     runAt: options.runAt,
     js,


### PR DESCRIPTION
### Overview

Preserves `matchOriginAsFallback` when WXT maps content script options into the MV3 registered content script payload used during dev reloads.

Chrome and the generated browser types support `matchOriginAsFallback` for `scripting.RegisteredContentScript`, while `matchAboutBlank`, `includeGlobs`, and `excludeGlobs` stay manifest-only options.

### Manual Testing

- `bun run --filter wxt test run content-scripts`
- `bun run --filter wxt check`
- `bun run --filter wxt test run`
- `bun run check`
- `bun run test`

### Related Issue

This PR closes #2335
