### PR TITLE
docs: link shared content script UI options

### DIFF
--- a/packages/wxt/src/utils/content-script-ui/iframe.ts
+++ b/packages/wxt/src/utils/content-script-ui/iframe.ts
@@ -7,6 +7,8 @@ import { applyPosition, createMountFunctions, mountUi } from './shared';
 /**
  * Create a content script UI using an iframe.
  *
+ * @param options - Iframe options. See {@link ContentScriptUiOptions} for shared
+ *   positioning, anchoring, `append`, and removal options.
  * @see https://wxt.dev/guide/essentials/content-scripts.html#iframe
  */
 export function createIframeUi<TMounted>(

--- a/packages/wxt/src/utils/content-script-ui/integrated.ts
+++ b/packages/wxt/src/utils/content-script-ui/integrated.ts
@@ -6,6 +6,8 @@ import { applyPosition, createMountFunctions, mountUi } from './shared';
 /**
  * Create a content script UI without any isolation.
  *
+ * @param options - Integrated UI options. See {@link ContentScriptUiOptions} for
+ *   shared positioning, anchoring, `append`, and removal options.
  * @see https://wxt.dev/guide/essentials/content-scripts.html#integrated
  */
 export function createIntegratedUi<TMounted>(

--- a/packages/wxt/src/utils/content-script-ui/shadow-root.ts
+++ b/packages/wxt/src/utils/content-script-ui/shadow-root.ts
@@ -13,6 +13,8 @@ import { splitShadowRootCss } from '../split-shadow-root-css';
  *
  * > This function is async because it has to load the CSS via a network call.
  *
+ * @param options - Shadow root options. See {@link ContentScriptUiOptions} for
+ *   shared positioning, anchoring, `append`, and removal options.
  * @see https://wxt.dev/guide/essentials/content-scripts.html#shadow-root
  */
 export async function createShadowRootUi<TMounted>(


### PR DESCRIPTION
## Summary
- link each content script UI factory directly to its shared options
- call out positioning, anchoring, append, and removal options on the generated function pages
- avoid duplicating shared property documentation

## Testing
- bun run check
- bun run docs:build

Apart of #1452