### PR TITLE
ci: Add caching to github actions

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -15,17 +15,25 @@ runs:
       with:
         bun-version-file: '.tool-versions'
 
-    - name: 📦 Cache Dependencies
+    - name: 🔍 Get Bun cache path
       if: ${{ inputs.install == 'true' }}
-      id: cache
-      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+      id: bun-cache
+      shell: bash
+      run: echo "path=$(bun pm cache)" >> $GITHUB_OUTPUT
+
+    - name: 📦 Cache Bun store
+      if: ${{ inputs.install == 'true' }}
+      uses: actions/cache@v4
       with:
-        path: |
-          node_modules
-          packages/*/node_modules
-          packages/*/.wxt
-          .cache/packages
+        path: ${{ steps.bun-cache.outputs.path }}
         key: ${{ runner.os }}-bun-${{ hashFiles('bun.lock') }}
+
+    - name: 📦 Cache buildc
+      if: ${{ inputs.install == 'true' }}
+      uses: actions/cache@v4
+      with:
+        path: .cache/packages
+        key: ${{ runner.os }}-buildc-${{ hashFiles('bun.lock') }}
 
     - name: 📦 Install Dependencies
       if: ${{ inputs.install == 'true' }}

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -26,7 +26,7 @@ runs:
       uses: actions/cache@v4
       with:
         path: ${{ steps.bun-cache.outputs.path }}
-        key: ${{ runner.os }}-bun-${{ hashFiles('bun.lock') }}
+        key: ${{ runner.os }}-bun-store-${{ hashFiles('bun.lock') }}
 
     - name: 📦 Cache buildc
       if: ${{ inputs.install == 'true' }}

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -15,6 +15,18 @@ runs:
       with:
         bun-version-file: '.tool-versions'
 
+    - name: 📦 Cache Dependencies
+      if: ${{ inputs.install == 'true' }}
+      id: cache
+      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+      with:
+        path: |
+          node_modules
+          packages/*/node_modules
+          packages/*/.wxt
+          .cache/packages
+        key: ${{ runner.os }}-bun-${{ hashFiles('bun.lock') }}
+
     - name: 📦 Install Dependencies
       if: ${{ inputs.install == 'true' }}
       shell: bash


### PR DESCRIPTION
### Overview

Windows tests were slow, I think from having to rebuild all the packages. Testing how effective caches are:

| Metric | Cache Miss | Cache Hit |
| --- | --- | --- |
| Checks | 1m 27s | 1m 2s |
| Builds | 59s | 36s |
| Linux tests | 1m 22s | 58s |
| Windows tests | 3m 20s | 2m 59s |

These are one-off stats, the number vary all the time. May not be an accurate representation of how much time is actually saved.