### PR TITLE
chore(deps): Inline `dequal`

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -234,11 +234,11 @@
       "dependencies": {
         "@wxt-dev/browser": "workspace:^",
         "async-mutex": "^0.5.0",
-        "dequal": "^2.0.3",
       },
       "devDependencies": {
         "@aklinker1/buildc": "catalog:",
         "@webext-core/fake-browser": "catalog:",
+        "dequal": "^2.0.3",
         "oxlint": "catalog:",
         "publint": "catalog:",
         "tsdown": "catalog:",

--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -25,7 +25,7 @@
   "license": "MIT",
   "funding": "https://github.com/sponsors/wxt-dev",
   "scripts": {
-    "build": "buildc -- tsdown",
+    "build": "buildc -- tsdown --deps.onlyBundle dequal",
     "check": "buildc --deps-only -- check",
     "test": "buildc --deps-only -- vitest",
     "test:coverage": "bun run test run --coverage",
@@ -33,12 +33,12 @@
   },
   "dependencies": {
     "@wxt-dev/browser": "workspace:^",
-    "async-mutex": "^0.5.0",
-    "dequal": "^2.0.3"
+    "async-mutex": "^0.5.0"
   },
   "devDependencies": {
     "@aklinker1/buildc": "catalog:",
     "@webext-core/fake-browser": "catalog:",
+    "dequal": "^2.0.3",
     "oxlint": "catalog:",
     "publint": "catalog:",
     "tsdown": "catalog:",


### PR DESCRIPTION
### Overview

Apart of #2523. 0.3 kB increase to package code, -14.3kb for not having to download `dequal`. So -14 kB total
