### PR TITLE
docs: Added "GringaChange" to showcase

### DIFF
--- a/docs/assets/extension-showcase.yml
+++ b/docs/assets/extension-showcase.yml
@@ -536,3 +536,6 @@
 - # Video Time Manager
   chromeId: fpoooibdndpjcnoodfionoeakeojdjaj
   firefoxSlug: youtube-time-manager@avi12.com
+
+- # GringaChange
+  chromeId: amkfidglmdkclmhgnnkicocfcgoplanp


### PR DESCRIPTION
Adds [GringaChange](https://chromewebstore.google.com/detail/gringachange/amkfidglmdkclmhgnnkicocfcgoplanp) to the extension showcase — a currency exchange extension (BRL rates, alerts, remittance simulator) for people earning in foreign currency, built with WXT + Vue 3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)