### PR TITLE
feat: support SPA content scripts

### DIFF
--- a/packages/wxt/src/core/utils/__tests__/content-scripts.test.ts
+++ b/packages/wxt/src/core/utils/__tests__/content-scripts.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it, beforeEach } from 'vitest';
-import { hashContentScriptOptions } from '../content-scripts';
+import {
+  getContentScriptDomainMatches,
+  hashContentScriptOptions,
+  mapWxtOptionsToContentScript,
+} from '../content-scripts';
 import { setFakeWxt } from '../testing/fake-objects';
 
 describe('Content Script Utils', () => {
@@ -28,6 +32,40 @@ describe('Content Script Utils', () => {
       });
 
       expect(hash1).toBe(hash2);
+    });
+  });
+
+  describe('getContentScriptDomainMatches', () => {
+    it('should strip path patterns so SPA content scripts can run on same-origin navigations', () => {
+      expect(
+        getContentScriptDomainMatches([
+          '*://*.youtube.com/watch*',
+          '*://*.youtube.com/shorts/*',
+          'https://example.com/admin/*',
+          '<all_urls>',
+          'file:///*',
+        ]),
+      ).toEqual([
+        '*://*.youtube.com/*',
+        'https://example.com/*',
+        '<all_urls>',
+        'file:///*',
+      ]);
+    });
+  });
+
+  describe('mapWxtOptionsToContentScript', () => {
+    it('should use domain-level matches for SPA content scripts', () => {
+      const actual = mapWxtOptionsToContentScript(
+        {
+          matches: ['*://*.youtube.com/watch*'],
+          spa: true,
+        },
+        ['content-scripts/content.js'],
+        undefined,
+      );
+
+      expect(actual.matches).toEqual(['*://*.youtube.com/*']);
     });
   });
 });

--- a/packages/wxt/src/core/utils/__tests__/validation.test.ts
+++ b/packages/wxt/src/core/utils/__tests__/validation.test.ts
@@ -117,5 +117,32 @@ describe('Validation Utils', () => {
 
       expect(actual).toEqual(expected);
     });
+
+    it('should return an error when spa is enabled for main world content scripts', () => {
+      const entrypoint = fakeContentScriptEntrypoint({
+        options: {
+          matches: ['*://example.com/*'],
+          spa: true,
+          world: 'MAIN',
+        },
+      });
+      const expected = {
+        errors: [
+          {
+            type: 'error',
+            message:
+              '`spa` is only supported for isolated world content scripts',
+            value: true,
+            entrypoint,
+          },
+        ],
+        errorCount: 1,
+        warningCount: 0,
+      };
+
+      const actual = validateEntrypoints([entrypoint]);
+
+      expect(actual).toEqual(expected);
+    });
   });
 });

