### PR TITLE
fix: scope shadow root CSS properties

### DIFF
--- a/packages/wxt/src/utils/__tests__/split-shadow-root-css.test.ts
+++ b/packages/wxt/src/utils/__tests__/split-shadow-root-css.test.ts
@@ -69,5 +69,58 @@ describe('Shadow Root Utils', () => {
         documentCss: expectedDocumentCss,
       });
     });
+
+    it('should scope properties registered outside the shadow root', () => {
+      const css = `
+:host {
+  --tw-gradient-from: red;
+  color: var(--tw-gradient-from);
+  border-color: var(--tw-gradient-from-position);
+  background: var(--unregistered);
+}
+
+@property --tw-gradient-from {
+  syntax: "<color>";
+  inherits: false;
+  initial-value: #0000;
+}
+
+@property --tw-gradient-from-position {
+  syntax: "<length>";
+  inherits: false;
+  initial-value: 0%;
+}
+
+.button {
+  transition-property: --tw-gradient-from;
+}
+      `.trim();
+
+      const actual = splitShadowRootCss(css, {
+        propertyPrefix: 'wxt-test-extension-id',
+      });
+
+      expect(actual.documentCss).toContain(
+        '@property --wxt-test-extension-id-tw-gradient-from {',
+      );
+      expect(actual.documentCss).toContain(
+        '@property --wxt-test-extension-id-tw-gradient-from-position {',
+      );
+      expect(actual.shadowCss).toContain(
+        '--wxt-test-extension-id-tw-gradient-from: red;',
+      );
+      expect(actual.shadowCss).toContain(
+        'var(--wxt-test-extension-id-tw-gradient-from)',
+      );
+      expect(actual.shadowCss).toContain(
+        'var(--wxt-test-extension-id-tw-gradient-from-position)',
+      );
+      expect(actual.shadowCss).toContain(
+        'transition-property: --wxt-test-extension-id-tw-gradient-from;',
+      );
+      expect(actual.shadowCss).toContain('var(--unregistered)');
+      expect(actual.shadowCss).not.toContain('--tw-gradient-from');
+      expect(actual.documentCss).not.toContain('--tw-gradient-from');
+    });
   });
 });

--- a/packages/wxt/src/utils/content-script-ui/__tests__/index.test.ts
+++ b/packages/wxt/src/utils/content-script-ui/__tests__/index.test.ts
@@ -123,6 +123,47 @@ describe('Content Script UIs', () => {
           expect(ui.shadow.mode).toBe(expected);
         },
       );
+
+      it('should scope document-level CSS properties by runtime ID', async () => {
+        const ui = await createShadowRootUi(ctx, {
+          position: 'inline',
+          name: 'test-component',
+          css: `
+            :host {
+              --tw-gradient-from: red;
+              color: var(--tw-gradient-from);
+            }
+
+            @property --tw-gradient-from {
+              syntax: "<color>";
+              inherits: false;
+              initial-value: #0000;
+            }
+          `,
+          onMount(uiContainer) {
+            appendTestApp(uiContainer);
+          },
+        });
+
+        ui.mount();
+
+        const documentStyle = document.querySelector(
+          'style[wxt-shadow-root-document-styles]',
+        );
+        const shadowStyle = ui.shadow.querySelector('style');
+
+        expect(documentStyle?.textContent).toContain(
+          '@property --wxt-test-extension-id-tw-gradient-from',
+        );
+        expect(shadowStyle?.textContent).toContain(
+          '--wxt-test-extension-id-tw-gradient-from: red',
+        );
+        expect(shadowStyle?.textContent).toContain(
+          'var(--wxt-test-extension-id-tw-gradient-from)',
+        );
+
+        ui.remove();
+      });
     });
   });
 

--- a/packages/wxt/src/utils/content-script-ui/shadow-root.ts
+++ b/packages/wxt/src/utils/content-script-ui/shadow-root.ts
@@ -35,7 +35,9 @@ export async function createShadowRootUi<TMounted>(
   }
 
   // Some rules must be applied outside the shadow root, so split the CSS apart
