### PR TITLE
fix: skip keyboard shortcuts for non-interactive stdin

### DIFF
--- a/packages/wxt/src/core/__tests__/keyboard-shortcuts.test.ts
+++ b/packages/wxt/src/core/__tests__/keyboard-shortcuts.test.ts
@@ -1,0 +1,57 @@
+import { EventEmitter } from 'node:events';
+import readline from 'node:readline';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { mock } from 'vitest-mock-extended';
+import type { WxtDevServer } from '../../types';
+import { createKeyboardShortcuts } from '../keyboard-shortcuts';
+
+vi.mock('node:readline', () => ({
+  default: {
+    createInterface: vi.fn(),
+  },
+}));
+
+const originalIsTTY = Object.getOwnPropertyDescriptor(process.stdin, 'isTTY');
+
+describe('createKeyboardShortcuts', () => {
+  afterEach(() => {
+    if (originalIsTTY) {
+      Object.defineProperty(process.stdin, 'isTTY', originalIsTTY);
+    } else {
+      delete (process.stdin as Partial<NodeJS.ReadStream>).isTTY;
+    }
+    vi.clearAllMocks();
+  });
+
+  it('should not initialize stdin shortcuts when stdin is non-interactive', () => {
+    Object.defineProperty(process.stdin, 'isTTY', {
+      configurable: true,
+      value: undefined,
+    });
+
+    createKeyboardShortcuts(mock<WxtDevServer>()).start();
+
+    expect(readline.createInterface).not.toHaveBeenCalled();
+  });
+
+  it('should reopen the browser when o is entered in an interactive terminal', () => {
+    Object.defineProperty(process.stdin, 'isTTY', {
+      configurable: true,
+      value: true,
+    });
+    const input = new EventEmitter();
+    vi.mocked(readline.createInterface).mockReturnValue(
+      input as readline.Interface,
+    );
+    const server = mock<WxtDevServer>();
+
+    createKeyboardShortcuts(server).start();
+    input.emit('line', 'o');
+
+    expect(readline.createInterface).toHaveBeenCalledWith({
+      input: process.stdin,
+      terminal: false,
+    });
+    expect(server.restartBrowser).toHaveBeenCalledOnce();
+  });
+});

--- a/packages/wxt/src/core/__tests__/keyboard-shortcuts.test.ts
+++ b/packages/wxt/src/core/__tests__/keyboard-shortcuts.test.ts
@@ -20,7 +20,6 @@ describe('createKeyboardShortcuts', () => {
     } else {
       delete (process.stdin as Partial<NodeJS.ReadStream>).isTTY;
     }
-    vi.clearAllMocks();
   });
 
   it('should not initialize stdin shortcuts when stdin is non-interactive', () => {

--- a/packages/wxt/src/core/keyboard-shortcuts.ts
+++ b/packages/wxt/src/core/keyboard-shortcuts.ts
@@ -26,6 +26,8 @@ export function createKeyboardShortcuts(
     start() {
       this.stop();
 
+      if (!process.stdin.isTTY) return;
+
       rl ??= readline.createInterface({
         input: process.stdin,
         terminal: false, // Don't intercept ctrl+C, ctrl+Z, etc


### PR DESCRIPTION
## Summary

- Skip keyboard shortcut initialization when stdin is not an interactive terminal
- Preserve `o + Enter` browser reopening for interactive terminals
- Add focused regression coverage for interactive and non-interactive stdin

## Issue

`createKeyboardShortcuts.start()` initialized a `readline.Interface` over `process.stdin`. When WXT runs in a context with closed or non-TTY stdin, then initializing readline on watched file changes, causes the process to exit with code 0.

## Impact

WXT development processes no longer exit on the first hot-reload event solely because stdin is non-interactive. Interactive terminal behavior is unchanged.

## Validation

- `bun run --filter wxt test keyboard-shortcuts` (2 passed)
- `bun run --filter wxt test run` (51 files passed; 539 passed, 2 skipped, 2 todo)
- `bun run --filter wxt check`
- `git diff --check`