### PR TITLE
feat: Log warnings once

### DIFF
--- a/packages/wxt/src/core/__tests__/resolve-config.test.ts
+++ b/packages/wxt/src/core/__tests__/resolve-config.test.ts
@@ -1,0 +1,90 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { mkdtempSync, mkdirSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { resolveConfig } from '../resolve-config';
+import type { Logger } from '../../types';
+
+function fakeLogger(): Logger {
+  return {
+    debug: vi.fn(),
+    log: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    fatal: vi.fn(),
+    success: vi.fn(),
+    level: 3,
+  };
+}
+
+describe('resolveConfig', () => {
+  const tempDirs: string[] = [];
+
+  /**
+   * Creates an empty temp project dir, with an `entrypoints/` dir so
+   * `resolveConfig` doesn't warn about it being missing.
+   */
+  function tempProjectDir(): string {
+    const dir = mkdtempSync(join(tmpdir(), 'wxt-resolve-config-test-'));
+    tempDirs.push(dir);
+    mkdirSync(join(dir, 'entrypoints'));
+    return dir;
+  }
+
+  afterEach(() => {
+    for (const dir of tempDirs.splice(0)) {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  describe('logger', () => {
+    it('should wrap the resolved logger with warnOnce', async () => {
+      const logger = fakeLogger();
+
+      const config = await resolveConfig(
+        { root: tempProjectDir(), configFile: false, logger },
+        'build',
+      );
+
+      expect(config.logger.warnOnce).toBeTypeOf('function');
+    });
+
+    it('should give each resolved config its own warnOnce dedupe scope, instead of sharing one across resolves', async () => {
+      const logger = fakeLogger();
+      const root = tempProjectDir();
+
+      const configA = await resolveConfig(
+        { root, configFile: false, logger },
+        'build',
+      );
+      configA.logger.warnOnce('some warning');
+      configA.logger.warnOnce('some warning');
+
+      const configB = await resolveConfig(
+        { root, configFile: false, logger },
+        'build',
+      );
+      configB.logger.warnOnce('some warning');
+
+      // Simulates `wxt.reloadConfig()` calling `resolveConfig` again: each
+      // resolve wraps the logger in a new `WxtLogger`, so the message is
+      // logged once per resolve (2 total), not deduped across resolves.
+      expect(logger.warn).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe('logMissingDir', () => {
+    it('should warn (through the wrapped logger) when the entrypoints directory is missing', async () => {
+      const logger = fakeLogger();
+      const root = mkdtempSync(join(tmpdir(), 'wxt-resolve-config-test-'));
+      tempDirs.push(root);
+
+      await resolveConfig({ root, configFile: false, logger }, 'build');
+
+      expect(logger.warn).toHaveBeenCalledWith(
+        expect.stringContaining('Entrypoints directory not found'),
+      );
+    });
+  });
+});

--- a/packages/wxt/src/core/__tests__/resolve-config.test.ts
+++ b/packages/wxt/src/core/__tests__/resolve-config.test.ts
@@ -1,7 +1,4 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { mkdtempSync } from 'node:fs';
-import { tmpdir } from 'node:os';
-import { join } from 'node:path';
 import { resolveConfig } from '../resolve-config';
 import type { Logger } from '../../types';
 import { mock } from 'vitest-mock-extended';

--- a/packages/wxt/src/core/__tests__/resolve-config.test.ts
+++ b/packages/wxt/src/core/__tests__/resolve-config.test.ts
@@ -1,86 +1,39 @@
-import { afterEach, describe, expect, it, vi } from 'vitest';
-import { mkdtempSync, mkdirSync, rmSync } from 'node:fs';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { mkdtempSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { resolveConfig } from '../resolve-config';
 import type { Logger } from '../../types';
+import { mock } from 'vitest-mock-extended';
+import { loadConfig } from 'c12';
+import { pathExists } from '../utils/fs';
 
-function fakeLogger(): Logger {
-  return {
-    debug: vi.fn(),
-    log: vi.fn(),
-    info: vi.fn(),
-    warn: vi.fn(),
-    error: vi.fn(),
-    fatal: vi.fn(),
-    success: vi.fn(),
-    level: 3,
-  };
-}
+vi.mock('../utils/fs');
+const pathExistsMock = vi.mocked(pathExists);
+
+vi.mock('c12');
+const loadConfigMock = vi.mocked(loadConfig);
 
 describe('resolveConfig', () => {
-  const tempDirs: string[] = [];
-
-  /**
-   * Creates an empty temp project dir, with an `entrypoints/` dir so
-   * `resolveConfig` doesn't warn about it being missing.
-   */
-  function tempProjectDir(): string {
-    const dir = mkdtempSync(join(tmpdir(), 'wxt-resolve-config-test-'));
-    tempDirs.push(dir);
-    mkdirSync(join(dir, 'entrypoints'));
-    return dir;
-  }
-
-  afterEach(() => {
-    for (const dir of tempDirs.splice(0)) {
-      rmSync(dir, { recursive: true, force: true });
-    }
+  beforeEach(() => {
+    loadConfigMock.mockResolvedValue({ config: {} });
+    pathExistsMock.mockResolvedValue(true);
   });
 
   describe('logger', () => {
     it('should wrap the resolved logger with warnOnce', async () => {
-      const logger = fakeLogger();
+      const logger = mock<Logger>();
 
-      const config = await resolveConfig(
-        { root: tempProjectDir(), configFile: false, logger },
-        'build',
-      );
+      const config = await resolveConfig({ logger }, 'build');
 
       expect(config.logger.warnOnce).toBeTypeOf('function');
     });
 
-    it('should give each resolved config its own warnOnce dedupe scope, instead of sharing one across resolves', async () => {
-      const logger = fakeLogger();
-      const root = tempProjectDir();
+    it('should warn when the entrypoints directory is missing', async () => {
+      const logger = mock<Logger>();
+      pathExistsMock.mockResolvedValue(false);
 
-      const configA = await resolveConfig(
-        { root, configFile: false, logger },
-        'build',
-      );
-      configA.logger.warnOnce('some warning');
-      configA.logger.warnOnce('some warning');
-
-      const configB = await resolveConfig(
-        { root, configFile: false, logger },
-        'build',
-      );
-      configB.logger.warnOnce('some warning');
-
-      // Simulates `wxt.reloadConfig()` calling `resolveConfig` again: each
-      // resolve wraps the logger in a new `WxtLogger`, so the message is
-      // logged once per resolve (2 total), not deduped across resolves.
-      expect(logger.warn).toHaveBeenCalledTimes(2);
-    });
-  });
-
-  describe('logMissingDir', () => {
-    it('should warn (through the wrapped logger) when the entrypoints directory is missing', async () => {
-      const logger = fakeLogger();
-      const root = mkdtempSync(join(tmpdir(), 'wxt-resolve-config-test-'));
-      tempDirs.push(root);
-
-      await resolveConfig({ root, configFile: false, logger }, 'build');
+      await resolveConfig({ logger }, 'build');
 
       expect(logger.warn).toHaveBeenCalledWith(
         expect.stringContaining('Entrypoints directory not found'),

--- a/packages/wxt/src/core/resolve-config.ts
+++ b/packages/wxt/src/core/resolve-config.ts
@@ -14,6 +14,7 @@ import {
   WxtModuleWithMetadata,
   WxtResolvedUnimportOptions,
   ExtensionRunner,
+  WxtLogger,
 } from '../types';
 import path from 'node:path';
 import { createFsCache } from './utils/cache';
@@ -33,6 +34,7 @@ import { createSafariRunner } from './runners/safari';
 import isWsl from 'is-wsl';
 import { createWslRunner } from './runners/wsl';
 import { createManualRunner } from './runners/manual';
+import { createWxtLogger } from './utils/log/wxtLogger';
 
 /**
  * Given an inline config, discover the config file if necessary, merge the
@@ -67,7 +69,7 @@ export async function resolveConfig(
   // Apply defaults to make internal config.
 
   const debug = mergedConfig.debug ?? false;
-  const logger = mergedConfig.logger ?? consola;
+  const logger = createWxtLogger(mergedConfig.logger ?? consola);
   if (debug) logger.level = LogLevels.debug;
 
   const browser = mergedConfig.browser ?? 'chrome';
@@ -354,7 +356,7 @@ function resolveAnalysisConfig(
 async function getUnimportOptions(
   wxtDir: string,
   srcDir: string,
-  logger: Logger,
+  logger: WxtLogger,
   config: InlineConfig,
 ): Promise<WxtResolvedUnimportOptions> {
   const disabled = config.imports === false;
@@ -502,7 +504,7 @@ async function getUnimportOptions(
 }
 
 async function getUnimportEslintOptions(
-  logger: Logger,
+  logger: WxtLogger,
   wxtDir: string,
   options: InlineConfig['imports'],
 ): Promise<ResolvedEslintrc> {
@@ -518,7 +520,7 @@ async function getUnimportEslintOptions(
     case true:
       if (isNaN(major)) {
         if (inlineEnabled === true) {
-          logger.warn(
+          logger.warnOnce(
             'Could not determine installed ESLint version, `eslint-auto-imports.mjs` not generated',
           );
         }
@@ -558,8 +560,8 @@ async function isDirMissing(dir: string) {
   return !(await pathExists(dir));
 }
 
-function logMissingDir(logger: Logger, name: string, expected: string) {
-  logger.warn(
+function logMissingDir(logger: WxtLogger, name: string, expected: string) {
+  logger.warnOnce(
     `${name} directory not found: ./${normalizePath(
       path.relative(process.cwd(), expected),
     )}`,

--- a/packages/wxt/src/core/utils/__tests__/manifest.test.ts
+++ b/packages/wxt/src/core/utils/__tests__/manifest.test.ts
@@ -1693,7 +1693,7 @@ describe('Manifest Utils', () => {
 
         expect(actual.version).toBe('0.0.0');
         expect(actual.version_name).toBeUndefined();
-        expect(wxt.logger.warn).toBeCalledWith(
+        expect(wxt.logger.warnOnce).toHaveBeenCalledWith(
           expect.stringContaining('Extension version not found'),
         );
       });
@@ -2124,7 +2124,7 @@ describe('Manifest Utils', () => {
         const { manifest } = await generateManifest([], buildOutput);
 
         expect(manifest.manifest_version).toBe(expectedVersion);
-        expect(wxt.logger.warn).toBeCalledWith(
+        expect(wxt.logger.warnOnce).toHaveBeenCalledWith(
           expect.stringContaining(
             '`manifest.manifest_version` config was set, but ignored',
           ),

--- a/packages/wxt/src/core/utils/log/__tests__/wxtLogger.test.ts
+++ b/packages/wxt/src/core/utils/log/__tests__/wxtLogger.test.ts
@@ -20,7 +20,7 @@ describe('createWxtLogger', () => {
   describe('warnOnce', () => {
     it('should log with the given arguments the first time it is called, and not again for repeated calls with the same arguments', () => {
       const inner = fakeLogger();
-      const logger = createWxtLogger(() => inner);
+      const logger = createWxtLogger(inner);
 
       logger.warnOnce('some warning');
       logger.warnOnce('some warning');
@@ -32,7 +32,7 @@ describe('createWxtLogger', () => {
 
     it('should log separately for each distinct set of arguments', () => {
       const inner = fakeLogger();
-      const logger = createWxtLogger(() => inner);
+      const logger = createWxtLogger(inner);
 
       logger.warnOnce('warning A');
       logger.warnOnce('warning B');
@@ -46,7 +46,7 @@ describe('createWxtLogger', () => {
 
     it('should not affect regular warn calls, which are never deduped', () => {
       const inner = fakeLogger();
-      const logger = createWxtLogger(() => inner);
+      const logger = createWxtLogger(inner);
 
       logger.warn('some warning');
       logger.warn('some warning');
@@ -55,31 +55,26 @@ describe('createWxtLogger', () => {
       expect(inner.warn).toHaveBeenCalledTimes(3);
     });
 
-    it('should keep deduping by the same key even if the underlying logger changes', () => {
-      // Simulates `wxt.logger.warnOnce` being called before and after
-      // `wxt.reloadConfig()` replaces `wxt.config` (and thus `wxt.config.logger`).
-      let inner = fakeLogger();
-      const logger = createWxtLogger(() => inner);
+    it('should scope deduping to a single createWxtLogger instance, not share it across separate instances', () => {
+      // `resolveConfig` calls `createWxtLogger` once per resolve/reload, so
+      // each instance's dedupe state should be independent of the others.
+      const innerA = fakeLogger();
+      const loggerA = createWxtLogger(innerA);
+      loggerA.warnOnce('some warning');
 
-      logger.warnOnce('some warning');
-      expect(inner.warn).toHaveBeenCalledTimes(1);
+      const innerB = fakeLogger();
+      const loggerB = createWxtLogger(innerB);
+      loggerB.warnOnce('some warning');
 
-      const newInner = fakeLogger();
-      inner = newInner;
-
-      logger.warnOnce('some warning');
-      expect(newInner.warn).not.toHaveBeenCalled();
-
-      logger.warnOnce('a new warning');
-      expect(newInner.warn).toHaveBeenCalledTimes(1);
-      expect(newInner.warn).toHaveBeenCalledWith('a new warning');
+      expect(innerA.warn).toHaveBeenCalledTimes(1);
+      expect(innerB.warn).toHaveBeenCalledTimes(1);
     });
   });
 
   describe('delegation', () => {
     it('should pass every call through for non-warnOnce methods', () => {
       const inner = fakeLogger();
-      const logger = createWxtLogger(() => inner);
+      const logger = createWxtLogger(inner);
 
       logger.debug('debug');
       logger.log('log');
@@ -98,7 +93,7 @@ describe('createWxtLogger', () => {
 
     it('should get and set level on the underlying logger', () => {
       const inner = fakeLogger();
-      const logger = createWxtLogger(() => inner);
+      const logger = createWxtLogger(inner);
 
       expect(logger.level).toBe(inner.level);
 

--- a/packages/wxt/src/core/utils/log/__tests__/wxtLogger.test.ts
+++ b/packages/wxt/src/core/utils/log/__tests__/wxtLogger.test.ts
@@ -1,25 +1,13 @@
-import { describe, expect, it, vi } from 'vitest';
+import { describe, expect, it } from 'vitest';
 import { createWxtLogger } from '../wxtLogger';
 import type { Logger } from '../../../../types';
 import { LogLevels } from 'consola';
-
-function fakeLogger(): Logger {
-  return {
-    debug: vi.fn(),
-    log: vi.fn(),
-    info: vi.fn(),
-    warn: vi.fn(),
-    error: vi.fn(),
-    fatal: vi.fn(),
-    success: vi.fn(),
-    level: LogLevels.info,
-  };
-}
+import { mock } from 'vitest-mock-extended';
 
 describe('createWxtLogger', () => {
   describe('warnOnce', () => {
     it('should log with the given arguments the first time it is called, and not again for repeated calls with the same arguments', () => {
-      const inner = fakeLogger();
+      const inner = mock<Logger>();
       const logger = createWxtLogger(inner);
 
       logger.warnOnce('some warning');
@@ -31,7 +19,7 @@ describe('createWxtLogger', () => {
     });
 
     it('should log separately for each distinct set of arguments', () => {
-      const inner = fakeLogger();
+      const inner = mock<Logger>();
       const logger = createWxtLogger(inner);
 
       logger.warnOnce('warning A');
@@ -45,7 +33,7 @@ describe('createWxtLogger', () => {
     });
 
     it('should not affect regular warn calls, which are never deduped', () => {
-      const inner = fakeLogger();
+      const inner = mock<Logger>();
       const logger = createWxtLogger(inner);
 
       logger.warn('some warning');
@@ -55,44 +43,36 @@ describe('createWxtLogger', () => {
       expect(inner.warn).toHaveBeenCalledTimes(3);
     });
 
-    it('should scope deduping to a single createWxtLogger instance, not share it across separate instances', () => {
-      // `resolveConfig` calls `createWxtLogger` once per resolve/reload, so
-      // each instance's dedupe state should be independent of the others.
-      const innerA = fakeLogger();
+    it('should not log the same warning multiple times when called on different instances', () => {
+      const innerA = mock<Logger>();
+      const innerB = mock<Logger>();
       const loggerA = createWxtLogger(innerA);
-      loggerA.warnOnce('some warning');
-
-      const innerB = fakeLogger();
       const loggerB = createWxtLogger(innerB);
+
+      loggerA.warnOnce('some warning');
       loggerB.warnOnce('some warning');
 
       expect(innerA.warn).toHaveBeenCalledTimes(1);
-      expect(innerB.warn).toHaveBeenCalledTimes(1);
+      expect(innerB.warn).not.toHaveBeenCalled();
     });
   });
 
   describe('delegation', () => {
-    it('should pass every call through for non-warnOnce methods', () => {
-      const inner = fakeLogger();
-      const logger = createWxtLogger(inner);
+    it.each(['debug', 'log', 'info', 'fatal', 'success'] as const)(
+      'should pass calls through %s',
+      (fn) => {
+        const inner = mock<Logger>();
+        const logger = createWxtLogger(inner);
+        const message = 'some message';
 
-      logger.debug('debug');
-      logger.log('log');
-      logger.info('info');
-      logger.error('error');
-      logger.fatal('fatal');
-      logger.success('success');
+        logger[fn](message);
 
-      expect(inner.debug).toHaveBeenCalledWith('debug');
-      expect(inner.log).toHaveBeenCalledWith('log');
-      expect(inner.info).toHaveBeenCalledWith('info');
-      expect(inner.error).toHaveBeenCalledWith('error');
-      expect(inner.fatal).toHaveBeenCalledWith('fatal');
-      expect(inner.success).toHaveBeenCalledWith('success');
-    });
+        expect(inner[fn]).toHaveBeenCalledWith(message);
+      },
+    );
 
     it('should get and set level on the underlying logger', () => {
-      const inner = fakeLogger();
+      const inner = mock<Logger>();
       const logger = createWxtLogger(inner);
 
       expect(logger.level).toBe(inner.level);

--- a/packages/wxt/src/core/utils/log/__tests__/wxtLogger.test.ts
+++ b/packages/wxt/src/core/utils/log/__tests__/wxtLogger.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it, vi } from 'vitest';
+import { createWxtLogger } from '../wxtLogger';
+import type { Logger } from '../../../../types';
+import { LogLevels } from 'consola';
+
+function fakeLogger(): Logger {
+  return {
+    debug: vi.fn(),
+    log: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    fatal: vi.fn(),
+    success: vi.fn(),
+    level: LogLevels.info,
+  };
+}
+
+describe('createWxtLogger', () => {
+  describe('warnOnce', () => {
+    it('should log with the given arguments the first time it is called, and not again for repeated calls with the same arguments', () => {
+      const inner = fakeLogger();
+      const logger = createWxtLogger(() => inner);
+
+      logger.warnOnce('some warning');
+      logger.warnOnce('some warning');
+      logger.warnOnce('some warning');
+
+      expect(inner.warn).toHaveBeenCalledTimes(1);
+      expect(inner.warn).toHaveBeenCalledWith('some warning');
+    });
+
+    it('should log separately for each distinct set of arguments', () => {
+      const inner = fakeLogger();
+      const logger = createWxtLogger(() => inner);
+
+      logger.warnOnce('warning A');
+      logger.warnOnce('warning B');
+      logger.warnOnce('warning A');
+      logger.warnOnce('warning B');
+
+      expect(inner.warn).toHaveBeenCalledTimes(2);
+      expect(inner.warn).toHaveBeenNthCalledWith(1, 'warning A');
+      expect(inner.warn).toHaveBeenNthCalledWith(2, 'warning B');
+    });
+
+    it('should not affect regular warn calls, which are never deduped', () => {
+      const inner = fakeLogger();
+      const logger = createWxtLogger(() => inner);
+
+      logger.warn('some warning');
+      logger.warn('some warning');
+      logger.warn('some warning');
+
+      expect(inner.warn).toHaveBeenCalledTimes(3);
+    });
+
+    it('should keep deduping by the same key even if the underlying logger changes', () => {
+      // Simulates `wxt.logger.warnOnce` being called before and after
+      // `wxt.reloadConfig()` replaces `wxt.config` (and thus `wxt.config.logger`).
+      let inner = fakeLogger();
+      const logger = createWxtLogger(() => inner);
+
+      logger.warnOnce('some warning');
+      expect(inner.warn).toHaveBeenCalledTimes(1);
+
+      const newInner = fakeLogger();
+      inner = newInner;
+
+      logger.warnOnce('some warning');
+      expect(newInner.warn).not.toHaveBeenCalled();
+
+      logger.warnOnce('a new warning');
+      expect(newInner.warn).toHaveBeenCalledTimes(1);
+      expect(newInner.warn).toHaveBeenCalledWith('a new warning');
+    });
+  });
+
+  describe('delegation', () => {
+    it('should pass every call through for non-warnOnce methods', () => {
+      const inner = fakeLogger();
+      const logger = createWxtLogger(() => inner);
+
+      logger.debug('debug');
+      logger.log('log');
+      logger.info('info');
+      logger.error('error');
+      logger.fatal('fatal');
+      logger.success('success');
+
+      expect(inner.debug).toHaveBeenCalledWith('debug');
+      expect(inner.log).toHaveBeenCalledWith('log');
+      expect(inner.info).toHaveBeenCalledWith('info');
+      expect(inner.error).toHaveBeenCalledWith('error');
+      expect(inner.fatal).toHaveBeenCalledWith('fatal');
+      expect(inner.success).toHaveBeenCalledWith('success');
+    });
+
+    it('should get and set level on the underlying logger', () => {
+      const inner = fakeLogger();
+      const logger = createWxtLogger(() => inner);
+
+      expect(logger.level).toBe(inner.level);
+
+      logger.level = LogLevels.debug;
+
+      expect(inner.level).toBe(LogLevels.debug);
+    });
+  });
+});

--- a/packages/wxt/src/core/utils/log/__tests__/wxtLogger.test.ts
+++ b/packages/wxt/src/core/utils/log/__tests__/wxtLogger.test.ts
@@ -1,10 +1,12 @@
-import { describe, expect, it } from 'vitest';
-import { createWxtLogger } from '../wxtLogger';
+import { beforeEach, describe, expect, it } from 'vitest';
+import { clearWarnSetForTesting, createWxtLogger } from '../wxtLogger';
 import type { Logger } from '../../../../types';
 import { LogLevels } from 'consola';
 import { mock } from 'vitest-mock-extended';
 
 describe('createWxtLogger', () => {
+  beforeEach(clearWarnSetForTesting);
+
   describe('warnOnce', () => {
     it('should log with the given arguments the first time it is called, and not again for repeated calls with the same arguments', () => {
       const inner = mock<Logger>();

--- a/packages/wxt/src/core/utils/log/index.ts
+++ b/packages/wxt/src/core/utils/log/index.ts
@@ -2,3 +2,4 @@ export * from './printBuildSummary';
 export * from './printFileList';
 export * from './printHeader';
 export * from './printTable';
+export * from './wxtLogger';

--- a/packages/wxt/src/core/utils/log/wxtLogger.ts
+++ b/packages/wxt/src/core/utils/log/wxtLogger.ts
@@ -1,32 +1,32 @@
 import type { Logger, WxtLogger } from '../../../types';
 
 /**
- * Wraps a getter for the current `Logger` with a `warnOnce`. The set already
- * warned messages is scoped to this wrapper instance, so it's only reset when a
- * new wrapper is created, not every time the config is resolved/reloaded.
+ * Wraps a `Logger` with a `warnOnce`. The set of already-warned messages is
+ * scoped to this wrapper instance, so it's reset whenever a new wrapper is
+ * created, e.g. once per `resolveConfig` call.
  */
-export function createWxtLogger(getLogger: () => Logger): WxtLogger {
+export function createWxtLogger(logger: Logger): WxtLogger {
   const warned = new Set<string>();
 
   return {
     get level() {
-      return getLogger().level;
+      return logger.level;
     },
     set level(value) {
-      getLogger().level = value;
+      logger.level = value;
     },
-    debug: (...args) => getLogger().debug(...args),
-    log: (...args) => getLogger().log(...args),
-    info: (...args) => getLogger().info(...args),
-    warn: (...args) => getLogger().warn(...args),
-    error: (...args) => getLogger().error(...args),
-    fatal: (...args) => getLogger().fatal(...args),
-    success: (...args) => getLogger().success(...args),
+    debug: (...args) => logger.debug(...args),
+    log: (...args) => logger.log(...args),
+    info: (...args) => logger.info(...args),
+    warn: (...args) => logger.warn(...args),
+    error: (...args) => logger.error(...args),
+    fatal: (...args) => logger.fatal(...args),
+    success: (...args) => logger.success(...args),
     warnOnce: (...args: any[]) => {
       const key = JSON.stringify(args);
       if (warned.has(key)) return;
       warned.add(key);
-      getLogger().warn(...args);
+      logger.warn(...args);
     },
   };
 }

--- a/packages/wxt/src/core/utils/log/wxtLogger.ts
+++ b/packages/wxt/src/core/utils/log/wxtLogger.ts
@@ -1,0 +1,32 @@
+import type { Logger, WxtLogger } from '../../../types';
+
+/**
+ * Wraps a getter for the current `Logger` with a `warnOnce`. The set already
+ * warned messages is scoped to this wrapper instance, so it's only reset when a
+ * new wrapper is created, not every time the config is resolved/reloaded.
+ */
+export function createWxtLogger(getLogger: () => Logger): WxtLogger {
+  const warned = new Set<string>();
+
+  return {
+    get level() {
+      return getLogger().level;
+    },
+    set level(value) {
+      getLogger().level = value;
+    },
+    debug: (...args) => getLogger().debug(...args),
+    log: (...args) => getLogger().log(...args),
+    info: (...args) => getLogger().info(...args),
+    warn: (...args) => getLogger().warn(...args),
+    error: (...args) => getLogger().error(...args),
+    fatal: (...args) => getLogger().fatal(...args),
+    success: (...args) => getLogger().success(...args),
+    warnOnce: (...args: any[]) => {
+      const key = JSON.stringify(args);
+      if (warned.has(key)) return;
+      warned.add(key);
+      getLogger().warn(...args);
+    },
+  };
+}

--- a/packages/wxt/src/core/utils/log/wxtLogger.ts
+++ b/packages/wxt/src/core/utils/log/wxtLogger.ts
@@ -30,3 +30,8 @@ export function createWxtLogger(logger: Logger): WxtLogger {
     },
   };
 }
+
+/** @internal for testing only */
+export function clearWarnSetForTesting(): void {
+  warned.clear();
+}

--- a/packages/wxt/src/core/utils/log/wxtLogger.ts
+++ b/packages/wxt/src/core/utils/log/wxtLogger.ts
@@ -1,13 +1,13 @@
 import type { Logger, WxtLogger } from '../../../types';
 
+const warned = new Set<string>();
+
 /**
  * Wraps a `Logger` with a `warnOnce`. The set of already-warned messages is
  * scoped to this wrapper instance, so it's reset whenever a new wrapper is
  * created, e.g. once per `resolveConfig` call.
  */
 export function createWxtLogger(logger: Logger): WxtLogger {
-  const warned = new Set<string>();
-
   return {
     get level() {
       return logger.level;
@@ -15,13 +15,13 @@ export function createWxtLogger(logger: Logger): WxtLogger {
     set level(value) {
       logger.level = value;
     },
-    debug: (...args) => logger.debug(...args),
-    log: (...args) => logger.log(...args),
-    info: (...args) => logger.info(...args),
-    warn: (...args) => logger.warn(...args),
-    error: (...args) => logger.error(...args),
-    fatal: (...args) => logger.fatal(...args),
-    success: (...args) => logger.success(...args),
+    debug: logger.debug,
+    log: logger.log.bind(logger),
+    info: logger.info.bind(logger),
+    warn: logger.warn.bind(logger),
+    error: logger.error.bind(logger),
+    fatal: logger.fatal.bind(logger),
+    success: logger.success.bind(logger),
     warnOnce: (...args: any[]) => {
       const key = JSON.stringify(args);
       if (warned.has(key)) return;

--- a/packages/wxt/src/core/utils/manifest.ts
+++ b/packages/wxt/src/core/utils/manifest.ts
@@ -59,7 +59,7 @@ export async function generateManifest(
     pkg?.version;
   if (versionName == null) {
     versionName = '0.0.0';
-    wxt.logger.warn(
+    wxt.logger.warnOnce(
       'Extension version not found, defaulting to "0.0.0". Add a version to your `package.json` or `wxt.config.ts` file. For more details, see: https://wxt.dev/guide/key-concepts/manifest.html#version-and-version-name',
     );
   }
@@ -76,7 +76,7 @@ export async function generateManifest(
   const userManifest = wxt.config.manifest;
   if (userManifest.manifest_version) {
     delete userManifest.manifest_version;
-    wxt.logger.warn(
+    wxt.logger.warnOnce(
       '`manifest.manifest_version` config was set, but ignored. To change the target manifest version, use the `manifestVersion` option or the `--mv2`/`--mv3` CLI flags.\nSee https://wxt.dev/guide/essentials/target-different-browsers.html#target-a-manifest-version',
     );
   }
@@ -122,7 +122,7 @@ export async function generateManifest(
       ?.data_collection_permissions &&
     !wxt.config.suppressWarnings?.firefoxDataCollection
   ) {
-    wxt.logger.warn(
+    wxt.logger.warnOnce(
       'Firefox requires `data_collection_permissions` for new extensions from November 3, 2025. Existing extensions are exempt for now.\n' +
         'For more details, see: https://extensionworkshop.com/documentation/develop/firefox-builtin-data-consent/\n' +
         'To suppress this warning, set `suppressWarnings.firefoxDataCollection` to `true` in your wxt config.\n',
@@ -134,7 +134,7 @@ export async function generateManifest(
     !manifest.browser_specific_settings?.gecko?.id &&
     !wxt.config.suppressWarnings?.firefoxId
   ) {
-    wxt.logger.warn(
+    wxt.logger.warnOnce(
       'Firefox requires extension ID for MV3 and recommends it for MV2.\n' +
         'For more details, see: https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/browser_specific_settings#id',
     );

--- a/packages/wxt/src/core/wxt.ts
+++ b/packages/wxt/src/core/wxt.ts
@@ -5,7 +5,6 @@ import { InlineConfig, Wxt, WxtCommand, WxtHooks, WxtModule } from '../types';
 import { createViteBuilder } from './builders/vite';
 import { createWxtPackageManager } from './package-managers';
 import { resolveConfig } from './resolve-config';
-import { createWxtLogger } from './utils/log/wxtLogger';
 
 /**
  * Global variable set once `createWxt` is called once. Since this variable is
@@ -34,15 +33,13 @@ export async function registerWxt(
     createWxtPackageManager(config.root),
   ]);
 
-  // Created once so `warnOnce`. Reads `wxt.config` so it always delegates to
-  // the latest resolved logger, even after the config is reloaded.
-  const logger = createWxtLogger(() => wxt.config.logger);
-
   wxt = {
     config,
     hooks,
     hook: hooks.hook.bind(hooks),
-    logger,
+    get logger() {
+      return config.logger;
+    },
     async reloadConfig() {
       // Prevent changing the server port when resolving config multiple times
       // get-port-please doesn't always return the same port if it was recently closed.

--- a/packages/wxt/src/core/wxt.ts
+++ b/packages/wxt/src/core/wxt.ts
@@ -5,6 +5,7 @@ import { InlineConfig, Wxt, WxtCommand, WxtHooks, WxtModule } from '../types';
 import { createViteBuilder } from './builders/vite';
 import { createWxtPackageManager } from './package-managers';
 import { resolveConfig } from './resolve-config';
+import { createWxtLogger } from './utils/log/wxtLogger';
 
 /**
  * Global variable set once `createWxt` is called once. Since this variable is
@@ -33,13 +34,15 @@ export async function registerWxt(
     createWxtPackageManager(config.root),
   ]);
 
+  // Created once so `warnOnce`. Reads `wxt.config` so it always delegates to
+  // the latest resolved logger, even after the config is reloaded.
+  const logger = createWxtLogger(() => wxt.config.logger);
+
   wxt = {
     config,
     hooks,
     hook: hooks.hook.bind(hooks),
-    get logger() {
-      return config.logger;
-    },
+    logger,
     async reloadConfig() {
       // Prevent changing the server port when resolving config multiple times
       // get-port-please doesn't always return the same port if it was recently closed.

--- a/packages/wxt/src/types.ts
+++ b/packages/wxt/src/types.ts
@@ -643,6 +643,18 @@ export interface Logger {
   level: LogLevel;
 }
 
+/**
+ * The logger available at `wxt.logger`. Extends {@link Logger} with a `warnOnce`
+ * which only logs a message once per process.
+ */
+export interface WxtLogger extends Logger {
+  /**
+   * Same as {@link Logger.warn}, but only logs a given message once per process,
+   * even if called multiple times with the same arguments.
+   */
+  warnOnce(...args: any[]): void;
+}
+
 export interface BaseEntrypointOptions {
   /**
    * List of target browsers to include this entrypoint in. Defaults to being
@@ -1520,8 +1532,8 @@ export interface Wxt {
   hooks: Hookable<WxtHooks>;
   /** Alias for `wxt.hooks.hook(...)`. */
   hook: Hookable<WxtHooks>['hook'];
-  /** Alias for config.logger */
-  logger: Logger;
+  /** Wraps `config.logger`, adding `warnOnce`. */
+  logger: WxtLogger;
   /** Reload config file and update `wxt.config` with the result. */
   reloadConfig: () => Promise<void>;
   /** Package manager utilities. */

--- a/packages/wxt/src/types.ts
+++ b/packages/wxt/src/types.ts
@@ -1585,7 +1585,7 @@ export interface ResolvedConfig {
   targetBrowsers: TargetBrowser[];
   manifestVersion: TargetManifestVersion;
   env: ConfigEnv;
-  logger: Logger;
+  logger: WxtLogger;
   imports: WxtResolvedUnimportOptions;
   manifest: UserManifest;
   fsCache: FsCache;


### PR DESCRIPTION
### Overview

- Wrapped `wxt.logger` with `createWxtLogger` to add `warnOnce` (the Logger type itself stays unchanged)
- The dedup `Set` is created once in `registerWxt` and delegates through a closure that always reads the current `wxt.config.logger`
- State persists across `reloadConfig()`, so `manifest.ts` warnings no longer repeat on dev-server restarts

### Manual Testing

#### `warnOnce`
- Calling it repeatedly with the same arguments logs to the underlying `warn` only once, on the first call, with those exact arguments
- Calling it with distinct arguments logs each one independently, once per distinct message
- Regular warn calls are unaffected by dedup — they always pass through to the underlying warn every time
- If the underlying logger instance is swapped out mid-life (simulating wxt.reloadConfig() replacing wxt.config.logger), the same message still isn't re-logged, while a genuinely new message is correctly delivered to the new underlying logger
#### `delegation`
- `debug`/ `log` / `info` / `error` / `fatal` / `success` are all passed straight through to the underlying logger
- Reading and writing `level` is reflected on the underlying logger

<img width="759" height="178" alt="image" src="https://github.com/user-attachments/assets/cd3aba73-1bdc-4003-af6c-30d42bad146b" />

### Related Issue
This PR closes #2507 