### PR TITLE
docs: Don't underline the comma when hovering over showcase item store links

### DIFF
--- a/docs/.vitepress/components/UsingWxtSection.vue
+++ b/docs/.vitepress/components/UsingWxtSection.vue
@@ -139,8 +139,7 @@ function formatStars(r: number): string {
                 target="_blank"
                 class="store-link"
                 :title="store.label"
-              >
-                {{ store.label }}</a
+                >{{ store.label }}</a
               >
               <span
                 v-if="i < extension.stores.length - 1"

--- a/docs/.vitepress/components/UsingWxtSection.vue
+++ b/docs/.vitepress/components/UsingWxtSection.vue
@@ -124,32 +124,32 @@ function formatStars(r: number): string {
           {{ extension.shortDescription }}
         </p>
         <div v-if="extension.stores.length > 0" class="store-stats">
-          <span class="store-stats-info">
+          <p class="store-stats-info">
             <span>{{ formatUsers(extension.users) }}</span>
             <template v-if="extension.rating">
               <span class="store-stats-sep" aria-hidden="true">,</span>
               <span>{{ formatStars(extension.rating) }}</span>
             </template>
-          </span>
-          <span class="store-stats-sep" aria-hidden="true">&middot;</span>
-          <span class="store-links">
-            <a
-              v-for="(store, i) of extension.stores"
-              :key="store.label"
-              :href="store.url"
-              target="_blank"
-              class="store-link"
-              :title="store.label"
-            >
-              {{ store.label
-              }}<span
+          </p>
+          <p class="store-stats-sep" aria-hidden="true">&middot;</p>
+          <p class="store-links">
+            <template v-for="(store, i) of extension.stores" :key="store.label">
+              <a
+                :href="store.url"
+                target="_blank"
+                class="store-link"
+                :title="store.label"
+              >
+                {{ store.label }}</a
+              >
+              <span
                 v-if="i < extension.stores.length - 1"
                 class="store-stats-sep"
                 aria-hidden="true"
                 >,&nbsp;</span
               >
-            </a>
-          </span>
+            </template>
+          </p>
         </div>
       </div>
     </li>


### PR DESCRIPTION
### Overview

`main`:

<img width="148" height="88" alt="image" src="https://github.com/user-attachments/assets/6d761247-a547-4d29-8645-a8789563e641" />

This branch:

<img width="148" height="88" alt="image" src="https://github.com/user-attachments/assets/27b02224-bf1d-4fc4-9fc0-b3df9b70d8eb" />

