### PR TITLE
docs: Added "Teams Chat Exporter" Edge Addons (edgeId) to extension showcase

### DIFF
--- a/docs/assets/extension-showcase.yml
+++ b/docs/assets/extension-showcase.yml
@@ -401,6 +401,7 @@
 - # Teams Chat Exporter
   chromeId: jmghclbfbbapimhbgnpffbimphlpolnm
   firefoxSlug: teams-chat-exporter
+  edgeId: phlomfiieaggnbfpacmjmidcjdlaiplp
 
 - # Lofi BGM Player - Free lofi focus music for work & study
   chromeId: jdcppdokgfbnhiacbeplahgnciahnhck


### PR DESCRIPTION
Adds the Edge Add-ons ID for Teams Chat Exporter, already listed in the showcase with Chrome and Firefox. This adds an Edge store link to its card.

Thanks for building WXT and maintaining the showcase.
