### PR TITLE
test: skip package manager tests when binaries is missing

### DIFF
--- a/packages/wxt/src/core/package-managers/__tests__/pnpm.test.ts
+++ b/packages/wxt/src/core/package-managers/__tests__/pnpm.test.ts
@@ -2,10 +2,11 @@ import spawn from 'nano-spawn';
 import path from 'node:path';
 import { beforeAll, describe, expect, it } from 'vitest';
 import { pnpm } from '../pnpm';
+import { describeWithBin } from '../../utils/testing/fixtures';
 
 process.env.WXT_PNPM_IGNORE_WORKSPACE = 'true';
 
-describe('PNPM Package Management Utils', () => {
+describeWithBin('pnpm', 'PNPM Package Management Utils', () => {
   describe('listDependencies', () => {
     const cwd = path.resolve(__dirname, 'fixtures/simple-pnpm-project');
 

--- a/packages/wxt/src/core/package-managers/__tests__/yarn.test.ts
+++ b/packages/wxt/src/core/package-managers/__tests__/yarn.test.ts
@@ -1,17 +1,9 @@
 import { describe, expect, it } from 'vitest';
 import path from 'node:path';
-import { spawnSync } from 'node:child_process';
 import { yarn } from '../yarn';
+import { describeWithBin } from '../../utils/testing/fixtures';
 
-const describeIfYarnInstalled =
-  spawnSync('yarn', ['--version'], {
-    stdio: 'ignore',
-    shell: process.platform === 'win32',
-  }).status === 0
-    ? describe
-    : describe.skip;
-
-describeIfYarnInstalled('Yarn Package Management Utils', () => {
+describeWithBin('yarn', 'Yarn Package Management Utils', () => {
   describe('listDependencies', () => {
     const cwd = path.resolve(__dirname, 'fixtures/simple-yarn-project');
 

--- a/packages/wxt/src/core/package-managers/__tests__/yarn.test.ts
+++ b/packages/wxt/src/core/package-managers/__tests__/yarn.test.ts
@@ -1,8 +1,17 @@
 import { describe, expect, it } from 'vitest';
 import path from 'node:path';
+import { spawnSync } from 'node:child_process';
 import { yarn } from '../yarn';
 
-describe('Yarn Package Management Utils', () => {
+const describeIfYarnInstalled =
+  spawnSync('yarn', ['--version'], {
+    stdio: 'ignore',
+    shell: process.platform === 'win32',
+  }).status === 0
+    ? describe
+    : describe.skip;
+
+describeIfYarnInstalled('Yarn Package Management Utils', () => {
   describe('listDependencies', () => {
     const cwd = path.resolve(__dirname, 'fixtures/simple-yarn-project');
 

--- a/packages/wxt/src/core/utils/testing/fixtures.ts
+++ b/packages/wxt/src/core/utils/testing/fixtures.ts
@@ -1,0 +1,17 @@
+import { spawnSync } from 'node:child_process';
+import { describe } from 'vitest';
+
+export function describeWithBin(
+  bin: string,
+  title: string,
+  callback: () => void,
+) {
+  if (process.env.CI === 'true') return describe(title, callback);
+
+  const result = spawnSync(bin, ['--version'], {
+    stdio: 'ignore',
+    shell: true,
+  });
+  if (result.status !== 0) return describe.skip(title, callback);
+  return describe(title, callback);
+}


### PR DESCRIPTION
## Summary

- Skip the yarn package-manager test suite when the `yarn` binary is not available.
- Keep the existing assertions unchanged for environments with yarn installed.

Fixes #2371.

## Testing

- `bun run --filter wxt test src/core/package-managers/__tests__/yarn.test.ts`
- `PATH=/Users/terry/.bun/bin:/usr/bin:/bin bun run --filter wxt test src/core/package-managers/__tests__/yarn.test.ts`
- `bun run --filter wxt check`
- `bun run prettier --check packages/wxt/src/core/package-managers/__tests__/yarn.test.ts`
- `git diff --check`
