### PR TITLE
docs: add MindSnap to showcase

### DIFF
--- a/docs/assets/extension-showcase.yml
+++ b/docs/assets/extension-showcase.yml
@@ -528,3 +528,6 @@
 
 - #ArcPort - Tab Rebrand
   chromeId: pgmohcikgaeddapienpncpbiklbmfkgp
+
+- #MindSnap
+  chromeId: mdcpckfcphpicfpiopfcpeambjknjabl


### PR DESCRIPTION
## Summary

Add MindSnap to the WXT showcase.

MindSnap is an AI-powered browser extension that transforms webpages, PDFs, YouTube videos, and other content into interactive mind maps. It helps users quickly understand and organize information with AI-generated summaries and visual maps.

After migrating the project from Plasmo to WXT, the production ZIP size was reduced from **6 MB to 2 MB**, while keeping the same functionality. WXT also simplified the development workflow and improved the overall developer experience.

### Links
- Chrome Web Store: https://chromewebstore.google.com/detail/mindsnap/mdcpckfcphpicfpiopfcpeambjknjabl
- Website: https://www.mindsnap.dev
- 
I migrated my extension from Plasmo to WXT, and it was definitely the right decision. It reduced my extension ZIP size from **6 MB to 2 MB**. That's really impressive.

Thanks for creating WXT!
