### PR TITLE
fix: preserve gitignore during init

### DIFF
--- a/packages/wxt/src/core/__tests__/initialize.test.ts
+++ b/packages/wxt/src/core/__tests__/initialize.test.ts
@@ -1,0 +1,90 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  mkdir,
+  mkdtemp,
+  readFile,
+  readdir,
+  rm,
+  writeFile,
+} from 'node:fs/promises';
+import path from 'node:path';
+import { tmpdir } from 'node:os';
+import { initialize } from '../initialize';
+
+const mocks = vi.hoisted(() => ({
+  downloadTemplate: vi.fn(),
+  destinationDir: '',
+}));
+
+vi.mock('prompts', () => ({
+  default: vi.fn(() => ({})),
+}));
+
+vi.mock('giget', () => ({
+  downloadTemplate: mocks.downloadTemplate,
+}));
+
+vi.mock('nanospinner', () => ({
+  createSpinner: () => ({
+    start() {
+      return this;
+    },
+    success: vi.fn(),
+    error: vi.fn(),
+  }),
+}));
+
+describe('initialize', () => {
+  let rootDir: string;
+
+  beforeEach(async () => {
+    rootDir = await mkdtemp(path.join(tmpdir(), 'wxt-init-test-'));
+    mocks.destinationDir = path.join(rootDir, 'extension');
+    await mkdir(path.join(rootDir, '.git'));
+    await mkdir(mocks.destinationDir);
+
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => {
+        return new Response(
+          JSON.stringify({
+            files: [{ path: 'templates/vue/package.json' }],
+          }),
+          { status: 200, statusText: 'OK' },
+        );
+      }),
+    );
+
+    mocks.downloadTemplate.mockImplementation(async (_input, options) => {
+      await mkdir(options.dir, { recursive: true });
+      await writeFile(path.join(options.dir, 'package.json'), '{}');
+
+      if (options.dir !== mocks.destinationDir) {
+        await writeFile(path.join(options.dir, '_gitignore'), 'node_modules\n');
+      }
+    });
+  });
+
+  afterEach(async () => {
+    vi.unstubAllGlobals();
+    vi.clearAllMocks();
+    await rm(rootDir, { recursive: true, force: true });
+  });
+
+  it('creates the gitignore when the destination already exists inside a parent Git repo', async () => {
+    await initialize({
+      directory: mocks.destinationDir,
+      template: 'vue',
+      packageManager: 'npm',
+    });
+
+    const extractedDir = mocks.downloadTemplate.mock.calls[0][1].dir;
+    expect(extractedDir).not.toBe(mocks.destinationDir);
+    expect(
+      await readFile(path.join(mocks.destinationDir, '.gitignore'), 'utf8'),
+    ).toBe('node_modules\n');
+    await expect(readdir(mocks.destinationDir)).resolves.not.toContain(
+      '_gitignore',
+    );
+  });
+});

--- a/packages/wxt/src/core/initialize.ts
+++ b/packages/wxt/src/core/initialize.ts
@@ -1,9 +1,10 @@
 import prompts from 'prompts';
 import { consola } from 'consola';
 import { downloadTemplate } from 'giget';
-import { readdir, rename } from 'node:fs/promises';
+import { cp, mkdtemp, readdir, rename, rm } from 'node:fs/promises';
 import { pathExists } from './utils/fs';
 import path from 'node:path';
+import { tmpdir } from 'node:os';
 import { styleText } from 'node:util';
 import { TextStyle } from '../utils/text-style';
 
@@ -166,25 +167,37 @@ async function cloneProject({
 }) {
   const { createSpinner } = await import('nanospinner');
   const spinner = createSpinner('Downloading template').start();
+  let templateDir: string | undefined;
   try {
-    // 1. Clone repo
+    // Download away from the target path so existing empty directories inside
+    // parent Git repos get the same files as newly created project paths.
+    templateDir = await mkdtemp(path.join(tmpdir(), 'wxt-init-'));
+
     await downloadTemplate(`gh:${REPO}/${template.path}`, {
-      dir: directory,
+      dir: templateDir,
       force: true,
     });
 
-    // 2. Move _gitignore -> .gitignore
-    await rename(
-      path.join(directory, '_gitignore'),
-      path.join(directory, '.gitignore'),
-    ).catch((err) =>
-      consola.warn('Failed to move _gitignore to .gitignore:', err),
-    );
+    await moveGitignore(templateDir);
+    await cp(templateDir, directory, { recursive: true, force: true });
 
     spinner.success();
   } catch (err) {
     spinner.error();
     throw Error(`Failed to setup new project: ${JSON.stringify(err, null, 2)}`);
+  } finally {
+    if (templateDir) await rm(templateDir, { recursive: true, force: true });
+  }
+}
+
+async function moveGitignore(directory: string) {
+  const gitignoreSource = path.join(directory, '_gitignore');
+  const gitignoreTarget = path.join(directory, '.gitignore');
+
+  if (await pathExists(gitignoreSource)) {
+    await rename(gitignoreSource, gitignoreTarget);
+  } else if (!(await pathExists(gitignoreTarget))) {
+    consola.warn('Template did not include _gitignore');
   }
 }
 


### PR DESCRIPTION
## Summary
- Download init templates into a temporary directory before copying them into the requested project directory.
- Rename `_gitignore` before copying so existing empty project directories under parent Git repos still receive `.gitignore`.
- Add regression coverage for an already-created target directory inside a parent Git repo.

Fixes #2289

## Tests
- `bun run --filter wxt test run src/core/__tests__/initialize.test.ts`
- `bun run --filter wxt test run src/core/__tests__/initialize.test.ts src/cli/__tests__/index.test.ts e2e/tests/init.test.ts`
- `bun run --filter wxt test run`
- `bun run --filter wxt check`
- `bunx prettier --check packages/wxt/src/core/initialize.ts packages/wxt/src/core/__tests__/initialize.test.ts`
- Manual init check in an already-created directory under a parent Git repo; verified `.gitignore` exists and `_gitignore` is absent.
