### PR TITLE
fix: handle spread content script configs

### DIFF
--- a/packages/wxt/src/core/utils/__tests__/transform.test.ts
+++ b/packages/wxt/src/core/utils/__tests__/transform.test.ts
@@ -55,6 +55,34 @@ describe('Transform Utils', () => {
       expect(actual).toEqual(expected);
     });
 
+    it('should preserve spread config when removing the main field', () => {
+      const input = `
+        const sharedConfig = {
+          matches: ['*://*/*'],
+        };
+
+        export default defineContentScript({
+          ...sharedConfig,
+          runAt: 'document_idle',
+          main(ctx) {
+            console.log(ctx);
+          },
+        })
+      `;
+      const expected = `const sharedConfig = {
+  matches: ['*://*/*'],
+};
+
+export default defineContentScript({
+  ...sharedConfig,
+  runAt: 'document_idle'
+})`;
+
+      const actual = removeMainFunctionCode(input).code;
+
+      expect(actual).toEqual(expected);
+    });
+
     it('should remove unused imports', () => {
       const input = `
         import { defineBackground } from "#imports"

--- a/packages/wxt/src/core/utils/transform.ts
+++ b/packages/wxt/src/core/utils/transform.ts
@@ -41,10 +41,18 @@ function emptyMainFunction(mod: ProxifiedModule): void {
       // ex: "fn({ ..., main: () => {} })" to "fn({ ... })"
       mod.exports.default.$ast.arguments[0].properties =
         mod.exports.default.$ast.arguments[0].properties.filter(
-          (prop: any) => prop.key.name !== 'main',
+          (prop: any) => !isMainProperty(prop),
         );
     }
   }
+}
+
+function isMainProperty(prop: any): boolean {
+  if (!prop?.key || prop.computed) {
+    return false;
+  }
+
+  return prop.key.name === 'main' || prop.key.value === 'main';
 }
 
 function removeUnusedTopLevelVariables(mod: ProxifiedModule): number {

--- a/packages/wxt/src/core/utils/transform.ts
+++ b/packages/wxt/src/core/utils/transform.ts
@@ -41,18 +41,10 @@ function emptyMainFunction(mod: ProxifiedModule): void {
       // ex: "fn({ ..., main: () => {} })" to "fn({ ... })"
       mod.exports.default.$ast.arguments[0].properties =
         mod.exports.default.$ast.arguments[0].properties.filter(
-          (prop: any) => !isMainProperty(prop),
+          (prop: any) => prop.key?.name !== 'main',
         );
     }
   }
-}
-
-function isMainProperty(prop: any): boolean {
-  if (!prop?.key || prop.computed) {
-    return false;
-  }
-
-  return prop.key.name === 'main' || prop.key.value === 'main';
 }
 
 function removeUnusedTopLevelVariables(mod: ProxifiedModule): number {


### PR DESCRIPTION
## Summary
- keep spread members when removing content script `main` during entrypoint analysis
- add transform regression coverage for shared config spread in `defineContentScript`

Fixes #2400

## Checks
- `bun run --filter wxt test transform.test.ts run`
- `bun run --filter wxt check`
- `bun run --filter wxt test run`