### PR TITLE
fix!: Update content and unlisted script `globalName` default to `false`

### DIFF
--- a/packages/wxt/e2e/tests/output-structure.test.ts
+++ b/packages/wxt/e2e/tests/output-structure.test.ts
@@ -506,11 +506,30 @@ describe('Output Directory Structure', () => {
   });
 
   describe('globalName option', () => {
-    it('generates an IIFE with a default name', async () => {
+    it('does not generate a IIFE return variable by default', async () => {
       const project = new TestProject();
       project.addFile(
         'entrypoints/content.js',
         `export default defineContentScript({
+          matches: ["*://*/*"],
+          main() {},
+        })`,
+      );
+
+      await project.build({ vite: () => ({ build: { minify: false } }) });
+
+      const output = await project.serializeFile(
+        '.output/chrome-mv3/content-scripts/content.js',
+      );
+      expect(output.includes('var content')).toBe(false);
+    });
+
+    it('does generates the IIFE name based on the entrypoint name when true', async () => {
+      const project = new TestProject();
+      project.addFile(
+        'entrypoints/content.js',
+        `export default defineContentScript({
+          globalName: true,
           matches: ["*://*/*"],
           main() {},
         })`,

--- a/packages/wxt/src/core/builders/vite/index.ts
+++ b/packages/wxt/src/core/builders/vite/index.ts
@@ -145,7 +145,7 @@ export async function createViteBuilder(
         iifeReturnValueName = entrypoint.options.globalName(entrypoint);
       }
 
-      if (entrypoint.options.globalName === false) {
+      if (!entrypoint.options.globalName) {
         plugins.push(wxtPlugins.iifeAnonymous(iifeReturnValueName));
       } else {
         plugins.push(wxtPlugins.iifeFooter(iifeReturnValueName));

--- a/packages/wxt/src/types.ts
+++ b/packages/wxt/src/types.ts
@@ -680,7 +680,7 @@ export interface BaseScriptEntrypointOptions extends BaseEntrypointOptions {
    * - `function`: A function that receives the entrypoint and returns a string to
    *   use as the variable name.
    *
-   * @default true
+   * @default false
    */
   globalName?: string | boolean | ((entrypoint: Entrypoint) => string);
 }


### PR DESCRIPTION
> [!WARNING]
> BREAKING CHANGE: If your script needs to return a value, like for `browser.scripting.executeScript`, set `globalName: true` to maintain the old behavior.

### Overview

Don't generate IIFE global variable for content and unlisted scripts by default. This prevents generating extra code when a return value isn't necessary.

This closes #2156