### PR TITLE
fix: await analytics reporting methods

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -55,6 +55,7 @@
         "publint": "catalog:",
         "tsdown": "catalog:",
         "typescript": "catalog:",
+        "vitest": "catalog:",
         "wxt": "workspace:*",
       },
       "peerDependencies": {

--- a/packages/analytics/modules/analytics/__tests__/client.test.ts
+++ b/packages/analytics/modules/analytics/__tests__/client.test.ts
@@ -1,0 +1,302 @@
+import { beforeEach, describe, expect, expectTypeOf, it, vi } from 'vitest';
+import { createAnalytics } from '../client';
+import type { Analytics, AnalyticsConfig } from '../types';
+
+let mockBrowser: any;
+let mockIsBackground = false;
+
+vi.mock('@wxt-dev/browser', () => ({
+  get browser() {
+    return mockBrowser;
+  },
+}));
+
+vi.mock('@wxt-dev/is-background', () => ({
+  isBackground: () => mockIsBackground,
+}));
+
+type MessageListener = (message: unknown) => void;
+type DisconnectListener = () => void;
+
+function flushMicrotasks(times = 1): Promise<void> {
+  if (times <= 0) return Promise.resolve();
+
+  return new Promise((resolve) => {
+    queueMicrotask(() => {
+      void flushMicrotasks(times - 1).then(resolve);
+    });
+  });
+}
+
+function createPortPair(name: string) {
+  const frontendMessageListeners: MessageListener[] = [];
+  const backgroundMessageListeners: MessageListener[] = [];
+  const disconnectListeners: DisconnectListener[] = [];
+
+  const frontendPort = {
+    name,
+    onMessage: {
+      addListener: vi.fn((listener: MessageListener) => {
+        frontendMessageListeners.push(listener);
+      }),
+    },
+    onDisconnect: {
+      addListener: vi.fn((listener: DisconnectListener) => {
+        disconnectListeners.push(listener);
+      }),
+    },
+    postMessage: vi.fn((message: unknown) => {
+      queueMicrotask(() => {
+        backgroundMessageListeners.forEach((listener) => listener(message));
+      });
+    }),
+  };
+
+  const backgroundPort = {
+    name,
+    onMessage: {
+      addListener: vi.fn((listener: MessageListener) => {
+        backgroundMessageListeners.push(listener);
+      }),
+    },
+    postMessage: vi.fn((message: unknown) => {
+      queueMicrotask(() => {
+        frontendMessageListeners.forEach((listener) => listener(message));
+      });
+    }),
+  };
+
+  return {
+    frontendPort,
+    backgroundPort,
+    disconnect: () => {
+      disconnectListeners.forEach((listener) => listener());
+    },
+  };
+}
+
+function setupBrowser() {
+  let connectListener: ((port: any) => void) | undefined;
+  let lastPortPair: ReturnType<typeof createPortPair> | undefined;
+
+  const browser = {
+    runtime: {
+      id: 'test-extension',
+      getManifest: vi.fn(() => ({ version: '1.0.0' })),
+      getPlatformInfo: vi.fn(async () => ({ arch: 'arm', os: 'mac' })),
+      onConnect: {
+        addListener: vi.fn((listener: (port: any) => void) => {
+          connectListener = listener;
+        }),
+      },
+      connect: vi.fn(({ name }: { name: string }) => {
+        lastPortPair = createPortPair(name);
+        connectListener?.(lastPortPair.backgroundPort);
+        return lastPortPair.frontendPort;
+      }),
+    },
+    storage: {
+      local: {
+        get: vi.fn(async () => ({})),
+        set: vi.fn(async () => {}),
+      },
+    },
+  };
+
+  return {
+    browser,
+    getLastPortPair: () => lastPortPair,
+  };
+}
+
+function setupGlobals() {
+  vi.stubGlobal('navigator', {
+    language: 'en-US',
+    userAgent:
+      'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 Chrome/126.0.0.0 Safari/537.36',
+  });
+  vi.stubGlobal('window', {
+    screen: {
+      width: 1440,
+      height: 900,
+    },
+  });
+  vi.stubGlobal('document', {
+    referrer: 'https://example.com/start',
+    title: 'Popup',
+  });
+  vi.stubGlobal('location', {
+    href: 'chrome-extension://test/popup.html',
+  });
+  vi.stubGlobal('crypto', {
+    randomUUID: vi.fn(() => 'generated-user-id'),
+  });
+}
+
+function createConfig(
+  overrides: Partial<AnalyticsConfig> = {},
+): AnalyticsConfig {
+  return {
+    providers: [],
+    enabled: {
+      getValue: vi.fn(async () => true),
+      setValue: vi.fn(async () => {}),
+    },
+    userId: {
+      getValue: vi.fn(async () => 'user-1'),
+      setValue: vi.fn(async () => {}),
+    },
+    userProperties: {
+      getValue: vi.fn(async () => ({ plan: 'test' })),
+      setValue: vi.fn(async () => {}),
+    },
+    version: '1.0.0',
+    ...overrides,
+  };
+}
+
+describe('createAnalytics', () => {
+  beforeEach(() => {
+    vi.unstubAllGlobals();
+    vi.clearAllMocks();
+    mockIsBackground = false;
+    setupGlobals();
+    mockBrowser = setupBrowser().browser;
+  });
+
+  it('exposes promise-returning analytics methods', () => {
+    expectTypeOf<ReturnType<Analytics['track']>>().toEqualTypeOf<
+      Promise<void>
+    >();
+    expectTypeOf<ReturnType<Analytics['page']>>().toEqualTypeOf<
+      Promise<void>
+    >();
+    expectTypeOf<ReturnType<Analytics['identify']>>().toEqualTypeOf<
+      Promise<void>
+    >();
+    expectTypeOf<ReturnType<Analytics['setEnabled']>>().toEqualTypeOf<
+      Promise<void>
+    >();
+    expectTypeOf<Parameters<Analytics['page']>>().toEqualTypeOf<
+      [url?: string | undefined]
+    >();
+  });
+
+  it('resolves frontend track calls after the background handler finishes', async () => {
+    let resolveTrack: (() => void) | undefined;
+    const track = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveTrack = resolve;
+        }),
+    );
+
+    mockIsBackground = true;
+    createAnalytics(
+      createConfig({
+        providers: [
+          () => ({
+            identify: vi.fn(async () => {}),
+            page: vi.fn(async () => {}),
+            track,
+          }),
+        ],
+      }),
+    );
+
+    mockIsBackground = false;
+    const analytics = createAnalytics();
+    const result = analytics.track('installed', { source: 'test' });
+
+    for (let i = 0; i < 10 && track.mock.calls.length === 0; i++) {
+      await flushMicrotasks();
+    }
+
+    expect(track).toHaveBeenCalledTimes(1);
+    expect(track).toHaveBeenCalledWith(
+      expect.objectContaining({
+        event: {
+          name: 'installed',
+          properties: { source: 'test' },
+        },
+        meta: expect.objectContaining({
+          language: 'en-US',
+          screen: '1440x900',
+          title: 'Popup',
+          url: 'chrome-extension://test/popup.html',
+        }),
+      }),
+    );
+
+    let resolved = false;
+    const completion = result.then(() => {
+      resolved = true;
+    });
+
+    await flushMicrotasks(3);
+    expect(resolved).toBe(false);
+
+    resolveTrack?.();
+    await completion;
+    expect(resolved).toBe(true);
+  });
+
+  it('keeps page metadata separate when location is omitted', async () => {
+    const page = vi.fn(async () => {});
+
+    mockIsBackground = true;
+    createAnalytics(
+      createConfig({
+        providers: [
+          () => ({
+            identify: vi.fn(async () => {}),
+            page,
+            track: vi.fn(async () => {}),
+          }),
+        ],
+      }),
+    );
+
+    mockIsBackground = false;
+    const analytics = createAnalytics();
+
+    await analytics.page();
+
+    expect(page).toHaveBeenCalledWith(
+      expect.objectContaining({
+        page: {
+          url: 'chrome-extension://test/popup.html',
+          location: undefined,
+          title: 'Popup',
+        },
+        meta: expect.objectContaining({
+          language: 'en-US',
+          title: 'Popup',
+          url: 'chrome-extension://test/popup.html',
+        }),
+      }),
+    );
+  });
+
+  it('rejects frontend setEnabled calls when the background handler fails', async () => {
+    const setValue = vi.fn(async () => {
+      throw new Error('storage failed');
+    });
+
+    mockIsBackground = true;
+    createAnalytics(
+      createConfig({
+        enabled: {
+          getValue: vi.fn(async () => true),
+          setValue,
+        },
+      }),
+    );
+
+    mockIsBackground = false;
+    const analytics = createAnalytics();
+
+    await expect(analytics.setEnabled(true)).rejects.toThrow('storage failed');
+    expect(setValue).toHaveBeenCalledWith(true);
+  });
+});

