### PR TITLE
docs: use consola's fancy reporter in init demo GIF

### DIFF
--- a/cspell.yml
+++ b/cspell.yml
@@ -29,6 +29,7 @@ words:
   - comctx
   - confbox
   - configfile
+  - consola
   - consolas
   - Cpath
   - crbug

--- a/docs/tapes/init-demo.tape
+++ b/docs/tapes/init-demo.tape
@@ -37,6 +37,9 @@ Hide
 # Create a temporary folder for demo
 Type 'mkdir packages/wxt/init-demo' Enter
 Type 'cd packages/wxt/init-demo' Enter
+# Unset CI variables inherited from the GitHub Actions runner so consola
+# picks its fancy reporter instead of the basic one (#2461)
+Type 'unset CI GITHUB_ACTIONS' Enter
 Type 'clear' Enter
 Show
 


### PR DESCRIPTION
## Problem

The `wxt init` demo GIF shows consola's basic reporter output (`[log]` / `[info]` prefixes) instead of the fancy reporter (no prefix / `ℹ`).

## Root cause

`initialize.ts` logs through consola's default instance, which picks its reporter at import time:

```
options.fancy ?? !(isCI || isTest) ? new FancyReporter() : new BasicReporter()
```

std-env reports `isCI: true` whenever `GITHUB_ACTIONS` is present with **any** value (CI provider scan), independent of `CI`. The vhs recording runs on the GitHub Actions runner, so the ttyd shell inherits `CI=true` and `GITHUB_ACTIONS=true` → BasicReporter.

## Fix

`unset CI GITHUB_ACTIONS` in the tape's hidden preparation block, before `bunx wxt init` runs. A shell-level `unset` (rather than vhs `Env`) reliably defeats both the `env.CI` check and the provider scan, and it never appears in the recording.

## Verification

Reproduced the reporter selection with consola 3.4.2 using the same calls `wxt init` makes:

| Environment | Output |
|---|---|
| `CI=true GITHUB_ACTIONS=true` | `[info] Initializing new project` (basic) |
| both unset | `ℹ Initializing new project` (fancy) |

Since `vhs.yml` triggers on tape changes (and supports `workflow_dispatch`), the GIF will regenerate on merge and can be re-checked there.

Fixes #2461