-  const { shadowCss, documentCss } = splitShadowRootCss(css.join('\n').trim());
+  const { shadowCss, documentCss } = splitShadowRootCss(css.join('\n').trim(), {
+    propertyPrefix: getRuntimePropertyPrefix(),
+  });
 
   const {
     isolatedElement: uiContainer,
@@ -131,6 +133,14 @@ async function loadCss(): Promise<string> {
     );
     return '';
   }
+}
+
+function getRuntimePropertyPrefix() {
+  const runtimeId = browser.runtime?.id;
+  if (!runtimeId) return undefined;
+
+  const id = runtimeId.replace(/[^-_a-zA-Z0-9]/g, '-');
+  return id ? `wxt-${id}` : undefined;
 }
 
 export interface ShadowRootContentScriptUi<

--- a/packages/wxt/src/utils/split-shadow-root-css.ts
+++ b/packages/wxt/src/utils/split-shadow-root-css.ts
@@ -1,6 +1,12 @@
 /** @module wxt/utils/split-shadow-root-css */
 
 const AT_RULE_BLOCKS = /(\s*@(property|font-face)[\s\S]*?{[\s\S]*?})/gm;
+const REGISTERED_PROPERTY_NAMES = /@property\s+(--[-_a-zA-Z0-9]+)\s*{/g;
+
+export interface SplitShadowRootCssOptions {
+  /** Prefix applied to custom properties registered by `@property` rules. */
+  propertyPrefix?: string;
+}
 
 /**
  * Given a CSS string that will be loaded into a shadow root, split it into two
@@ -12,10 +18,15 @@ const AT_RULE_BLOCKS = /(\s*@(property|font-face)[\s\S]*?{[\s\S]*?})/gm;
  *
  * @param css
  */
-export function splitShadowRootCss(css: string): {
+export function splitShadowRootCss(
+  css: string,
+  options: SplitShadowRootCssOptions = {},
+): {
   documentCss: string;
   shadowCss: string;
 } {
+  css = scopeRegisteredProperties(css, options.propertyPrefix);
+
   const documentCss = Array.from(css.matchAll(AT_RULE_BLOCKS), (m) => m[0])
     .join('')
     .trim();
@@ -25,4 +36,31 @@ export function splitShadowRootCss(css: string): {
     documentCss: documentCss,
     shadowCss: shadowCss,
   };
+}
+
+function scopeRegisteredProperties(css: string, prefix: string | undefined) {
+  if (!prefix) return css;
+
+  const propertyNames = Array.from(
+    new Set(
+      Array.from(css.matchAll(REGISTERED_PROPERTY_NAMES), (match) => match[1]),
+    ),
+  ).sort((a, b) => b.length - a.length);
+  if (propertyNames.length === 0) return css;
+
+  const propertyPattern = new RegExp(
+    `${propertyNames.map(escapeRegExp).join('|')}(?![-_a-zA-Z0-9])`,
+    'g',
+  );
+  const normalizedPrefix = prefix.replace(/^--+/, '').replace(/-+$/, '');
+  if (!normalizedPrefix) return css;
+
+  return css.replace(
+    propertyPattern,
+    (propertyName) => `--${normalizedPrefix}-${propertyName.slice(2)}`,
+  );
+}
+
+function escapeRegExp(text: string) {
+  return text.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 }


### PR DESCRIPTION
## Summary
- scope document-level `@property` registrations with the runtime extension ID
- rewrite matching shadow-root CSS references for those registered properties
- add splitter and content-script UI coverage for Tailwind-style registered properties

## Tests
- `bun run test run src/utils/__tests__/split-shadow-root-css.test.ts`
- `bun run test run src/utils/content-script-ui/__tests__/index.test.ts`
- `bun run --filter wxt check`
- `bun run docs:build`

Fixes #1955