### PR TITLE
feat(Firefox): List files in sources zip

### DIFF
--- a/packages/wxt/src/core/zip.ts
+++ b/packages/wxt/src/core/zip.ts
@@ -95,7 +95,7 @@ export async function zip(config?: InlineConfig): Promise<string[]> {
     await wxt.hooks.callHook('zip:sources:done', wxt, sourcesZipPath);
 
     await printFileList(
-      wxt.logger.success,
+      wxt.logger.info,
       `Sources included in \`${sourcesZipFilename}\``,
       wxt.config.zip.sourcesRoot,
       files,

--- a/packages/wxt/src/core/zip.ts
+++ b/packages/wxt/src/core/zip.ts
@@ -11,6 +11,7 @@ import { registerWxt, wxt } from './wxt';
 import JSZip from 'jszip';
 import { glob } from 'tinyglobby';
 import { normalizePath } from './utils';
+import { relative } from 'node:path/win32';
 
 /**
  * Build and zip the extension for distribution.
@@ -79,7 +80,7 @@ export async function zip(config?: InlineConfig): Promise<string[]> {
       wxt.config.outBaseDir,
       sourcesZipFilename,
     );
-    await zipDir(wxt.config.zip.sourcesRoot, sourcesZipPath, {
+    const files = await zipDir(wxt.config.zip.sourcesRoot, sourcesZipPath, {
       include: wxt.config.zip.includeSources,
       exclude: excludeSources,
       transform(absolutePath, zipPath, content) {
@@ -92,6 +93,13 @@ export async function zip(config?: InlineConfig): Promise<string[]> {
     });
     zipFiles.push(sourcesZipPath);
     await wxt.hooks.callHook('zip:sources:done', wxt, sourcesZipPath);
+
+    await printFileList(
+      wxt.logger.success,
+      `Sources included in \`${sourcesZipFilename}\``,
+      wxt.config.zip.sourcesRoot,
+      files,
+    );
   }
 
   await printFileList(
@@ -121,7 +129,7 @@ async function zipDir(
     additionalFiles?: string[];
     dot?: boolean;
   },
-): Promise<void> {
+): Promise<string[]> {
   const archive = new JSZip();
   // includeSources patterns are used directly (defaults to ['**/*'] from config)
   // excludeSources patterns are passed to glob's ignore option for efficient filtering
@@ -167,6 +175,8 @@ async function zipDir(
       .on('error', reject)
       .on('close', resolve),
   );
+
+  return filesToZip;
 }
 
 async function downloadPrivatePackages() {

--- a/packages/wxt/src/core/zip.ts
+++ b/packages/wxt/src/core/zip.ts
@@ -144,7 +144,7 @@ async function zipDir(
     ...(options?.additionalFiles ?? []).map((file) =>
       path.relative(directory, file),
     ),
-  ];
+  ].sort();
   for (const file of filesToZip) {
     const absolutePath = path.resolve(directory, file);
     if (file.endsWith('.json')) {

--- a/packages/wxt/src/core/zip.ts
+++ b/packages/wxt/src/core/zip.ts
@@ -11,7 +11,6 @@ import { registerWxt, wxt } from './wxt';
 import JSZip from 'jszip';
 import { glob } from 'tinyglobby';
 import { normalizePath } from './utils';
-import { relative } from 'node:path/win32';
 
 /**
  * Build and zip the extension for distribution.


### PR DESCRIPTION
### Overview

With the changes to in #2111, we need to make it easier to migrate. This PR prints all the files in the ZIP so you can quickly see what needs to be removed or included.

### Manual Testing

```
$ cd packages/wxt-demo
$ bun wxt zip -b firefox
WXT 0.20.27
ℹ Example module with options: { a: 'a', c: 'c' }                                                                                                                                                                                                                                                                                  12:49:01 PM
ℹ [i18n] Default locale: en                                                                                                                                                                                                                                                                                                        12:49:01 PM
ℹ Building firefox-mv2 for production with Vite 7.3.1                                                                                                                                                                                                                                                                              12:49:01 PM
...
✔ Built extension in 1.506 s                                                                                                                                                                                                                                                                                                       12:49:03 PM
  ├─ .output/firefox-mv2/manifest.json                                 1.07 kB
  ├─ .output/firefox-mv2/example.html                                  287 B
  ├─ .output/firefox-mv2/iframe-src.html                               426 B
  ├─ .output/firefox-mv2/options.html                                  504 B
  ├─ .output/firefox-mv2/popup.html                                    404 B
  ├─ .output/firefox-mv2/sandbox.html                                  287 B
  ├─ .output/firefox-mv2/sidepanel.html                                327 B
  ├─ .output/firefox-mv2/background.js                                 13 kB
  ├─ .output/firefox-mv2/chunks/_virtual_wxt-html-plugins-DPbbfBKe.js  779 B
  ├─ .output/firefox-mv2/chunks/iframe-src-CknGQcVu.js                 73 B
  ├─ .output/firefox-mv2/chunks/logger-BtMHEi2b.js                     848 B
  ├─ .output/firefox-mv2/chunks/options-utuQpyBu.js                    282 B
  ├─ .output/firefox-mv2/content-scripts/automount.js                  10.93 kB
  ├─ .output/firefox-mv2/content-scripts/content.js                    4.24 kB
  ├─ .output/firefox-mv2/content-scripts/example-tsx.js                196.44 kB
  ├─ .output/firefox-mv2/content-scripts/iframe.js                     9.34 kB
  ├─ .output/firefox-mv2/content-scripts/location-change.js            3.74 kB
  ├─ .output/firefox-mv2/content-scripts/main-world.js                 464 B
  ├─ .output/firefox-mv2/content-scripts/ui.js                         13.17 kB
  ├─ .output/firefox-mv2/unlisted.js                                   633 B
  ├─ .output/firefox-mv2/assets/example-2.css                          27 B
  ├─ .output/firefox-mv2/assets/options-06If5sjy.css                   33 B
  ├─ .output/firefox-mv2/assets/popup-1IKQK_ZO.css                     2.13 kB
  ├─ .output/firefox-mv2/content-scripts/automount.css                 2.62 kB
  ├─ .output/firefox-mv2/content-scripts/injected.css                  17 B
  ├─ .output/firefox-mv2/content-scripts/ui.css                        2.3 kB
  ├─ .output/firefox-mv2/_locales/en/messages.json                     714 B
  ├─ .output/firefox-mv2/icons/128.png                                 1.68 kB
  ├─ .output/firefox-mv2/icons/16.png                                  639 B
  ├─ .output/firefox-mv2/icons/32.png                                  1.41 kB
  └─ .output/firefox-mv2/icons/48.png                                  2.3 kB
Σ Total size: 271.11 kB
ℹ Zipping extension...                                                                                                                                                                                                                                                                                                             12:49:03 PM
ℹ Downloading package: sass@1.97.3                                                                                                                                                                                                                                                                                                 12:49:03 PM
ℹ Sources included in wxt-demo-1.0.0-sources.zip                                                                                                                                                                                                                                                                                   12:49:03 PM
  ├─ /.wxt/local_modules/sass-1.97.3.tgz           922.8 kB
  ├─ /coverage/base.css                            5.39 kB
  ├─ /coverage/block-navigation.js                 2.66 kB
  ├─ /coverage/clover.xml                          3.26 kB
  ├─ /coverage/coverage-final.json                 3.98 kB
  ├─ /coverage/favicon.png                         445 B
  ├─ /coverage/index.html                          6.37 kB
  ├─ /coverage/prettify.css                        676 B
  ├─ /coverage/prettify.js                         17.59 kB
  ├─ /coverage/sort-arrow-sprite.png               138 B
  ├─ /coverage/sorter.js                           6.73 kB
  ├─ /coverage/src/app.config.ts.html              4.3 kB
  ├─ /coverage/src/entrypoints/background.ts.html  8.49 kB
  ├─ /coverage/src/entrypoints/index.html          4.47 kB
  ├─ /coverage/src/index.html                      4.38 kB
  ├─ /coverage/src/utils/index.html                4.43 kB
  ├─ /coverage/src/utils/logger.ts.html            3.67 kB
  ├─ /eslint.config.js                             204 B
  ├─ /modules/auto-icons.ts                        72 B
  ├─ /modules/example.ts                           437 B
  ├─ /modules/i18n.ts                              67 B
  ├─ /modules/unocss.ts                            43 B
  ├─ /package.json                                 1.4 kB
  ├─ /src/app.config.ts                            211 B
  ├─ /src/assets/icon.png                          2.68 kB
  ├─ /src/entrypoints/automount.content/index.ts   2.2 kB
  ├─ /src/entrypoints/automount.content/style.css  32 B
  ├─ /src/entrypoints/background.ts                1.6 kB
  ├─ /src/entrypoints/content.ts                   241 B
  ├─ /src/entrypoints/example-2.scss               34 B
  ├─ /src/entrypoints/example-tsx.content.tsx      677 B
  ├─ /src/entrypoints/example.sandbox/index.html   274 B
  ├─ /src/entrypoints/iframe-src/index.html        301 B
  ├─ /src/entrypoints/iframe-src/main.ts           25 B
  ├─ /src/entrypoints/iframe.content.ts            291 B
  ├─ /src/entrypoints/injected.content/index.css   24 B
  ├─ /src/entrypoints/location-change.content.ts   342 B
  ├─ /src/entrypoints/main-world.content.ts        152 B
  ├─ /src/entrypoints/options/index.html           355 B
  ├─ /src/entrypoints/options/main.ts              178 B
  ├─ /src/entrypoints/options/style.css            46 B
  ├─ /src/entrypoints/popup.html                   279 B
  ├─ /src/entrypoints/sandbox.html                 271 B
  ├─ /src/entrypoints/sidepanel.html               231 B
  ├─ /src/entrypoints/ui.content/index.ts          791 B
  ├─ /src/entrypoints/ui.content/manual-style.css  62 B
  ├─ /src/entrypoints/ui.content/style.css         68 B
  ├─ /src/entrypoints/unlisted.ts                  75 B
  ├─ /src/locales/en.yml                           499 B
  ├─ /src/utils/logger.ts                          97 B
  ├─ /tsconfig.json                                211 B
  ├─ /vitest.config.ts                             224 B
  └─ /wxt.config.ts                                1.31 kB
Σ Total size: 1.02 MB
✔ Zipped extension in 605 ms                                                                                                                                                                                                                                                                                                       12:49:03 PM
  ├─ .output/wxt-demo-1.0.0-firefox.zip  98.07 kB
  └─ .output/wxt-demo-1.0.0-sources.zip  964.22 kB
Σ Total size: 1.06 MB
✔ Finished in 2.449 s
```

As you can see, it's now obvious we should exclude the `coverage` folder from the zip.
