### PR TITLE
fix(init): Allow entering an empty directory for project path

### DIFF
--- a/packages/wxt/src/core/initialize.ts
+++ b/packages/wxt/src/core/initialize.ts
@@ -54,7 +54,7 @@ export async function initialize(options: {
       onCancel: () => process.exit(1),
     },
   );
-  input.directory ??= options.directory;
+  input.directory ||= options.directory || '.';
   input.template ??= defaultTemplate;
   input.packageManager ??= options.packageManager;
 


### PR DESCRIPTION
### Overview

There were some path resolution issues when using `""` as the project directory, but everything works with `"."` so fallback to that instead.

### Manual Testing

Use the version published by pkg-pr-new to test it, leaving the project dir blank when prompted.

```
$ pnpm dlx wxt@https://pkg.pr.new/wxt@2458 init
WXT 0.20.27
ℹ Initializing new project
✔ Project Directory …
✔ Choose a template › vanilla
✔ Package Manager › npm
✔ Downloading template

✨ WXT project created with the vanilla template.

Next steps:
  1. npm install
```

### Related Issue

This PR closes https://github.com/wxt-dev/wxt/issues/2289
