### PR TITLE
docs: Add Chinese (Simplified) README and language switcher

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[English](./README.md) | [简体中文](./README_zh.md)
+
 <div align="center">
 
 # <img align="top" width="44" src="https://raw.githubusercontent.com/wxt-dev/wxt/HEAD/docs/public/hero-logo.svg" alt="WXT Logo"> WXT

--- a/README_zh.md
+++ b/README_zh.md
@@ -1,0 +1,68 @@
+<div align="center">
+
+# <img align="top" width="44" src="https://raw.githubusercontent.com/wxt-dev/wxt/HEAD/docs/public/hero-logo.svg" alt="WXT Logo"> WXT
+
+[![npm 版本](https://img.shields.io/npm/v/wxt?labelColor=black&color=%234fa048)](https://www.npmjs.com/package/wxt)
+[![下载量](https://img.shields.io/npm/dm/wxt?labelColor=black&color=%234fa048)](https://www.npmjs.com/package/wxt)
+[![许可证 | MIT](https://img.shields.io/npm/l/wxt?labelColor=black&color=%234fa048)](https://github.com/wxt-dev/wxt/blob/main/LICENSE)
+[![覆盖率](https://img.shields.io/codecov/c/github/wxt-dev/wxt?labelColor=black&color=%234fa048)](https://codecov.io/github/wxt-dev/wxt)
+
+用于开发 Web 扩展（浏览器插件）的新一代框架。<br/>⚡<br/><q><i>就像 Nuxt，但是用于 Web 扩展</i></q>
+
+[快速开始](https://wxt.dev/guide/installation.html) •
+[配置](https://wxt.dev/api/config.html) •
+[示例](https://wxt.dev/examples.html) •
+[更新日志](https://github.com/wxt-dev/wxt/blob/main/packages/wxt/CHANGELOG.md) •
+[Discord](https://discord.gg/ZFsZqGery9)
+
+</div>
+
+![CLI 输出示例](https://raw.githubusercontent.com/wxt-dev/wxt/HEAD/docs/assets/cli-output.png)
+
+## 演示
+
+<https://github.com/wxt-dev/wxt/assets/10101283/4d678939-1bdb-495c-9c36-3aa281d84c94>
+
+## 快速开始
+
+初始化一个新项目：
+
+```sh
+# npm
+npx wxt@latest init
+
+# pnpm
+pnpm dlx wxt@latest init
+
+# bun
+bunx wxt@latest init
+```
+
+或者查看[安装指南](https://wxt.dev/guide/installation.html)以开始使用 WXT。
+
+## 特性
+
+- 🌐 支持所有浏览器
+- ✅ 同时支持 MV2 与 MV3
+- ⚡ 带 HMR 与快速重载的开发模式
+- 📂 基于文件的入口点（File based entrypoints）
+- 🚔 TypeScript
+- 🦾 自动导入（Auto-imports）
+- 🤖 自动化发布
+- 🎨 前端框架无关：可与 Vue、React、Svelte 等配合使用
+- 📦 [模块系统](https://wxt.dev/guide/essentials/wxt-modules.html#overview)，用于在多个扩展之间复用代码
+- 🖍️ 快速初始化新项目
+- 📏 打包体积分析
+
+## 赞助商
+
+WXT 是一个采用 [MIT 许可证](https://github.com/wxt-dev/wxt/blob/main/LICENSE) 的开源项目，其持续开发完全依靠这些优秀支持者的赞助。如果你也想加入他们，请考虑[赞助 WXT 的开发](https://github.com/sponsors/wxt-dev)。
+
+[![WXT 赞助商](https://raw.githubusercontent.com/wxt-dev/static/refs/heads/main/sponsorkit/sponsors.svg)](https://github.com/sponsors/wxt-dev)
+
+## 贡献者
+
+基于 [MIT](https://github.com/wxt-dev/wxt/blob/main/LICENSE) 许可证发布。
+由 [@aklinker1](https://github.com/aklinker1) 与 [社区](https://github.com/wxt-dev/wxt/graphs/contributors) 💛 共同打造
+
+[![WXT 贡献者](https://contrib.rocks/image?repo=wxt-dev/wxt)](https://github.com/wxt-dev/wxt/graphs/contributors)


### PR DESCRIPTION
## Overview
This PR adds Simplified Chinese documentation for wxt to help Chinese-speaking users get started:

- Added `README_zh.md`, fully translated from the English `README.md`
- Added a language switcher at the top of `README.md`: `[English](./README.md) | [简体中文](./README_zh.md)`

## Notes
- Only documentation was added/updated; no code or structure changes
- Translation stays semantically consistent with the English version, with terms aligned to community conventions

> [!TIP]
> This PR is submitted on behalf of VZService~
