### PR TITLE
docs: Remove dangling "Remote Code" sidebar link

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -243,7 +243,6 @@ export default defineConfig({
           menuItem('WXT Modules', 'wxt-modules.md'),
           menuItem('Frontend Frameworks', 'frontend-frameworks.md'),
           menuItem('ES Modules', 'es-modules.md'),
-          menuItem('Remote Code', 'remote-code.md'),
           menuItem('Unit Testing', 'unit-testing.md'),
           menuItem('E2E Testing', 'e2e-testing.md'),
           menuItem('Publishing', 'publishing.md'),

--- a/docs/public/_redirects
+++ b/docs/public/_redirects
@@ -38,6 +38,10 @@
 # 0.19.0
 /guide/go-further/entrypoint-side-effects.html /guide/go-further/entrypoint-loaders.html
 
+# 0.21.0
+# The `url:` import feature was removed, along with its docs page.
+/guide/essentials/remote-code.html /guide/resources/upgrading.html#url-imports-removed
+
 # https://github.com/wxt-dev/wxt/issues/704
 # Generated via `pnpm docs:build && find docs/.vitepress/dist -type f -name "*.html"`
 
@@ -59,7 +63,7 @@
 /guide/go-further/handling-updates.html                       /guide/essentials/testing-updates.html
 /guide/go-further/custom-events.html                          /guide/essentials/content-scripts.html#dealing-with-spas
 /guide/go-further/debugging.html                              /TODO
-/guide/go-further/remote-code.html                            /guide/essentials/remote-code.html
+/guide/go-further/remote-code.html                            /guide/resources/upgrading.html#url-imports-removed
 /guide/go-further/vite.html                                   /guide/essentials/config/vite.html
 /guide/go-further/testing.html                                /guide/essentials/unit-testing.html
 /guide/go-further/how-wxt-works.html                          /guide/resources/how-wxt-works.html


### PR DESCRIPTION
### Overview

<https://wxt.dev/guide/essentials/remote-code.html> currently 404s, and it's reachable straight from the sidebar:

![Remote Code page 404](https://raw.githubusercontent.com/rxliuli/wxt/assets/docs-remote-code-404/remote-code-404.png)

#2456 removed the `url:` import feature and deleted `docs/guide/essentials/remote-code.md`, but the sidebar entry pointing at that file was left behind in `docs/.vitepress/config.ts`:

```ts
menuItem('ES Modules', 'es-modules.md'),
menuItem('Remote Code', 'remote-code.md'), // <-- file no longer exists
menuItem('Unit Testing', 'unit-testing.md'),
```

VitePress's dead-link checker only validates links inside markdown content, not sidebar/nav config, so the build stayed green and the broken link shipped.

This PR:

1. **Removes the dangling sidebar entry** — fixes the 404 reachable from the "Essentials" menu.
2. **Redirects the old URL** to [the upgrade guide section explaining the removal](https://wxt.dev/guide/resources/upgrading.html#url-imports-removed), so inbound links from search results, blog posts, and Discord land somewhere useful instead of dead.
3. **Fixes a now-broken legacy redirect** — `/guide/go-further/remote-code.html` pointed at `/guide/essentials/remote-code.html`, i.e. one dead URL redirecting to another. Netlify doesn't chain redirects, so it now points at the same upgrade-guide anchor directly.

### Manual Testing

Because the sidebar link lives in config rather than markdown, I checked every sidebar entry resolves to a file that actually exists:

```sh
# extract every '*.md' reference in config.ts, assert a matching file exists under docs/
```

- On `main`: reports `remote-code.md` missing.
- With this PR: no missing entries.

Redirect targets verified against the live site — `/guide/resources/upgrading.html#url-imports-removed` exists and the anchor resolves to the **`url:` Imports Removed** section.

It might be worth adding that config-vs-filesystem check to CI so the next page removal can't silently leave a dead sidebar link. Happy to do it in this PR or a follow-up — let me know which you'd prefer.

### Related Issue

No existing issue — found while browsing the docs.
