### PR TITLE
feat: export `getEntrypointBundlePath` from `wxt`

### DIFF
--- a/packages/wxt/src/core/utils/index.ts
+++ b/packages/wxt/src/core/utils/index.ts
@@ -1,1 +1,2 @@
 export { normalizePath } from './paths';
+export { getEntrypointBundlePath } from './entrypoints';


### PR DESCRIPTION
Exports `getEntrypointBundlePath` from `wxt` so external modules can compute bundle paths without copying the internal helper.

Per #2040 — splitting this off into its own PR as requested.

The function already exists at `packages/wxt/src/core/utils/entrypoints.ts`; this change is a single-line re-export added to `packages/wxt/src/core/utils/index.ts`. No behavior change, no signature change.

Will be consumed by `@wxt-dev/entrypoint-refs` (follow-up PR, depends on this landing first).
