### PR TITLE
fix: Lint not checking root scripts folder

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -19,6 +19,7 @@
         "markdownlint-cli": "^0.49.0",
         "nano-spawn": "catalog:",
         "nano-staged": "^1.0.2",
+        "oxlint": "catalog:",
         "p-map": "^7.0.4",
         "prettier": "^3.8.1",
         "prettier-plugin-jsdoc": "^1.8.0",

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "markdownlint-cli": "^0.49.0",
     "nano-spawn": "catalog:",
     "nano-staged": "^1.0.2",
+    "oxlint": "catalog:",
     "p-map": "^7.0.4",
     "prettier": "^3.8.1",
     "prettier-plugin-jsdoc": "^1.8.0",


### PR DESCRIPTION
### Overview
Oxlint was missing from the root `package.json#devDependencies`, so skipped when running check at the repo root outside `packages/*` files were type checked but never linted. Added oxlint to root `devDependencies`.

### Manual Testing
Check on local after run `bun run check` command.

**Before implementation**
<img width="476" height="150" alt="スクリーンショット 2026-07-12 2 51 04" src="https://github.com/user-attachments/assets/ef8345f3-ca23-459a-a959-a59ba4bb5ceb" />

**After implementation**
<img width="951" height="285" alt="スクリーンショット 2026-07-12 19 41 16" src="https://github.com/user-attachments/assets/7f9a8399-b4f3-4e0e-b0d9-898ff7e65ba4" />



### Related Issue
This PR closes #1999
