### PR TITLE
fix(auto-icons): dedupe merged icon sizes to prevent generating the same size multiple times

### DIFF
--- a/packages/auto-icons/src/__test__/index.test.ts
+++ b/packages/auto-icons/src/__test__/index.test.ts
@@ -259,6 +259,33 @@ describe('auto-icons module', () => {
         '`[auto-icons]` icons property found in manifest, overwriting with auto-generated icons',
       );
     });
+
+    it('should not duplicate icon entries in manifest when sizes overlap defaults', async () => {
+      const options: AutoIconsOptions = {
+        enabled: true,
+        sizes: [16, 32, 48, 96, 128],
+      };
+
+      await autoIconsModule.setup!(mockWxt as unknown as Wxt, options);
+
+      const manifestHook = vi
+        .mocked(mockWxt.hooks.hook)
+        .mock.calls.find((call) => call[0] === 'build:manifestGenerated')?.[1];
+
+      const manifest: UserManifest = {};
+      if (manifestHook) {
+        await manifestHook(mockWxt as unknown as Wxt, manifest);
+      }
+
+      expect(Object.keys(manifest.icons ?? {})).toHaveLength(5);
+      expect(manifest.icons).toEqual({
+        16: 'icons/16.png',
+        32: 'icons/32.png',
+        48: 'icons/48.png',
+        96: 'icons/96.png',
+        128: 'icons/128.png',
+      });
+    });
   });
 
   describe('icon generation hook', () => {
@@ -417,6 +444,35 @@ describe('auto-icons module', () => {
       }
 
       expect(mockSharpInstance.grayscale).not.toHaveBeenCalled();
+    });
+
+    it('should deduplicate sizes that overlap with defaults', async () => {
+      const options: AutoIconsOptions = {
+        enabled: true,
+        sizes: [16, 32, 48, 96, 128], // fully overlaps defaults [128, 48, 32, 16], only 96 is new
+      };
+
+      const output: BuildOutput = { publicAssets: [] };
+
+      await autoIconsModule.setup!(mockWxt as unknown as Wxt, options);
+
+      const buildHook = vi
+        .mocked(mockWxt.hooks.hook)
+        .mock.calls.find((call) => call[0] === 'build:done')?.[1];
+
+      if (buildHook) {
+        await buildHook(mockWxt as unknown as Wxt, output);
+      }
+
+      // Each size should only be resized/written once
+      expect(mockSharpInstance.resize).toHaveBeenCalledTimes(5);
+      expect(output.publicAssets).toEqual([
+        { type: 'asset', fileName: 'icons/16.png' },
+        { type: 'asset', fileName: 'icons/32.png' },
+        { type: 'asset', fileName: 'icons/48.png' },
+        { type: 'asset', fileName: 'icons/96.png' },
+        { type: 'asset', fileName: 'icons/128.png' },
+      ]);
     });
   });
 

--- a/packages/auto-icons/src/index.ts
+++ b/packages/auto-icons/src/index.ts
@@ -19,6 +19,9 @@ export default defineWxtModule<AutoIconsOptions>({
       },
     );
 
+    // Remove duplicates after merging user sizes with defaults.
+    const sizes = Array.from(new Set(parsedOptions.sizes));
+
     // Backward compatibility for the deprecated option
     if (options?.grayscaleOnDevelopment !== undefined) {
       wxt.logger.warn(
@@ -54,14 +57,14 @@ export default defineWxtModule<AutoIconsOptions>({
         );
 
       manifest.icons = Object.fromEntries(
-        parsedOptions.sizes.map((size) => [size, `icons/${size}.png`]),
+        sizes.map((size) => [size, `icons/${size}.png`]),
       );
     });
 
     wxt.hooks.hook('build:done', async (wxt, output) => {
       const outputFolder = wxt.config.outDir;
 
-      for (const size of parsedOptions.sizes) {
+      for (const size of sizes) {
         const resizedImage = sharp(resolvedPath).resize(size).png();
 
         if (wxt.config.mode === 'development') {
@@ -106,7 +109,7 @@ export default defineWxtModule<AutoIconsOptions>({
     });
 
     wxt.hooks.hook('prepare:publicPaths', (wxt, paths) => {
-      for (const size of parsedOptions.sizes) {
+      for (const size of sizes) {
         paths.push(`icons/${size}.png`);
       }
     });


### PR DESCRIPTION
### Overview

`defu` merges user-provided `sizes` with the default array via concatenation rather than union, so sizes overlapping a default (128, 48, 32, 16) were processed and written twice — duplicate icons generated and duplicate manifest entries. This dedupes the merged array once via `Set` before it's consumed by the manifest, build, and public-paths hooks. Additive behavior is preserved (custom sizes still extend defaults) — no breaking change.

### Manual Testing

- `bun run --filter @wxt-dev/auto-icons test` — 21/21 passing, including new regression tests for overlapping size configs
- Verified in a real WXT extension build (`wxt` dev and production build) that `icons/` output contains exactly one file per unique size, and `manifest.json` has no duplicate icon keys

### Related Issue

This PR closes #2491