### PR TITLE
fix: exit completed CLI commands

### DIFF
--- a/packages/wxt/e2e/tests/cli.test.ts
+++ b/packages/wxt/e2e/tests/cli.test.ts
@@ -1,0 +1,31 @@
+import { mkdir, writeFile } from 'node:fs/promises';
+import { dirname } from 'node:path';
+import { x as spawn } from 'tinyexec';
+import { describe, expect, it } from 'vitest';
+import { TestProject, WXT_PACKAGE_DIR } from '../utils';
+
+describe('CLI', () => {
+  it('should exit after prepare when an entrypoint creates active handles', async () => {
+    const project = new TestProject();
+    const backgroundPath = project.resolvePath('entrypoints/background.ts');
+    await mkdir(dirname(backgroundPath), { recursive: true });
+    await writeFile(
+      backgroundPath,
+      `new BroadcastChannel('wxt-prepare-test');
+
+export default defineBackground(() => {});
+`,
+    );
+
+    const result = await spawn(
+      'node',
+      ['--import', 'tsx', 'src/cli/index.ts', 'prepare', project.root],
+      {
+        timeout: 5_000,
+        nodeOptions: { cwd: WXT_PACKAGE_DIR },
+      },
+    );
+
+    expect(result.exitCode).toBe(0);
+  });
+});

--- a/packages/wxt/src/cli/__tests__/index.test.ts
+++ b/packages/wxt/src/cli/__tests__/index.test.ts
@@ -44,6 +44,7 @@ describe('CLI', () => {
   beforeEach(() => {
     vi.resetModules();
     process.argv = ogArgv;
+    vi.spyOn(process, 'exit').mockImplementation(() => undefined as never);
     createServerMock.mockResolvedValue(mock());
   });
 
@@ -53,6 +54,7 @@ describe('CLI', () => {
       await importCli();
 
       expect(createServerMock).toBeCalledWith({});
+      expect(process.exit).not.toBeCalled();
     });
 
     it('should respect passing a custom root', async () => {
@@ -399,6 +401,7 @@ describe('CLI', () => {
       await importCli();
 
       expect(prepareMock).toBeCalledWith({});
+      expect(process.exit).toBeCalledWith(0);
     });
 
     it('should respect passing a custom root', async () => {

--- a/packages/wxt/src/cli/cli-utils.ts
+++ b/packages/wxt/src/cli/cli-utils.ts
@@ -9,7 +9,8 @@ import { x as spawn } from 'tinyexec';
 
 /**
  * Wrap an action handler to add a timer, error handling, and maybe enable debug
- * mode.
+ * mode. Completed commands exit explicitly so handles created while loading
+ * user entrypoints cannot keep the CLI alive.
  */
 export function wrapAction(
   cb: (
@@ -38,10 +39,13 @@ export function wrapAction(
 
       const status = await cb(...args);
 
-      if (!status?.isOngoing && !options?.disableFinishedLog)
-        consola.success(
-          `Finished in ${formatDuration(Date.now() - startTime)}`,
-        );
+      if (!status?.isOngoing) {
+        if (!options?.disableFinishedLog)
+          consola.success(
+            `Finished in ${formatDuration(Date.now() - startTime)}`,
+          );
+        process.exit(0);
+      }
     } catch (err) {
       consola.fail(
         `Command failed after ${formatDuration(Date.now() - startTime)}`,


### PR DESCRIPTION
### Overview

WXT evaluates extension entrypoints in Node while running one-shot commands such as `wxt prepare`. If an imported dependency creates a referenced Node handle (for example, a `BroadcastChannel`), WXT prints `Finished` but the CLI process never exits. This also leaves package-manager lifecycle scripts such as `postinstall: wxt prepare` stuck indefinitely.

This change explicitly exits successful, completed CLI actions after their final log. Long-running commands are unchanged: `wxt dev` already returns `{ isOngoing: true }`, so it continues running normally.

The regression test launches the real TypeScript CLI with Node against an extension whose background entrypoint contains:

```ts
new BroadcastChannel('wxt-prepare-test');

export default defineBackground(() => {});
```

Without the fix, the child process reaches `Finished` and is killed by the five-second test timeout. With the fix, it exits with code 0.

### Manual Testing

- `bun run --filter wxt test run e2e/tests/cli.test.ts`
- `bun run --filter wxt test run src/cli/__tests__/index.test.ts` (53 tests)
- `bun run --filter wxt check`
- `bun run --filter wxt test run` (51 files, 538 passed, 2 skipped, 2 todo)

### Related Issue

Related to #1841.
