### PR TITLE
docs: Cleanup the "extension APIs" page

### DIFF
--- a/docs/guide/essentials/extension-apis.md
+++ b/docs/guide/essentials/extension-apis.md
@@ -96,7 +96,7 @@ WXT's `browser` types are based on the `@types/chrome` package. That means some 
    // <srcDir>/browser-types.d.ts
    import '@wxt-dev/browser';
    import type { SidebarAction } from 'webextension-polyfill';
-   
+
    declare module '@wxt-dev/browser' {
      namespace Browser {
        export const sidebarAction: SidebarAction.Static;
@@ -126,41 +126,32 @@ The fix is simple, just move your API usage into the entrypoint's main function:
 
 :::code-group
 
+<!-- prettier-ignore -->
 ```ts [background.ts]
-browser.action.onClicked.addListener(() => { // [!code --]
-  /* ... */ // [!code --]
-}); // [!code --]
+browser.action.onClicked.addListener(() => { /* ... */ }); // [!code --]
 
 export default defineBackground(() => {
-  browser.action.onClicked.addListener(() => { // [!code ++]
-    /* ... */ // [!code ++]
-  }); // [!code ++]
+  browser.action.onClicked.addListener(() => { /* ... */ }); // [!code ++]
 });
 ```
 
+<!-- prettier-ignore -->
 ```ts [content.ts]
-browser.runtime.onMessage.addListener(() => { // [!code --]
-  /* ... */ // [!code --]
-}); // [!code --]
+browser.runtime.onMessage.addListener(() => { /* ... */ }); // [!code --]
 
 export default defineContentScript({
   main() {
-    browser.runtime.onMessage.addListener(() => { // [!code ++]
-      /* ... */ // [!code ++]
-    }); // [!code ++]
+    browser.runtime.onMessage.addListener(() => { /* ... */ }); // [!code ++]
   },
 });
 ```
 
+<!-- prettier-ignore -->
 ```ts [unlisted.ts]
-browser.runtime.onMessage.addListener(() => { // [!code --]
-  /* ... */ // [!code --]
-}); // [!code --]
+browser.runtime.onMessage.addListener(() => { /* ... */ }); // [!code --]
 
 export default defineUnlistedScript(() => {
-  browser.runtime.onMessage.addListener(() => { // [!code ++]
-    /* ... */ // [!code ++]
-  }); // [!code ++]
+  browser.runtime.onMessage.addListener(() => { /* ... */ }); // [!code ++]
 });
 ```
 

--- a/docs/guide/essentials/extension-apis.md
+++ b/docs/guide/essentials/extension-apis.md
@@ -1,3 +1,7 @@
+---
+outline: deep
+---
+
 # Extension APIs
 
 [Chrome Docs](https://developer.chrome.com/docs/extensions/reference/api) • [Firefox Docs](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/Browser_support_for_JavaScript_APIs)
@@ -78,25 +82,31 @@ Alternatively, if you're trying to use similar APIs under different names (to su
 
 ### Augmenting the Browser Type
 
-WXT's `browser` types are based on the `@types/chrome` package. That means some Firefox-specific APIs may not be typed, like `browser.sidebarAction`. If you want to add types for these APIs, you can augment the browser type to add them yourself:
+WXT's `browser` types are based on the `@types/chrome` package. That means some Firefox-specific APIs may not be typed, like `browser.sidebarAction`. If you want to add types for these APIs, you can augment the browser type by:
 
-```ts
-// <srcDir>/browser-types.d.ts
-import '@wxt-dev/browser';
-import type { SidebarAction } from 'webextension-polyfill';
+1. Installing `@wxt-dev/browser` as a direct dependency
 
-declare module '@wxt-dev/browser' {
-  namespace Browser {
-    export const sidebarAction: SidebarAction.Static;
-  }
-}
-```
+   ```sh
+   pnpm add @wxt-dev/browser
+   ```
 
-> For this to work, you may need to install `@wxt-dev/browser` as a direct dependency.
->
-> ```sh
-> pnpm add @wxt-dev/browser
-> ```
+2. Augmenting the `Browser` type:
+
+   ```ts
+   // <srcDir>/browser-types.d.ts
+   import '@wxt-dev/browser';
+   import type { SidebarAction } from 'webextension-polyfill';
+   
+   declare module '@wxt-dev/browser' {
+     namespace Browser {
+       export const sidebarAction: SidebarAction.Static;
+     }
+   }
+   ```
+
+You can add types from any source: `webextension-polyfill`, `@types/firefox-webext-browser`, or your own custom types.
+
+See TypeScript's documentation on [declaration merging](https://www.typescriptlang.org/docs/handbook/declaration-merging.html) for more information.
 
 ## Entrypoint Limitations
 
@@ -117,39 +127,39 @@ The fix is simple, just move your API usage into the entrypoint's main function:
 :::code-group
 
 ```ts [background.ts]
-browser.action.onClicked.addListener(() => {
-  /* ... */
+browser.action.onClicked.addListener(() => { // [!code --]
+  /* ... */ // [!code --]
 }); // [!code --]
 
 export default defineBackground(() => {
-  browser.action.onClicked.addListener(() => {
-    /* ... */
+  browser.action.onClicked.addListener(() => { // [!code ++]
+    /* ... */ // [!code ++]
   }); // [!code ++]
 });
 ```
 
 ```ts [content.ts]
-browser.runtime.onMessage.addListener(() => {
-  /* ... */
+browser.runtime.onMessage.addListener(() => { // [!code --]
+  /* ... */ // [!code --]
 }); // [!code --]
 
 export default defineContentScript({
   main() {
-    browser.runtime.onMessage.addListener(() => {
-      /* ... */
+    browser.runtime.onMessage.addListener(() => { // [!code ++]
+      /* ... */ // [!code ++]
     }); // [!code ++]
   },
 });
 ```
 
 ```ts [unlisted.ts]
-browser.runtime.onMessage.addListener(() => {
-  /* ... */
+browser.runtime.onMessage.addListener(() => { // [!code --]
+  /* ... */ // [!code --]
 }); // [!code --]
 
 export default defineUnlistedScript(() => {
-  browser.runtime.onMessage.addListener(() => {
-    /* ... */
+  browser.runtime.onMessage.addListener(() => { // [!code ++]
+    /* ... */ // [!code ++]
   }); // [!code ++]
 });
 ```

--- a/docs/guide/essentials/extension-apis.md
+++ b/docs/guide/essentials/extension-apis.md
@@ -1,7 +1,3 @@
----
-outline: deep
----
-
 # Extension APIs
 
 [Chrome Docs](https://developer.chrome.com/docs/extensions/reference/api) • [Firefox Docs](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/Browser_support_for_JavaScript_APIs)
@@ -80,7 +76,7 @@ Alternatively, if you're trying to use similar APIs under different names (to su
 });
 ```
 
-### Augmenting the Browser Type
+## Add Firefox Types
 
 WXT's `browser` types are based on the `@types/chrome` package. That means some Firefox-specific APIs may not be typed, like `browser.sidebarAction`. If you want to add types for these APIs, you can augment the browser type by:
 


### PR DESCRIPTION
### Overview

Noticed some issues with this page while reviewing https://discord.com/channels/1212416027611365476/1518852775025442877.

- Old: https://wxt.dev/guide/essentials/extension-apis.html
- New: https://deploy-preview-2473--creative-fairy-df92c4.netlify.app/guide/essentials/extension-apis.html