--- a/packages/wxt/src/core/utils/content-scripts.ts
+++ b/packages/wxt/src/core/utils/content-scripts.ts
@@ -53,7 +53,9 @@ export function mapWxtOptionsToContentScript(
   css: string[] | undefined,
 ): ManifestContentScript {
   return {
-    matches: options.matches ?? [],
+    matches: options.spa
+      ? getContentScriptDomainMatches(options.matches)
+      : (options.matches ?? []),
     all_frames: options.allFrames,
     match_about_blank: options.matchAboutBlank,
     exclude_globs: options.excludeGlobs,
@@ -75,7 +77,9 @@ export function mapWxtOptionsToRegisteredContentScript(
   return {
     allFrames: options.allFrames,
     excludeMatches: options.excludeMatches,
-    matches: options.matches,
+    matches: options.spa
+      ? getContentScriptDomainMatches(options.matches)
+      : options.matches,
     runAt: options.runAt,
     js,
     css,
@@ -88,4 +92,22 @@ export function getContentScriptJs(
   entrypoint: ContentScriptEntrypoint,
 ): string[] {
   return [getEntrypointBundlePath(entrypoint, config.outDir, '.js')];
+}
+
+export function getContentScriptDomainMatches(
+  matches: string[] | undefined,
+): string[] {
+  return [...new Set((matches ?? []).map(getContentScriptDomainMatch))];
+}
+
+function getContentScriptDomainMatch(pattern: string): string {
+  if (pattern === '<all_urls>' || pattern.startsWith('file:')) return pattern;
+
+  const schemeSeparatorIndex = pattern.indexOf('://');
+  if (schemeSeparatorIndex === -1) return pattern;
+
+  const pathStartIndex = pattern.indexOf('/', schemeSeparatorIndex + 3);
+  if (pathStartIndex === -1) return pattern;
+
+  return `${pattern.slice(0, pathStartIndex)}/*`;
 }

--- a/packages/wxt/src/core/utils/validation.ts
+++ b/packages/wxt/src/core/utils/validation.ts
@@ -41,6 +41,14 @@ function validateContentScriptEntrypoint(
       entrypoint: definition,
     });
   }
+  if (definition.options.spa && definition.options.world === 'MAIN') {
+    errors.push({
+      type: 'error',
+      message: '`spa` is only supported for isolated world content scripts',
+      value: definition.options.spa,
+      entrypoint: definition,
+    });
+  }
   return errors;
 }
 

--- a/packages/wxt/src/types.ts
+++ b/packages/wxt/src/types.ts
@@ -746,6 +746,19 @@ export interface BaseContentScriptEntrypointOptions extends BaseScriptEntrypoint
    * https://github.com/wxt-dev/wxt/pull/2035 for a detailed discussion.
    */
   noScriptStartedPostMessage?: boolean;
+  /**
+   * Re-run this content script when a single-page app changes URL and the new
+   * URL matches one of the configured match patterns.
+   *
+   * When enabled, WXT registers the content script for the match pattern's
+   * whole origin, then filters against the original match patterns at runtime.
+   *
+   * Only supported for isolated world content scripts.
+   *
+   * @default false
+   * @experimental
+   */
+  spa?: PerBrowserOption<boolean>;
 }
 
 export interface MainWorldContentScriptEntrypointOptions extends BaseContentScriptEntrypointOptions {

--- a/packages/wxt/src/utils/internal/__tests__/spa-content-script.test.ts
+++ b/packages/wxt/src/utils/internal/__tests__/spa-content-script.test.ts
@@ -1,0 +1,74 @@
+/** @vitest-environment happy-dom */
+/** @vitest-environment-options {"url": "https://example.com/home"} */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { fakeBrowser } from '@webext-core/fake-browser';
+import { runContentScriptWithSpaSupport } from '../spa-content-script';
+import { ContentScriptContext } from '../../content-script-context';
+
+function waitForEventsToFire() {
+  return new Promise((res) => setTimeout(res));
+}
+
+function dispatchLocationChange(newUrl: string, oldUrl: string) {
+  window.dispatchEvent(
+    Object.assign(
+      new Event(`${fakeBrowser.runtime.id}:undefined:wxt:locationchange`),
+      {
+        newUrl: new URL(newUrl),
+        oldUrl: new URL(oldUrl),
+      },
+    ),
+  );
+}
+
+describe('runContentScriptWithSpaSupport', () => {
+  beforeEach(() => {
+    vi.useRealTimers();
+    fakeBrowser.runtime.id = 'anything';
+    window.history.replaceState(null, '', '/home');
+  });
+
+  it('should run on matching URLs and abort the previous child context when navigating', async () => {
+    const parentContext = new ContentScriptContext('content');
+    const childInvalidated = vi.fn();
+    const main = vi.fn((ctx: ContentScriptContext) => {
+      ctx.onInvalidated(childInvalidated);
+    });
+
+    runContentScriptWithSpaSupport(parentContext, {
+      matches: ['https://example.com/app/*'],
+      spa: true,
+      main,
+    });
+
+    expect(main).not.toHaveBeenCalled();
+
+    dispatchLocationChange(
+      'https://example.com/app/one',
+      'https://example.com/home',
+    );
+    await waitForEventsToFire();
+
+    expect(main).toHaveBeenCalledTimes(1);
+    expect(childInvalidated).not.toHaveBeenCalled();
+
+    dispatchLocationChange(
+      'https://example.com/app/two',
+      'https://example.com/app/one',
+    );
+    await waitForEventsToFire();
+
+    expect(main).toHaveBeenCalledTimes(2);
+    expect(childInvalidated).toHaveBeenCalledTimes(1);
+
+    dispatchLocationChange(
+      'https://example.com/settings',
+      'https://example.com/app/two',
+    );
+    await waitForEventsToFire();
+
+    expect(main).toHaveBeenCalledTimes(2);
+    expect(childInvalidated).toHaveBeenCalledTimes(2);
+  });
+});

--- a/packages/wxt/src/utils/internal/spa-content-script.ts
+++ b/packages/wxt/src/utils/internal/spa-content-script.ts
@@ -1,0 +1,89 @@
+import { MatchPattern } from '@webext-core/match-patterns';
+import type { ContentScriptDefinition, PerBrowserOption } from '../../types';
+import { ContentScriptContext } from '../content-script-context';
+import { logger } from './logger';
+
+interface SpaContentScriptDefinition {
+  matches?: PerBrowserOption<string[]>;
+  spa?: PerBrowserOption<boolean>;
+  main(ctx: any): any;
+}
+
+export function runContentScriptWithSpaSupport(
+  parentContext: ContentScriptContext,
+  definition: SpaContentScriptDefinition,
+): void {
+  const childMatches = getMatchPatterns(definition.matches);
+  let childContext: ContentScriptContext | undefined;
+
+  const run = (url: string, initial = false) => {
+    if (!isUrlMatch(childMatches, url)) {
+      if (childContext) {
+        logger.debug(
+          'SPA navigated off matching page, stopping content script',
+        );
+        childContext.abort('SPA navigated off matching page');
+        childContext = undefined;
+      } else if (initial) {
+        logger.debug('Ignoring initial load of SPA site on non-matching page');
+      }
+      return;
+    }
+
+    if (childContext) {
+      logger.debug(
+        'SPA navigated to a new matching page, restarting content script',
+      );
+      childContext.abort('SPA navigated to a new matching page');
+    } else if (initial) {
+      logger.debug(
+        'SPA site loaded on matching page, running content script main function',
+      );
+    } else {
+      logger.debug(
+        'SPA navigated to matching page, running content script main function',
+      );
+    }
+
+    childContext = new ContentScriptContext(
+      `${import.meta.env.ENTRYPOINT}:spa`,
+      definition as Omit<ContentScriptDefinition, 'main'>,
+    );
+    void definition.main(childContext);
+  };
+
+  run(location.href, true);
+  parentContext.addEventListener(window, 'wxt:locationchange', (event) => {
+    run(event.newUrl.href);
+  });
+
+  parentContext.onInvalidated(() => {
+    childContext?.abort('SPA parent content script invalidated');
+    childContext = undefined;
+  });
+}
+
+function isUrlMatch(matches: MatchPattern[] | undefined, url: string): boolean {
+  return matches?.some((match) => match.includes(url)) ?? false;
+}
+
+function getMatchPatterns(
+  matches: PerBrowserOption<string[]> | undefined,
+): MatchPattern[] | undefined {
+  return resolvePerBrowserOption(matches)?.map(
+    (pattern) => new MatchPattern(pattern),
+  );
+}
+
+function resolvePerBrowserOption<T>(
+  value: PerBrowserOption<T> | undefined,
+): T | undefined {
+  if (value == null || !isPerBrowserMap(value)) return value;
+  return (value as Record<string, T>)[import.meta.env.BROWSER];
+}
+
+function isPerBrowserMap<T>(
+  value: PerBrowserOption<T>,
+): value is Record<string, T> {
+  return !Array.isArray(value) && typeof value === 'object';
+}

--- a/packages/wxt/src/virtual/content-script-isolated-world-entrypoint.ts
+++ b/packages/wxt/src/virtual/content-script-isolated-world-entrypoint.ts
@@ -1,7 +1,8 @@
 import definition from 'virtual:user-content-script-isolated-world-entrypoint';
 import { logger } from '../utils/internal/logger';
-import { ContentScriptContext } from 'wxt/utils/content-script-context';
+import { ContentScriptContext } from '../utils/content-script-context';
 import { initPlugins } from 'virtual:wxt-plugins';
+import { runContentScriptWithSpaSupport } from '../utils/internal/spa-content-script';
 
 const result = (async () => {
   try {
@@ -9,7 +10,12 @@ const result = (async () => {
     const { main, ...options } = definition;
     const ctx = new ContentScriptContext(import.meta.env.ENTRYPOINT, options);
 
-    return await main(ctx);
+    if (options.spa) {
+      runContentScriptWithSpaSupport(ctx, definition);
+      return;
+    }
+
+    return await main(ctx as any);
   } catch (err) {
     logger.error(
       `The content script "${import.meta.env.ENTRYPOINT}" crashed on startup!`,


### PR DESCRIPTION
Fixes #1029

### Summary
- Add an experimental `spa` option for isolated world content scripts.
- Register SPA content scripts at origin scope while filtering against the original match patterns at runtime.
- Restart the content script context on matching SPA navigations and abort it when navigating away.
- Add validation and tests for SPA matching and unsupported MAIN world usage.

### Verification
- `bun run --filter wxt check`
- `bun run --filter wxt test content-scripts validation spa-content-script`
- `git diff --check`

### Disclosure
This contribution was prepared with AI assistance and reviewed before submission.