### PR TITLE
fix(TS)!: Update `.wxt/tsconfig.json` compiler options, require TS >=5.4

### DIFF
--- a/packages/module-react/modules/react.ts
+++ b/packages/module-react/modules/react.ts
@@ -1,6 +1,6 @@
 import 'wxt';
 import { addImportPreset, addViteConfig, defineWxtModule } from 'wxt/modules';
-import react, { Options as PluginOptions } from '@vitejs/plugin-react';
+import react, { type Options as PluginOptions } from '@vitejs/plugin-react';
 import type { PluginOption } from 'vite';
 
 export default defineWxtModule<ReactModuleOptions>({

--- a/packages/module-solid/components/App.tsx
+++ b/packages/module-solid/components/App.tsx
@@ -1,4 +1,4 @@
-import { Component } from 'solid-js';
+import type { Component } from 'solid-js';
 
 export const App: Component = () => {
   const [count, setCount] = createSignal(0);

--- a/packages/module-solid/modules/solid.ts
+++ b/packages/module-solid/modules/solid.ts
@@ -1,6 +1,6 @@
 import 'wxt';
 import { addImportPreset, addViteConfig, defineWxtModule } from 'wxt/modules';
-import solid, { Options as PluginOptions } from 'vite-plugin-solid';
+import solid, { type Options as PluginOptions } from 'vite-plugin-solid';
 
 export default defineWxtModule<SolidModuleOptions>({
   name: '@wxt-dev/module-solid',

--- a/packages/wxt/e2e/tests/typescript-project.test.ts
+++ b/packages/wxt/e2e/tests/typescript-project.test.ts
@@ -324,15 +324,21 @@ describe('TypeScript Project', () => {
       ----------------------------------------
       {
         "compilerOptions": {
+          "lib": [
+            "ESNext"
+          ],
           "target": "ESNext",
-          "module": "ESNext",
+          "module": "Preserve",
+          "moduleDetection": "force",
           "moduleResolution": "Bundler",
+          "allowImportingTsExtensions": true,
+          "verbatimModuleSyntax": true,
           "noEmit": true,
-          "esModuleInterop": true,
-          "forceConsistentCasingInFileNames": true,
-          "resolveJsonModule": true,
           "strict": true,
           "skipLibCheck": true,
+          "noFallthroughCasesInSwitch": true,
+          "noUncheckedIndexedAccess": true,
+          "noImplicitOverride": true,
           "paths": {
             "@": [
               ".."
@@ -406,15 +412,21 @@ describe('TypeScript Project', () => {
       ----------------------------------------
       {
         "compilerOptions": {
+          "lib": [
+            "ESNext"
+          ],
           "target": "ESNext",
-          "module": "ESNext",
+          "module": "Preserve",
+          "moduleDetection": "force",
           "moduleResolution": "Bundler",
+          "allowImportingTsExtensions": true,
+          "verbatimModuleSyntax": true,
           "noEmit": true,
-          "esModuleInterop": true,
-          "forceConsistentCasingInFileNames": true,
-          "resolveJsonModule": true,
           "strict": true,
           "skipLibCheck": true,
+          "noFallthroughCasesInSwitch": true,
+          "noUncheckedIndexedAccess": true,
+          "noImplicitOverride": true,
           "paths": {
             "@": [
               "../src"
@@ -473,15 +485,21 @@ describe('TypeScript Project', () => {
       ----------------------------------------
       {
         "compilerOptions": {
+          "lib": [
+            "ESNext"
+          ],
           "target": "ESNext",
-          "module": "ESNext",
+          "module": "Preserve",
+          "moduleDetection": "force",
           "moduleResolution": "Bundler",
+          "allowImportingTsExtensions": true,
+          "verbatimModuleSyntax": true,
           "noEmit": true,
-          "esModuleInterop": true,
-          "forceConsistentCasingInFileNames": true,
-          "resolveJsonModule": true,
           "strict": true,
           "skipLibCheck": true,
+          "noFallthroughCasesInSwitch": true,
+          "noUncheckedIndexedAccess": true,
+          "noImplicitOverride": true,
           "paths": {
             "example": [
               "../example"

--- a/packages/wxt/e2e/tests/typescript-project.test.ts
+++ b/packages/wxt/e2e/tests/typescript-project.test.ts
@@ -325,7 +325,9 @@ describe('TypeScript Project', () => {
       {
         "compilerOptions": {
           "lib": [
-            "ESNext"
+            "ESNext",
+            "DOM",
+            "DOM.Iterable"
           ],
           "target": "ESNext",
           "module": "Preserve",
@@ -413,7 +415,9 @@ describe('TypeScript Project', () => {
       {
         "compilerOptions": {
           "lib": [
-            "ESNext"
+            "ESNext",
+            "DOM",
+            "DOM.Iterable"
           ],
           "target": "ESNext",
           "module": "Preserve",
@@ -486,7 +490,9 @@ describe('TypeScript Project', () => {
       {
         "compilerOptions": {
           "lib": [
-            "ESNext"
+            "ESNext",
+            "DOM",
+            "DOM.Iterable"
           ],
           "target": "ESNext",
           "module": "Preserve",

--- a/packages/wxt/package.json
+++ b/packages/wxt/package.json
@@ -58,13 +58,17 @@
   "peerDependencies": {
     "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
     "vite": "^6.3.4 || ^7.0.0 || ^8.0.0-0",
-    "web-ext": ">=9.2.0"
+    "web-ext": ">=9.2.0",
+    "typescript": ">=5.4"
   },
   "peerDependenciesMeta": {
     "eslint": {
       "optional": true
     },
     "web-ext": {
+      "optional": true
+    },
+    "typescript": {
       "optional": true
     }
   },

--- a/packages/wxt/src/core/generate-wxt-dir.ts
+++ b/packages/wxt/src/core/generate-wxt-dir.ts
@@ -297,15 +297,22 @@ async function getTsConfigEntry(): Promise<WxtDirFileEntry> {
 
   const tsconfig = {
     compilerOptions: {
+      // Environment setup & latest features
+      lib: ['ESNext'],
       target: 'ESNext',
-      module: 'ESNext',
+      module: 'Preserve',
+      moduleDetection: 'force',
+      // Bundler mode
       moduleResolution: 'Bundler',
+      allowImportingTsExtensions: true,
+      verbatimModuleSyntax: true,
       noEmit: true,
-      esModuleInterop: true,
-      forceConsistentCasingInFileNames: true,
-      resolveJsonModule: true,
+      // Best practices
       strict: true,
       skipLibCheck: true,
+      noFallthroughCasesInSwitch: true,
+      noUncheckedIndexedAccess: true,
+      noImplicitOverride: true,
       paths,
     },
     include: [`${getTsconfigPath(wxt.config.root)}/**/*`, './wxt.d.ts'],

--- a/packages/wxt/src/core/generate-wxt-dir.ts
+++ b/packages/wxt/src/core/generate-wxt-dir.ts
@@ -313,6 +313,7 @@ async function getTsConfigEntry(): Promise<WxtDirFileEntry> {
       noFallthroughCasesInSwitch: true,
       noUncheckedIndexedAccess: true,
       noImplicitOverride: true,
+      // Project settings
       paths,
     },
     include: [`${getTsconfigPath(wxt.config.root)}/**/*`, './wxt.d.ts'],

--- a/packages/wxt/src/core/generate-wxt-dir.ts
+++ b/packages/wxt/src/core/generate-wxt-dir.ts
@@ -298,7 +298,7 @@ async function getTsConfigEntry(): Promise<WxtDirFileEntry> {
   const tsconfig = {
     compilerOptions: {
       // Environment setup & latest features
-      lib: ['ESNext'],
+      lib: ['ESNext', 'DOM', 'DOM.Iterable'],
       target: 'ESNext',
       module: 'Preserve',
       moduleDetection: 'force',


### PR DESCRIPTION
> [!WARNING]
> BREAKING CHANGE: Updates `.wxt/tsconfig.json` defaults to latest recommended settings for vite projects and requires Typescript 5.4 or later. See #2512 for details on what compiler options were changed.

### Overview

This closes #2449. Update to latest recommended tsconfig and set min version for typescript peer.
