### PR TITLE
fix(types): remove @ts-expect-error for default_state

### DIFF
--- a/packages/wxt/src/core/utils/manifest.ts
+++ b/packages/wxt/src/core/utils/manifest.ts
@@ -306,7 +306,6 @@ function addEntrypoints(
     if (popup.options.defaultTitle)
       options.default_title = popup.options.defaultTitle;
     if (popup.options.defaultState && wxt.config.manifestVersion === 3)
-      // @ts-expect-error: Not typed by @wxt-dev/browser, but supported by Chrome
       options.default_state = popup.options.defaultState;
     if (popup.options.browserStyle)
       // @ts-expect-error: Not typed by @wxt-dev/browser, but supported by Firefox


### PR DESCRIPTION
### Overview

Fix TS error after `@types/chrome` update (https://github.com/DefinitelyTyped/DefinitelyTyped/pull/75283)

### Manual Testing

-

### Related Issue

https://github.com/wxt-dev/wxt/actions/runs/30676389454/job/91304426873#step:4:370