### PR TITLE
Add Adaptive Tab Bar Colour to extension showcase

### DIFF
--- a/docs/assets/extension-showcase.yml
+++ b/docs/assets/extension-showcase.yml
@@ -519,3 +519,6 @@
 
 - # Leetcode Enhancer
   chromeId: cpoclfijojgjiafnlgnhjalkaiabcjch
+
+- # Adaptive Tab Bar Colour
+  firefoxSlug: adaptive-tab-bar-colour


### PR DESCRIPTION
### Overview

Add [Adaptive Tab Bar Colour](https://addons.mozilla.org/firefox/addon/adaptive-tab-bar-colour/) to extension showcase

### Manual Testing

N/A

### Related Issue

N/A