--- a/packages/analytics/modules/analytics/client.ts
+++ b/packages/analytics/modules/analytics/client.ts
@@ -12,20 +12,49 @@ import type {
 import { browser } from '@wxt-dev/browser';
 import { isBackground } from '@wxt-dev/is-background';
 
-type AnalyticsMessage = {
-  [K in keyof Analytics]: {
+type AsyncAnalyticsMethod = 'identify' | 'page' | 'track' | 'setEnabled';
+
+type BackgroundAnalyticsArgs = {
+  identify: [
+    userId: string,
+    userProperties?: Record<string, string>,
+    meta?: AnalyticsEventMetadata,
+  ];
+  page: [location?: string, meta?: AnalyticsEventMetadata];
+  track: [
+    eventName: string,
+    eventProperties?: Record<string, string | undefined>,
+    meta?: AnalyticsEventMetadata,
+  ];
+  setEnabled: [enabled: boolean];
+};
+
+type AnalyticsRequestMessage = {
+  [K in AsyncAnalyticsMethod]: {
+    id: number;
     fn: K;
-    args: Parameters<Analytics[K]>;
+    args: BackgroundAnalyticsArgs[K];
   };
-}[keyof Analytics];
+}[AsyncAnalyticsMethod];
 
-type AnalyticsMethod =
-  | ((...args: Parameters<Analytics[keyof Analytics]>) => void)
-  | undefined;
+type AnalyticsRequestPayload = {
+  [K in AsyncAnalyticsMethod]: {
+    fn: K;
+    args: BackgroundAnalyticsArgs[K];
+  };
+}[AsyncAnalyticsMethod];
 
-type MethodForwarder = <K extends keyof Analytics>(
-  fn: K,
-) => (...args: Parameters<Analytics[K]>) => void;
+type AnalyticsResponseMessage =
+  | { id: number; status: 'fulfilled' }
+  | { id: number; status: 'rejected'; error: string };
+
+type AnalyticsPortMessage = AnalyticsRequestMessage | AnalyticsResponseMessage;
+
+type BackgroundAnalytics = {
+  [K in AsyncAnalyticsMethod]: (
+    ...args: BackgroundAnalyticsArgs[K]
+  ) => Promise<void>;
+};
 
 const ANALYTICS_PORT = '@wxt-dev/analytics';
 
@@ -44,6 +73,28 @@ const INTERACTIVE_ROLES = new Set([
   'tab',
   'radio',
 ]);
+
+function isAnalyticsResponse(
+  message: AnalyticsPortMessage,
+): message is AnalyticsResponseMessage {
+  return 'status' in message;
+}
+
+async function callBackgroundAnalytics(
+  analytics: BackgroundAnalytics,
+  message: AnalyticsRequestMessage,
+): Promise<void> {
+  switch (message.fn) {
+    case 'identify':
+      return analytics.identify(...message.args);
+    case 'page':
+      return analytics.page(...message.args);
+    case 'track':
+      return analytics.track(...message.args);
+    case 'setEnabled':
+      return analytics.setEnabled(...message.args);
+  }
+}
 
 export function createAnalytics(config?: AnalyticsConfig): Analytics {
   if (!browser?.runtime?.id)
@@ -152,7 +203,7 @@ function createBackgroundAnalytics(
       }
     },
     page: async (
-      location: string,
+      location?: string,
       meta: AnalyticsEventMetadata = getBackgroundMeta(),
     ) => {
       const baseEvent = await getBaseEvent(meta);
@@ -207,12 +258,26 @@ function createBackgroundAnalytics(
 
   const providers =
     config?.providers?.map((provider) => provider(analytics, config)) ?? [];
+  const backgroundAnalytics = analytics as BackgroundAnalytics;
 
   // Listen for messages from the rest of the extension
   browser.runtime.onConnect.addListener((port) => {
     if (port.name === ANALYTICS_PORT) {
-      port.onMessage.addListener(({ fn, args }: AnalyticsMessage) => {
-        void (analytics[fn] as AnalyticsMethod)?.(...args);
+      port.onMessage.addListener((message: AnalyticsPortMessage) => {
+        if (isAnalyticsResponse(message)) return;
+
+        void (async () => {
+          try {
+            await callBackgroundAnalytics(backgroundAnalytics, message);
+            port.postMessage({ id: message.id, status: 'fulfilled' });
+          } catch (error) {
+            port.postMessage({
+              id: message.id,
+              status: 'rejected',
+              error: error instanceof Error ? error.message : String(error),
+            });
+          }
+        })();
       });
     }
   });
@@ -224,6 +289,11 @@ function createBackgroundAnalytics(
 function createFrontendAnalytics(): Analytics {
   const port = browser.runtime.connect({ name: ANALYTICS_PORT });
   const sessionId = Date.now();
+  let nextMessageId = 0;
+  const pendingMessages = new Map<
+    number,
+    { resolve: () => void; reject: (error: Error) => void }
+  >();
   const getFrontendMetadata = (): AnalyticsEventMetadata => ({
     sessionId,
     timestamp: Date.now(),
@@ -234,17 +304,61 @@ function createFrontendAnalytics(): Analytics {
     title: document.title || undefined,
   });
 
-  const methodForwarder: MethodForwarder =
-    (fn) =>
-    (...args) => {
-      port.postMessage({ fn, args: [...args, getFrontendMetadata()] });
-    };
+  port.onMessage.addListener((message: AnalyticsPortMessage) => {
+    if (!isAnalyticsResponse(message)) return;
+
+    const pendingMessage = pendingMessages.get(message.id);
+    if (pendingMessage == null) return;
+
+    pendingMessages.delete(message.id);
+    if (message.status === 'fulfilled') {
+      pendingMessage.resolve();
+    } else {
+      pendingMessage.reject(new Error(message.error));
+    }
+  });
+
+  port.onDisconnect?.addListener(() => {
+    for (const { reject } of pendingMessages.values()) {
+      reject(new Error('Analytics background connection closed'));
+    }
+    pendingMessages.clear();
+  });
+
+  const sendRequest = (payload: AnalyticsRequestPayload): Promise<void> =>
+    new Promise<void>((resolve, reject) => {
+      const id = ++nextMessageId;
+      pendingMessages.set(id, { resolve, reject });
+
+      try {
+        port.postMessage({ id, ...payload } as AnalyticsRequestMessage);
+      } catch (error) {
+        pendingMessages.delete(id);
+        reject(error instanceof Error ? error : new Error(String(error)));
+      }
+    });
 
   const analytics: Analytics = {
-    identify: methodForwarder('identify'),
-    page: methodForwarder('page'),
-    track: methodForwarder('track'),
-    setEnabled: methodForwarder('setEnabled'),
+    identify: (userId, userProperties) =>
+      sendRequest({
+        fn: 'identify',
+        args: [userId, userProperties, getFrontendMetadata()],
+      }),
+    page: (location) =>
+      sendRequest({
+        fn: 'page',
+        args: [location, getFrontendMetadata()],
+      }),
+    track: (eventName, eventProperties) =>
+      sendRequest({
+        fn: 'track',
+        args: [eventName, eventProperties, getFrontendMetadata()],
+      }),
+    setEnabled: (enabled) =>
+      sendRequest({
+        fn: 'setEnabled',
+        args: [enabled],
+      }),
     autoTrack: (root) => {
       const onClick = (event: Event) => {
         const element = event.target as HTMLElement | null;

--- a/packages/analytics/modules/analytics/types.ts
+++ b/packages/analytics/modules/analytics/types.ts
@@ -1,20 +1,23 @@
 export interface Analytics {
   /** Report a page change. */
-  page: (url: string) => void;
+  page: (url?: string) => Promise<void>;
   /** Report a custom event. */
   track: (
     eventName: string,
     eventProperties?: Record<string, string | undefined>,
-  ) => void;
+  ) => Promise<void>;
   /** Save information about the user. */
-  identify: (userId: string, userProperties?: Record<string, string>) => void;
+  identify: (
+    userId: string,
+    userProperties?: Record<string, string>,
+  ) => Promise<void>;
   /**
    * Automatically setup and track user interactions, returning a function to
    * remove any listeners that were setup.
    */
   autoTrack: (root: Document | ShadowRoot | Element) => () => void;
   /** Calls `config.enabled.setValue`. */
-  setEnabled: (enabled: boolean) => void;
+  setEnabled: (enabled: boolean) => Promise<void>;
 }
 
 export interface AnalyticsConfig {

--- a/packages/analytics/package.json
+++ b/packages/analytics/package.json
@@ -10,8 +10,8 @@
     "build": "buildc -- tsdown",
     "prepack": "bun run build",
     "postinstall": "buildc --deps-only -- wxt prepare",
-    "test": "echo 'noop'",
-    "test:coverage": "echo 'noop'"
+    "test": "buildc --deps-only -- vitest",
+    "test:coverage": "bun run test run --coverage"
   },
   "dependencies": {
     "@wxt-dev/browser": "workspace:^",
@@ -27,6 +27,7 @@
     "publint": "catalog:",
     "tsdown": "catalog:",
     "typescript": "catalog:",
+    "vitest": "catalog:",
     "wxt": "workspace:*"
   },
   "repository": {


### PR DESCRIPTION
### Description

Makes the public analytics reporting API return promises for `track`, `page`, `identify`, and `setEnabled`, matching the documented `await analytics.track(...)` usage. Foreground calls now resolve from a background-port acknowledgment after the background handler finishes, and reject when that handler fails.

This also allows `analytics.page()` with no location and keeps foreground metadata separate from optional analytics payload arguments.

### Linked Issues

fixes #2408

### Checks

- `bun run --filter @wxt-dev/analytics test run`
- `bun run --filter @wxt-dev/analytics check`
- `../../node_modules/.bin/tsdown` from `packages/analytics`
- `git diff --check`
- provenance and public-text scans