### PR TITLE
fix: `autoImports` import path of eslint.config.js

### DIFF
--- a/packages/wxt-demo/eslint.config.js
+++ b/packages/wxt-demo/eslint.config.js
@@ -1,4 +1,4 @@
-import autoImports from './.wxt/eslintrc-auto-import.js';
+import autoImports from './.wxt/eslint-auto-imports.mjs';
 
 export default [
   {


### PR DESCRIPTION
### Overview

To fix
<img width="768" height="92" alt="image" src="https://github.com/user-attachments/assets/050d4da4-ea75-4c94-bb4f-7479456d9fc3" />