### PR TITLE
feat!: Restore url: imports, require an integrity hash

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ Or see the [installation guide](https://wxt.dev/guide/installation.html) to get 
 - 📦 [Module system](https://wxt.dev/guide/essentials/wxt-modules.html#overview) for reusing code between extensions
 - 🖍️ Quickly bootstrap a new project
 - 📏 Bundle analysis
+- ⬇️ Download and bundle remote URL imports
 
 ## Sponsors
 

--- a/docs/guide/essentials/remote-code.md
+++ b/docs/guide/essentials/remote-code.md
@@ -1,0 +1,72 @@
+# Remote Code
+
+WXT will automatically download and bundle imports with the `url:` prefix so the extension does not depend on remote code, [a requirement from Google for MV3](https://developer.chrome.com/docs/extensions/migrating/improve-security/#remove-remote-code).
+
+## Integrity Hashes
+
+Every URL import must pin an integrity hash. Whatever you import is bundled into your extension and ships to your users, so an unpinned import means a compromised or hijacked CDN can put arbitrary code in your next release without you noticing.
+
+The hash goes between `url` and the URL, prefixed with `#`:
+
+```ts
+import 'url#sha256-kmHvs0B+OpCW5GVHUNjv9rOmY0IvSIRcf7zGUDTDQM8=:https://code.jquery.com/jquery-3.7.1.slim.min.js';
+```
+
+`sha256`, `sha384`, and `sha512` are supported, in either base64 (the same format as [Subresource Integrity](https://developer.mozilla.org/en-US/docs/Web/Security/Subresource_Integrity), which most CDNs publish) or hex.
+
+If you don't know the hash yet, import the URL without one. The build will fail and print the hash of the file currently being served:
+
+```
+URL imports must pin an integrity hash: "url:https://code.jquery.com/jquery-3.7.1.slim.min.js"
+
+  import 'url#sha256-kmHvs0B+OpCW5GVHUNjv9rOmY0IvSIRcf7zGUDTDQM8=:https://code.jquery.com/jquery-3.7.1.slim.min.js';
+```
+
+:::warning
+A hash locks in whatever is served today — it does not make untrusted code safe. Review the file before pinning it.
+:::
+
+When the remote file changes, the build fails instead of silently bundling the new version:
+
+```
+Integrity check failed for "https://code.jquery.com/jquery-3.7.1.slim.min.js".
+
+  Expected: sha256-kmHvs0B+OpCW5GVHUNjv9rOmY0IvSIRcf7zGUDTDQM8=
+  Received: sha256-b6WuS8lqRB1JlP0z1BjCXGKtIFgKPKcJPvXCLpxLxeM=
+
+The remote file changed since you added it. Review the new file, and if you trust it, update the hash in your import.
+```
+
+Run your build on a schedule in CI to find out when a remote dependency changes, rather than at release time.
+
+## Google Analytics
+
+For example, you can import Google Analytics:
+
+```ts
+// utils/google-analytics.ts
+import 'url#sha256-XXXXXX:https://www.googletagmanager.com/gtag/js?id=G-XXXXXX';
+
+window.dataLayer = window.dataLayer || [];
+// NOTE: This line is different from Google's documentation
+window.gtag = function () {
+  dataLayer.push(arguments);
+};
+gtag('js', new Date());
+gtag('config', 'G-XXXXXX');
+```
+
+Then you can import this in your HTML files to enable Google Analytics:
+
+```ts
+// popup/main.ts
+import '~/utils/google-analytics';
+
+gtag('event', 'event_name', {
+  key: 'value',
+});
+```
+
+:::warning
+`gtag/js` is regenerated frequently and its hash changes often, so pinning it means updating the hash regularly. Prefer an NPM package where one exists.
+:::

--- a/docs/guide/essentials/remote-code.md
+++ b/docs/guide/essentials/remote-code.md
@@ -23,7 +23,7 @@ URL imports must pin an integrity hash: "url:https://code.jquery.com/jquery-3.7.
 ```
 
 :::warning
-A hash locks in whatever is served today — it does not make untrusted code safe. Review the file before pinning it.
+A hash locks in whatever is served today. It does not make untrusted code safe, so review the file before pinning it.
 :::
 
 When the remote file changes, the build fails instead of silently bundling the new version:
@@ -41,7 +41,11 @@ Run your build on a schedule in CI to find out when a remote dependency changes,
 
 ## Google Analytics
 
-For example, you can import Google Analytics:
+:::tip You might be interested in [`@wxt-dev/analytics`](/analytics)
+It ships a [Google Analytics 4 provider](/analytics#google-analytics-4-measurement-protocol) built on the [Measurement Protocol](https://developers.google.com/analytics/devguides/collection/protocol/ga4), [Google's recommended approach for MV3](https://developer.chrome.com/docs/extensions/how-to/integrate/google-analytics-4#measurement-protocol). No remote code, so there's no hash to pin and keep up to date.
+:::
+
+If you'd still rather bundle `gtag/js` yourself:
 
 ```ts
 // utils/google-analytics.ts
@@ -68,5 +72,5 @@ gtag('event', 'event_name', {
 ```
 
 :::warning
-`gtag/js` is regenerated frequently and its hash changes often, so pinning it means updating the hash regularly. Prefer an NPM package where one exists.
+`gtag/js` is regenerated frequently and its hash changes often, so pinning it means updating the hash regularly.
 :::

--- a/docs/guide/essentials/remote-code.md
+++ b/docs/guide/essentials/remote-code.md
@@ -26,7 +26,19 @@ URL imports must pin an integrity hash: "url:https://code.jquery.com/jquery-3.7.
 A hash locks in whatever is served today. It does not make untrusted code safe, so review the file before pinning it.
 :::
 
-When the remote file changes, the build fails instead of silently bundling the new version:
+A file that doesn't match its hash is never bundled. What happens next depends on whether you already have a copy that does match.
+
+Downloads are cached in `.wxt/cache`. If the remote file changes and your cached copy still matches the hash, WXT keeps building with the version you pinned and warns you:
+
+```
+[warn] "https://code.jquery.com/jquery-3.7.1.slim.min.js" changed upstream. Using the cached copy
+that matches the expected hash. Review the new file and update your import when you're ready to
+pick it up.
+```
+
+So a remote file changing mid-feature doesn't block you, and you don't silently pick up code you haven't reviewed.
+
+Without a matching cached copy, there's nothing safe to build with, and the build fails:
 
 ```
 Integrity check failed for "https://code.jquery.com/jquery-3.7.1.slim.min.js".
@@ -37,7 +49,7 @@ Integrity check failed for "https://code.jquery.com/jquery-3.7.1.slim.min.js".
 The remote file changed since you added it. Review the new file, and if you trust it, update the hash in your import.
 ```
 
-Run your build on a schedule in CI to find out when a remote dependency changes, rather than at release time.
+Since `.wxt` isn't committed, CI starts from an empty cache and fails on drift rather than warning. Run your build on a schedule there to find out when a remote dependency changes, rather than at release time.
 
 ## Google Analytics
 

--- a/docs/guide/essentials/unit-testing.md
+++ b/docs/guide/essentials/unit-testing.md
@@ -21,6 +21,7 @@ This plugin does several things:
 - Polyfills the extension API, `browser`, with an in-memory implementation using [`@webext-core/fake-browser`](https://webext-core.aklinker1.io/fake-browser/installation)
 - Adds all vite config or plugins in `wxt.config.ts`
 - Configures auto-imports (if enabled)
+- Applies internal WXT vite plugins for things like [bundling remote code](/guide/essentials/remote-code)
 - Sets up global variables provided by WXT (`import.meta.env.BROWSER`, `import.meta.env.MANIFEST_VERSION`, `import.meta.env.IS_CHROME`, etc)
 - Configures aliases (`@/*`, `@@/*`, etc) so imports can be resolved
 

--- a/docs/guide/resources/compare.md
+++ b/docs/guide/resources/compare.md
@@ -24,6 +24,7 @@ Lets compare the features of WXT vs [Plasmo](https://docs.plasmo.com/framework) 
 | Supports all frontend frameworks                        |   ✅    | 🟡 [^c] |   ✅    |
 | Framework specific entrypoints (like `Popup.tsx`)       | 🟡 [^d] | ✅ [^e] |   ❌    |
 | Automated publishing                                    |   ✅    |   ✅    |   ❌    |
+| Remote Code Bundling (Google Analytics)                 |   ✅    |   ✅    |   ❌    |
 | Unlisted HTML Pages                                     |   ✅    |   ✅    |   ✅    |
 | Unlisted Scripts                                        |   ✅    |   ❌    |   ❌    |
 | ESM Content Scripts                                     | ❌ [^l] |   ❌    |   ✅    |

--- a/docs/guide/resources/compare.md
+++ b/docs/guide/resources/compare.md
@@ -24,7 +24,7 @@ Lets compare the features of WXT vs [Plasmo](https://docs.plasmo.com/framework) 
 | Supports all frontend frameworks                        |   ✅    | 🟡 [^c] |   ✅    |
 | Framework specific entrypoints (like `Popup.tsx`)       | 🟡 [^d] | ✅ [^e] |   ❌    |
 | Automated publishing                                    |   ✅    |   ✅    |   ❌    |
-| Remote Code Bundling (Google Analytics)                 |   ✅    |   ✅    |   ❌    |
+| Remote Code Bundling                                    |   ✅    |   ✅    |   ❌    |
 | Unlisted HTML Pages                                     |   ✅    |   ✅    |   ✅    |
 | Unlisted Scripts                                        |   ✅    |   ❌    |   ❌    |
 | ESM Content Scripts                                     | ❌ [^l] |   ❌    |   ✅    |

--- a/docs/guide/resources/migrate.md
+++ b/docs/guide/resources/migrate.md
@@ -51,7 +51,7 @@ Here's specific steps for other popular frameworks/build tools.
 3. Move public `assets/*` into the `public/` directory
 4. If you use CSUI, migrate to WXT's `createContentScriptUi`
 5. Convert Plasmo's custom import resolutions to Vite's
-6. Importing remote code via a URL is not supported in WXT, see [this issue](https://github.com/wxt-dev/wxt/issues/2262) for alternatives
+6. If importing remote code via a URL, add a `url:` prefix and an [integrity hash](/guide/essentials/remote-code) so it works with WXT
 7. Replace your [Plasmo tags](https://docs.plasmo.com/framework/workflows/build#with-a-custom-tag) (`--tag`) with [WXT build modes](/guide/essentials/config/build-mode) (`--mode`)
 8. ⚠️ Compare the old production manifest to `.output/*/manifest.json`. They should have the same content as before. If not, tweak your entrypoints and config until they are the same.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -66,6 +66,11 @@ features:
   - icon: 📏
     title: Bundle Analysis
     details: Tools for analyzing the final extension bundle and minimizing your extension's size.
+  - icon: ⬇️
+    title: Bundle Remote Code
+    details: Downloads and bundles remote code imported from URLs.
+    link: /guide/essentials/remote-code
+    linkText: Read docs
 ---
 
 ## Sponsors

--- a/packages/wxt-demo/src/entrypoints/options/main.ts
+++ b/packages/wxt-demo/src/entrypoints/options/main.ts
@@ -1,3 +1,6 @@
+// @ts-expect-error: URL imports not typed
+import 'url#sha256-kmHvs0B+OpCW5GVHUNjv9rOmY0IvSIRcf7zGUDTDQM8=:https://code.jquery.com/jquery-3.7.1.slim.min.js';
+
 console.log(browser.runtime.id);
 logId();
 console.log(2);

--- a/packages/wxt/README.md
+++ b/packages/wxt/README.md
@@ -54,6 +54,7 @@ Or see the [installation guide](https://wxt.dev/guide/installation.html) to get 
 - 📦 [Module system](https://wxt.dev/guide/essentials/wxt-modules.html#overview) for reusing code between extensions
 - 🖍️ Quickly bootstrap a new project
 - 📏 Bundle analysis
+- ⬇️ Download and bundle remote URL imports
 
 ## Sponsors
 

--- a/packages/wxt/e2e/tests/remote-code.test.ts
+++ b/packages/wxt/e2e/tests/remote-code.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect } from 'vitest';
+import { TestProject } from '../utils';
+
+const url = 'https://cdn.jsdelivr.net/npm/lodash@4.17.21/lodash.min.js';
+const integrity = 'sha256-qXBd/EfAdjOA2FGrGAG+b3YBn2tn5A6bhz+LSgYD96k=';
+
+describe('Remote Code', () => {
+  it('should download "url:*" modules and include them in the final bundle', async () => {
+    const project = new TestProject();
+    project.addFile(
+      'entrypoints/popup.ts',
+      `import "url#${integrity}:${url}"
+      export default defineUnlistedScript(() => {})`,
+    );
+
+    await project.build();
+
+    const output = await project.serializeFile('.output/chrome-mv3/popup.js');
+    expect(output).toContain(
+      // Some text that will hopefully be in future versions of this script
+      '__lodash_placeholder__',
+    );
+    expect(output).not.toContain(url);
+    expect(
+      await project.pathExists(`.wxt/cache/${encodeURIComponent(url)}`),
+    ).toBe(true);
+  });
+
+  it('should accept a hex integrity hash', async () => {
+    const hex =
+      'sha256-a9705dfc47c0763380d851ab1801be6f76019f6b67e40e9b873f8b4a0603f7a9';
+    const project = new TestProject();
+    project.addFile(
+      'entrypoints/popup.ts',
+      `import "url#${hex}:${url}"
+      export default defineUnlistedScript(() => {})`,
+    );
+
+    await project.build();
+
+    const output = await project.serializeFile('.output/chrome-mv3/popup.js');
+    expect(output).toContain('__lodash_placeholder__');
+  });
+
+  it('should fail the build when the integrity hash is missing', async () => {
+    const project = new TestProject();
+    project.addFile(
+      'entrypoints/popup.ts',
+      `import "url:${url}"
+      export default defineUnlistedScript(() => {})`,
+    );
+
+    await expect(project.build()).rejects.toThrow(
+      /URL imports must pin an integrity hash/,
+    );
+  });
+
+  it('should fail the build when the integrity hash does not match', async () => {
+    const project = new TestProject();
+    project.addFile(
+      'entrypoints/popup.ts',
+      `import "url#sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=:${url}"
+      export default defineUnlistedScript(() => {})`,
+    );
+
+    await expect(project.build()).rejects.toThrow(/Integrity check failed/);
+
+    expect(
+      await project.pathExists(`.wxt/cache/${encodeURIComponent(url)}`),
+    ).toBe(false);
+  });
+});

--- a/packages/wxt/e2e/tests/remote-code.test.ts
+++ b/packages/wxt/e2e/tests/remote-code.test.ts
@@ -50,9 +50,13 @@ describe('Remote Code', () => {
       export default defineUnlistedScript(() => {})`,
     );
 
-    await expect(project.build()).rejects.toThrow(
-      /URL imports must pin an integrity hash/,
-    );
+    await expect(project.build()).rejects.toMatchObject({
+      cause: {
+        message: expect.stringContaining(
+          'URL imports must pin an integrity hash',
+        ),
+      },
+    });
   });
 
   it('should fail the build when the integrity hash does not match', async () => {
@@ -63,7 +67,11 @@ describe('Remote Code', () => {
       export default defineUnlistedScript(() => {})`,
     );
 
-    await expect(project.build()).rejects.toThrow(/Integrity check failed/);
+    await expect(project.build()).rejects.toMatchObject({
+      cause: {
+        message: expect.stringContaining('Integrity check failed'),
+      },
+    });
 
     expect(
       await project.pathExists(`.wxt/cache/${encodeURIComponent(url)}`),

--- a/packages/wxt/src/core/builders/vite/index.ts
+++ b/packages/wxt/src/core/builders/vite/index.ts
@@ -94,6 +94,7 @@ export async function createViteBuilder(
 
     config.plugins ??= [];
     config.plugins.push(
+      wxtPlugins.download(wxtConfig),
       wxtPlugins.devHtmlPrerender(wxtConfig, server),
       wxtPlugins.resolveVirtualModules(wxtConfig),
       wxtPlugins.devServerGlobals(wxtConfig, server),

--- a/packages/wxt/src/core/builders/vite/plugins/download.ts
+++ b/packages/wxt/src/core/builders/vite/plugins/download.ts
@@ -8,9 +8,8 @@ import {
 } from '../../../utils/integrity';
 
 /**
- * Downloads any URL imports, like Google Analytics, into virtual modules so
- * they are bundled with the extension instead of depending on remote code at
- * runtime.
+ * Downloads any URL imports into virtual modules so they are bundled with the
+ * extension instead of depending on remote code at runtime.
  *
  * Every import must pin an integrity hash. Without one, a compromised CDN could
  * silently ship arbitrary code inside your extension.
@@ -74,6 +73,6 @@ async function missingIntegrityMessage(
   return (
     `${base}\n\n` +
     `  ${suggestion}\n\n` +
-    `Review the file at that URL before pinning it — the hash locks in whatever is served today, it doesn't make untrusted code safe.`
+    `Review the file at that URL before pinning it. A hash locks in whatever is served today, but it doesn't make untrusted code safe.`
   );
 }

--- a/packages/wxt/src/core/builders/vite/plugins/download.ts
+++ b/packages/wxt/src/core/builders/vite/plugins/download.ts
@@ -1,0 +1,79 @@
+import type { Plugin } from 'vite';
+import type { ResolvedConfig } from '../../../../types';
+import { fetchCached } from '../../../utils/network';
+import {
+  hashContent,
+  parseUrlImport,
+  verifyIntegrity,
+} from '../../../utils/integrity';
+
+/**
+ * Downloads any URL imports, like Google Analytics, into virtual modules so
+ * they are bundled with the extension instead of depending on remote code at
+ * runtime.
+ *
+ * Every import must pin an integrity hash. Without one, a compromised CDN could
+ * silently ship arbitrary code inside your extension.
+ *
+ * @example
+ *   import 'url#sha256-kmHvs0B+OpCW5GVHUNjv9rOmY0IvSIRcf7zGUDTDQM8=:https://code.jquery.com/jquery-3.7.1.slim.min.js';
+ */
+export function download(config: ResolvedConfig): Plugin {
+  return {
+    name: 'wxt:download',
+    enforce: 'pre',
+    resolveId: {
+      filter: {
+        id: /^url[:#]/,
+      },
+      handler(id) {
+        return `\0${id}`;
+      },
+    },
+    load: {
+      filter: {
+        //eslint-disable-next-line no-control-regex
+        id: /^\x00url[:#]/,
+      },
+      async handler(id) {
+        const specifier = id.slice(1);
+        const parsed = parseUrlImport(specifier);
+        if (!parsed) {
+          throw Error(
+            `Invalid URL import: "${specifier}". Expected "url#<integrity>:<url>".`,
+          );
+        }
+
+        const { url, integrity } = parsed;
+        if (!integrity) {
+          throw Error(await missingIntegrityMessage(url, config));
+        }
+
+        return await fetchCached(url, config, {
+          verify: (content) => verifyIntegrity(content, integrity, url),
+        });
+      },
+    },
+  };
+}
+
+async function missingIntegrityMessage(
+  url: string,
+  config: ResolvedConfig,
+): Promise<string> {
+  const base = `URL imports must pin an integrity hash: "url:${url}"`;
+
+  let suggestion: string;
+  try {
+    const content = await fetchCached(url, config, { noCache: true });
+    suggestion = `import 'url#${hashContent(content)}:${url}';`;
+  } catch {
+    suggestion = `import 'url#<integrity>:${url}';`;
+  }
+
+  return (
+    `${base}\n\n` +
+    `  ${suggestion}\n\n` +
+    `Review the file at that URL before pinning it — the hash locks in whatever is served today, it doesn't make untrusted code safe.`
+  );
+}

--- a/packages/wxt/src/core/builders/vite/plugins/index.ts
+++ b/packages/wxt/src/core/builders/vite/plugins/index.ts
@@ -1,5 +1,6 @@
 export * from './devHtmlPrerender';
 export * from './devServerGlobals';
+export * from './download';
 export * from './resolveVirtualModules';
 export * from './tsconfigPaths';
 export * from './noopBackground';

--- a/packages/wxt/src/core/utils/__tests__/integrity.test.ts
+++ b/packages/wxt/src/core/utils/__tests__/integrity.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it } from 'vitest';
+import { hashContent, parseUrlImport, verifyIntegrity } from '../integrity';
+
+const url = 'https://example.com/script.js';
+const content = 'console.log("hello");';
+// sha256 of `content`
+const base64 = 'sha256-N4H5TqgSuzNDfekEngS8OvQaDnOXFksFc3nAjDsKxIk=';
+const hex =
+  'sha256-3781f94ea812bb33437de9049e04bc3af41a0e7397164b057379c08c3b0ac489';
+
+describe('Integrity utils', () => {
+  describe('parseUrlImport', () => {
+    it('should parse an import with an integrity hash', () => {
+      expect(parseUrlImport(`url#${base64}:${url}`)).toEqual({
+        url,
+        integrity: base64,
+      });
+    });
+
+    it.each([`url:${url}`, `url#:${url}`])(
+      'should parse "%s" as an import without an integrity hash',
+      (id) => {
+        expect(parseUrlImport(id)).toEqual({ url, integrity: undefined });
+      },
+    );
+
+    it('should keep query params and ports in the URL', () => {
+      const complex = 'https://example.com:8443/gtag/js?id=G-XYZ&foo=a:b';
+      expect(parseUrlImport(`url#${base64}:${complex}`)).toEqual({
+        url: complex,
+        integrity: base64,
+      });
+    });
+
+    it.each(['url', 'url#', 'url:', 'other:https://a.com'])(
+      'should return undefined for invalid specifier "%s"',
+      (id) => {
+        expect(parseUrlImport(id)).toBeUndefined();
+      },
+    );
+  });
+
+  describe('hashContent', () => {
+    it('should return a base64 SRI hash', () => {
+      expect(hashContent(content)).toBe(base64);
+    });
+
+    it('should support other algorithms', () => {
+      expect(hashContent(content, 'sha512')).toMatch(/^sha512-/);
+    });
+  });
+
+  describe('verifyIntegrity', () => {
+    it('should pass for a matching base64 hash', () => {
+      expect(() => verifyIntegrity(content, base64, url)).not.toThrow();
+    });
+
+    it('should pass for a matching hex hash', () => {
+      expect(() => verifyIntegrity(content, hex, url)).not.toThrow();
+    });
+
+    it('should pass for a matching uppercase hex hash', () => {
+      expect(() =>
+        verifyIntegrity(
+          content,
+          hex.toUpperCase().replace('SHA256', 'sha256'),
+          url,
+        ),
+      ).not.toThrow();
+    });
+
+    it('should throw when the content does not match', () => {
+      expect(() => verifyIntegrity('console.log("bye");', base64, url)).toThrow(
+        /Integrity check failed/,
+      );
+    });
+
+    it('should include the expected and received hashes in the error', () => {
+      expect(() => verifyIntegrity('changed', base64, url)).toThrow(
+        new RegExp(`Expected: ${base64.replace(/[+/=]/g, '\\$&')}`),
+      );
+      expect(() => verifyIntegrity('changed', base64, url)).toThrow(
+        new RegExp(
+          `Received: ${hashContent('changed').replace(/[+/=]/g, '\\$&')}`,
+        ),
+      );
+    });
+
+    it('should report the received hash in the same encoding as the expected hash', () => {
+      expect(() => verifyIntegrity('changed', hex, url)).toThrow(
+        /Received: sha256-[0-9a-f]{64}\b/,
+      );
+      expect(() => verifyIntegrity('changed', base64, url)).toThrow(
+        /Received: sha256-[A-Za-z0-9+/]+=*\n/,
+      );
+    });
+
+    it('should throw for a hash with no algorithm', () => {
+      expect(() => verifyIntegrity(content, 'nodashes', url)).toThrow(
+        /Invalid integrity hash/,
+      );
+    });
+
+    it('should throw for an unsupported algorithm', () => {
+      expect(() => verifyIntegrity(content, 'md5-abc123', url)).toThrow(
+        /Unsupported hash algorithm "md5"/,
+      );
+    });
+  });
+});

--- a/packages/wxt/src/core/utils/__tests__/network.test.ts
+++ b/packages/wxt/src/core/utils/__tests__/network.test.ts
@@ -10,6 +10,15 @@ vi.mock('node:dns');
 const fetchMock = vi.fn<typeof fetch>();
 global.fetch = fetchMock;
 
+function mockOnline() {
+  vi.mocked(dns.resolve).mockImplementationOnce(((
+    _: string,
+    callback: DnsCallback,
+  ) => {
+    callback(null);
+  }) as typeof dns.resolve);
+}
+
 describe('Network utils', () => {
   describe('isOnline', () => {
     it('should return true when online', async () => {
@@ -183,6 +192,122 @@ describe('Network utils', () => {
       ).rejects.toThrow(
         'Offline and "https://example.com" has not been cached. Try again when online.',
       );
+    });
+
+    it('should not cache content that fails verification', async () => {
+      mockOnline();
+
+      const mockConfig = {
+        fsCache: { set: vi.fn(), get: vi.fn().mockResolvedValueOnce(null) },
+        logger: { debug: vi.fn() },
+      };
+
+      fetchMock.mockReturnValueOnce(
+        Promise.resolve({
+          status: 200,
+          text: async () => 'malicious',
+        } as Response),
+      );
+
+      await expect(
+        fetchCached(
+          'https://example.com',
+          mockConfig as unknown as ResolvedConfig,
+          {
+            verify: () => {
+              throw Error('Integrity check failed');
+            },
+          },
+        ),
+      ).rejects.toThrow('Integrity check failed');
+
+      expect(mockConfig.fsCache.set).not.toHaveBeenCalled();
+    });
+
+    it('should fall back to cache when the download fails verification', async () => {
+      mockOnline();
+
+      const mockConfig = {
+        fsCache: {
+          set: vi.fn(),
+          get: vi.fn().mockResolvedValueOnce('trusted'),
+        },
+        logger: { debug: vi.fn() },
+      };
+
+      fetchMock.mockReturnValueOnce(
+        Promise.resolve({
+          status: 200,
+          text: async () => 'malicious',
+        } as Response),
+      );
+
+      const result = await fetchCached(
+        'https://example.com',
+        mockConfig as unknown as ResolvedConfig,
+        {
+          verify: (content) => {
+            if (content !== 'trusted') throw Error('Integrity check failed');
+          },
+        },
+      );
+
+      expect(result).toBe('trusted');
+      expect(mockConfig.fsCache.set).not.toHaveBeenCalled();
+    });
+
+    it('should verify content read from the cache', async () => {
+      mockOnline();
+
+      const mockConfig = {
+        fsCache: {
+          set: vi.fn(),
+          get: vi.fn().mockResolvedValueOnce('poisoned'),
+        },
+        logger: { debug: vi.fn() },
+      };
+
+      fetchMock.mockReturnValueOnce(
+        Promise.resolve({ status: 500, text: async () => '' } as Response),
+      );
+
+      await expect(
+        fetchCached(
+          'https://example.com',
+          mockConfig as unknown as ResolvedConfig,
+          {
+            verify: () => {
+              throw Error('Integrity check failed');
+            },
+          },
+        ),
+      ).rejects.toThrow('Integrity check failed');
+    });
+
+    it('should not touch the cache when noCache is set', async () => {
+      mockOnline();
+
+      const mockConfig = {
+        fsCache: { set: vi.fn(), get: vi.fn() },
+        logger: { debug: vi.fn() },
+      };
+
+      fetchMock.mockReturnValueOnce(
+        Promise.resolve({
+          status: 200,
+          text: async () => 'fresh',
+        } as Response),
+      );
+
+      const result = await fetchCached(
+        'https://example.com',
+        mockConfig as unknown as ResolvedConfig,
+        { noCache: true },
+      );
+
+      expect(result).toBe('fresh');
+      expect(mockConfig.fsCache.set).not.toHaveBeenCalled();
+      expect(mockConfig.fsCache.get).not.toHaveBeenCalled();
     });
   });
 });

--- a/packages/wxt/src/core/utils/__tests__/network.test.ts
+++ b/packages/wxt/src/core/utils/__tests__/network.test.ts
@@ -277,7 +277,7 @@ describe('Network utils', () => {
       expect(mockConfig.fsCache.set).not.toHaveBeenCalled();
     });
 
-    it('should fall back to cache when the download fails verification', async () => {
+    it('should fall back to cache and warn when the download fails verification', async () => {
       mockOnline();
 
       const mockConfig = {
@@ -285,7 +285,7 @@ describe('Network utils', () => {
           set: vi.fn(),
           get: vi.fn().mockResolvedValueOnce('trusted'),
         },
-        logger: { debug: vi.fn() },
+        logger: { debug: vi.fn(), warn: vi.fn() },
       };
 
       fetchMock.mockReturnValueOnce(
@@ -307,6 +307,32 @@ describe('Network utils', () => {
 
       expect(result).toBe('trusted');
       expect(mockConfig.fsCache.set).not.toHaveBeenCalled();
+      expect(mockConfig.logger.warn).toHaveBeenCalledWith(
+        expect.stringContaining('changed upstream'),
+      );
+    });
+
+    it('should not warn when falling back to cache after a failed request', async () => {
+      mockOnline();
+
+      const mockConfig = {
+        fsCache: {
+          set: vi.fn(),
+          get: vi.fn().mockResolvedValueOnce('from cache'),
+        },
+        logger: { debug: vi.fn(), warn: vi.fn() },
+      };
+
+      fetchMock.mockRejectedValueOnce(new TypeError('fetch failed'));
+
+      const result = await fetchCached(
+        'https://example.com',
+        mockConfig as unknown as ResolvedConfig,
+        { verify: () => {} },
+      );
+
+      expect(result).toBe('from cache');
+      expect(mockConfig.logger.warn).not.toHaveBeenCalled();
     });
 
     it('should verify content read from the cache', async () => {

--- a/packages/wxt/src/core/utils/__tests__/network.test.ts
+++ b/packages/wxt/src/core/utils/__tests__/network.test.ts
@@ -139,6 +139,35 @@ describe('Network utils', () => {
       );
     });
 
+    it('should fall back to cache when the body read throws', async () => {
+      mockOnline();
+
+      const mockConfig = {
+        fsCache: {
+          set: vi.fn(),
+          get: vi.fn().mockResolvedValueOnce('from cache'),
+        },
+        logger: { debug: vi.fn() },
+      };
+
+      fetchMock.mockResolvedValueOnce({
+        status: 200,
+        text: async () => {
+          throw new TypeError('terminated');
+        },
+      } as unknown as Response);
+
+      const result = await fetchCached(
+        'https://example.com',
+        mockConfig as unknown as ResolvedConfig,
+      );
+
+      expect(result).toBe('from cache');
+      expect(mockConfig.logger.debug).toHaveBeenCalledWith(
+        expect.stringContaining('Failed to download'),
+      );
+    });
+
     it('should fall back to cache when the request throws', async () => {
       mockOnline();
 

--- a/packages/wxt/src/core/utils/__tests__/network.test.ts
+++ b/packages/wxt/src/core/utils/__tests__/network.test.ts
@@ -139,6 +139,30 @@ describe('Network utils', () => {
       );
     });
 
+    it('should fall back to cache when the request throws', async () => {
+      mockOnline();
+
+      const mockConfig = {
+        fsCache: {
+          set: vi.fn(),
+          get: vi.fn().mockResolvedValueOnce('from cache'),
+        },
+        logger: { debug: vi.fn() },
+      };
+
+      fetchMock.mockRejectedValueOnce(new TypeError('fetch failed'));
+
+      const result = await fetchCached(
+        'https://example.com',
+        mockConfig as unknown as ResolvedConfig,
+      );
+
+      expect(result).toBe('from cache');
+      expect(mockConfig.logger.debug).toHaveBeenCalledWith(
+        expect.stringContaining('Failed to download'),
+      );
+    });
+
     it('should use cache when offline', async () => {
       vi.mocked(dns.resolve).mockImplementationOnce(((
         _: string,

--- a/packages/wxt/src/core/utils/integrity.ts
+++ b/packages/wxt/src/core/utils/integrity.ts
@@ -15,9 +15,9 @@ const URL_IMPORT_RE = /^url(?:#([^:]*))?:(.*)$/s;
 const INTEGRITY_RE = /^([a-z0-9]+)-(.+)$/i;
 
 /**
- * Parses an import specifier like `url#sha256-abc123...:https://example.com/x.js`
- * into its URL and integrity hash. Returns `undefined` if the specifier isn't a
- * URL import.
+ * Parses an import specifier like
+ * `url#sha256-abc123...:https://example.com/x.js` into its URL and integrity
+ * hash. Returns `undefined` if the specifier isn't a URL import.
  */
 export function parseUrlImport(id: string): UrlImport | undefined {
   const match = URL_IMPORT_RE.exec(id);
@@ -44,7 +44,8 @@ export function hashContent(
 
 /**
  * Throws unless `content` matches `integrity`. Accepts both base64 (the
- * [Subresource Integrity](https://developer.mozilla.org/en-US/docs/Web/Security/Subresource_Integrity)
+ * [Subresource
+ * Integrity](https://developer.mozilla.org/en-US/docs/Web/Security/Subresource_Integrity)
  * format used by CDNs) and hex digests.
  */
 export function verifyIntegrity(

--- a/packages/wxt/src/core/utils/integrity.ts
+++ b/packages/wxt/src/core/utils/integrity.ts
@@ -1,0 +1,91 @@
+import { createHash } from 'node:crypto';
+
+export const HASH_ALGORITHMS = ['sha256', 'sha384', 'sha512'] as const;
+
+export type HashAlgorithm = (typeof HASH_ALGORITHMS)[number];
+
+export interface UrlImport {
+  url: string;
+  /** `undefined` when the import was written without an integrity hash. */
+  integrity: string | undefined;
+}
+
+const URL_IMPORT_RE = /^url(?:#([^:]*))?:(.*)$/s;
+
+const INTEGRITY_RE = /^([a-z0-9]+)-(.+)$/i;
+
+/**
+ * Parses an import specifier like `url#sha256-abc123...:https://example.com/x.js`
+ * into its URL and integrity hash. Returns `undefined` if the specifier isn't a
+ * URL import.
+ */
+export function parseUrlImport(id: string): UrlImport | undefined {
+  const match = URL_IMPORT_RE.exec(id);
+  if (!match) return;
+
+  const [, integrity, url] = match;
+  if (!url) return;
+
+  return { url, integrity: integrity || undefined };
+}
+
+/**
+ * Hashes content the same way {@link verifyIntegrity} does, returning a value
+ * usable as an integrity hash. Hashes are computed over the UTF-8 bytes of the
+ * file, so they match `shasum -a 256 <file>` for UTF-8 sources.
+ */
+export function hashContent(
+  content: string,
+  algorithm: HashAlgorithm = 'sha256',
+): string {
+  const digest = createHash(algorithm).update(content, 'utf8').digest();
+  return `${algorithm}-${digest.toString('base64')}`;
+}
+
+/**
+ * Throws unless `content` matches `integrity`. Accepts both base64 (the
+ * [Subresource Integrity](https://developer.mozilla.org/en-US/docs/Web/Security/Subresource_Integrity)
+ * format used by CDNs) and hex digests.
+ */
+export function verifyIntegrity(
+  content: string,
+  integrity: string,
+  url: string,
+): void {
+  const match = INTEGRITY_RE.exec(integrity);
+  if (!match) {
+    throw Error(
+      `Invalid integrity hash "${integrity}" for "${url}". Expected "<algorithm>-<hash>", like "${hashContent(content)}".`,
+    );
+  }
+
+  const [, algorithm, expected] = match;
+  if (!isSupportedAlgorithm(algorithm)) {
+    throw Error(
+      `Unsupported hash algorithm "${algorithm}" for "${url}". Supported algorithms: ${HASH_ALGORITHMS.join(', ')}.`,
+    );
+  }
+
+  const digest = createHash(algorithm).update(content, 'utf8').digest();
+  const matches =
+    digest.toString('base64') === expected ||
+    digest.toString('hex').toLowerCase() === expected.toLowerCase();
+
+  if (!matches) {
+    const encoding = isHex(expected) ? 'hex' : 'base64';
+    throw Error(
+      `Integrity check failed for "${url}".\n\n` +
+        `  Expected: ${algorithm}-${expected}\n` +
+        `  Received: ${algorithm}-${digest.toString(encoding)}\n\n` +
+        `The remote file changed since you added it. Review the new file, and if you trust it, update the hash in your import.`,
+    );
+  }
+}
+
+function isHex(hash: string): boolean {
+  return hash.length % 2 === 0 && /^[0-9a-f]+$/i.test(hash);
+}
+
+function isSupportedAlgorithm(algorithm: string): algorithm is HashAlgorithm {
+  return HASH_ALGORITHMS.includes(algorithm as HashAlgorithm);
+}

--- a/packages/wxt/src/core/utils/network.ts
+++ b/packages/wxt/src/core/utils/network.ts
@@ -44,8 +44,8 @@ export async function fetchCached(
   let verifyError: unknown;
 
   if (await isOnline()) {
-    const res = await fetch(url);
-    if (res.status < 300) {
+    const res = await fetch(url).catch(() => undefined);
+    if (res != null && res.status < 300) {
       const downloaded = await res.text();
       try {
         verify?.(downloaded);

--- a/packages/wxt/src/core/utils/network.ts
+++ b/packages/wxt/src/core/utils/network.ts
@@ -51,9 +51,6 @@ export async function fetchCached(
         content = downloaded;
       } catch (err) {
         verifyError = err;
-        config.logger.debug(
-          `Downloaded "${url}", but it failed verification, falling back to cache...`,
-        );
       }
       if (content && !noCache) await config.fsCache.set(url, content);
     }
@@ -64,6 +61,11 @@ export async function fetchCached(
     if (cached) {
       verify?.(cached);
       content = cached;
+      if (verifyError) {
+        config.logger.warn(
+          `"${url}" changed upstream. Using the cached copy that matches the expected hash. Review the new file and update your import when you're ready to pick it up.`,
+        );
+      }
     }
   }
 

--- a/packages/wxt/src/core/utils/network.ts
+++ b/packages/wxt/src/core/utils/network.ts
@@ -20,6 +20,17 @@ export async function isOnline(): Promise<boolean> {
   return !offline;
 }
 
+export interface FetchCachedOptions {
+  /**
+   * Called with content before it is cached or returned. Throw to reject it.
+   * Rejected downloads fall back to the cache, and rejected cache entries are
+   * never returned.
+   */
+  verify?: (content: string) => void;
+  /** Skip reading from and writing to the cache. */
+  noCache?: boolean;
+}
+
 /**
  * Fetches a URL with a simple GET request. Grabs it from cache if it doesn't
  * exist, or throws an error if it can't be resolved via the network or cache.
@@ -27,14 +38,25 @@ export async function isOnline(): Promise<boolean> {
 export async function fetchCached(
   url: string,
   config: ResolvedConfig,
+  { verify, noCache }: FetchCachedOptions = {},
 ): Promise<string> {
   let content: string = '';
+  let verifyError: unknown;
 
   if (await isOnline()) {
     const res = await fetch(url);
     if (res.status < 300) {
-      content = await res.text();
-      await config.fsCache.set(url, content);
+      const downloaded = await res.text();
+      try {
+        verify?.(downloaded);
+        content = downloaded;
+      } catch (err) {
+        verifyError = err;
+        config.logger.debug(
+          `Downloaded "${url}", but it failed verification, falling back to cache...`,
+        );
+      }
+      if (content && !noCache) await config.fsCache.set(url, content);
     } else {
       config.logger.debug(
         `Failed to download "${url}", falling back to cache...`,
@@ -42,11 +64,20 @@ export async function fetchCached(
     }
   }
 
-  if (!content) content = (await config.fsCache.get(url)) ?? '';
-  if (!content)
+  if (!content && !noCache) {
+    const cached = (await config.fsCache.get(url)) ?? '';
+    if (cached) {
+      verify?.(cached);
+      content = cached;
+    }
+  }
+
+  if (!content) {
+    if (verifyError) throw verifyError;
     throw Error(
       `Offline and "${url}" has not been cached. Try again when online.`,
     );
+  }
 
   return content;
 }

--- a/packages/wxt/src/core/utils/network.ts
+++ b/packages/wxt/src/core/utils/network.ts
@@ -44,9 +44,8 @@ export async function fetchCached(
   let verifyError: unknown;
 
   if (await isOnline()) {
-    const res = await fetch(url).catch(() => undefined);
-    if (res != null && res.status < 300) {
-      const downloaded = await res.text();
+    const downloaded = await download(url, config);
+    if (downloaded != null) {
       try {
         verify?.(downloaded);
         content = downloaded;
@@ -57,10 +56,6 @@ export async function fetchCached(
         );
       }
       if (content && !noCache) await config.fsCache.set(url, content);
-    } else {
-      config.logger.debug(
-        `Failed to download "${url}", falling back to cache...`,
-      );
     }
   }
 
@@ -80,4 +75,22 @@ export async function fetchCached(
   }
 
   return content;
+}
+
+/**
+ * Downloads a URL, returning `undefined` if it can't be retrieved for any
+ * reason: a bad status, a refused connection, or a request that dies partway
+ * through reading the body.
+ */
+async function download(
+  url: string,
+  config: ResolvedConfig,
+): Promise<string | undefined> {
+  try {
+    const res = await fetch(url);
+    if (res.status < 300) return await res.text();
+  } catch {
+    // Fall through to the same debug log as a bad status.
+  }
+  config.logger.debug(`Failed to download "${url}", falling back to cache...`);
 }

--- a/packages/wxt/src/testing/wxt-vitest-plugin.ts
+++ b/packages/wxt/src/testing/wxt-vitest-plugin.ts
@@ -7,6 +7,7 @@
 
 import type * as vite from 'vite';
 import {
+  download,
   tsconfigPaths,
   globals,
   extensionApiMock,
@@ -40,6 +41,7 @@ export async function WxtVitest(
 
   const plugins: vite.PluginOption[] = [
     globals(wxt.config),
+    download(wxt.config),
     tsconfigPaths(wxt.config),
     resolveAppConfig(wxt.config),
     extensionApiMock(wxt.config),


### PR DESCRIPTION
### Overview

#2456 removed `url:` imports over supply chain risk (#2229, #2262). The suggested alternative was to download the file and commit it to your repo. That works, but it has three problems:

1. **It goes stale silently.** Nothing tells you the upstream file changed after you vendored it.
2. **It isn't self-documenting.** A year later nobody knows where `vendor/gtag.min.js` came from. You can write it down, but docs drift.
3. **It's PR noise.** 70KB of minified JS in the diff, and again on every update.

This PR restores `url:` imports with a required integrity hash. That keeps the thing that made vendoring safe, knowing exactly which bytes ship, without any of the three problems:

```ts
import 'url#sha256-kmHvs0B+OpCW5GVHUNjv9rOmY0IvSIRcf7zGUDTDQM8=:https://code.jquery.com/jquery-3.7.1.slim.min.js';
```

sha256/384/512, in base64 (the SRI format CDNs already publish) or hex. **Every URL import must pin a hash, with no opt-out**, so the hole that motivated removal stays closed. A bare `url:` import is now a build error that prints the exact line to paste, so migrating is copy/paste. Content that fails verification is never bundled or cached, and the cache is verified on read, so a poisoned `.wxt/cache` can't slip through either.

That also covers #1924 without a new command: build on a schedule in CI and you find out when a remote dependency drifts.

### Manual Testing

`packages/wxt-demo` pins a jQuery URL, so `bun run build` exercises it. Then edit the import in `src/entrypoints/options/main.ts`: dropping the hash, corrupting the hash, or using `md5-` each fails with a specific error, and swapping base64 for hex still builds.

Unit tests cover parsing, hashing, verification, and the cache behavior. `e2e/tests/remote-code.test.ts` covers valid, hex, missing, and mismatched hashes.

### Related Issue

This PR closes #1924.

Also relevant: #2262, #2229, and #2456 (the removal this reverts). Targets `major`, since that's where #2456 landed and this is breaking.