### PR TITLE
feat(analytics): add extport provider

### DIFF
--- a/packages/analytics/README.md
+++ b/packages/analytics/README.md
@@ -4,6 +4,7 @@ Report analytics events from your web extension extension.
 
 ## Supported Analytics Providers
 
+- [extport](#extport)
 - [Google Analytics 4 (Measurement Protocol)](#google-analytics-4-measurement-protocol)
 - [Moderok](#moderok)
 - [PostHog](#posthog)
@@ -92,6 +93,29 @@ Report analytics events from your web extension extension.
    ```
 
 ## Providers
+
+### extport
+
+[extport](https://extport.dev) is an open, self-hostable platform for browser extension developers — publishing, licensing, and analytics across Chrome, Firefox, Edge, and Safari. Its analytics protocol is a single anonymous daily ping per install: actives, installs, and churn are all derived server-side, and there are no custom events by design (pair another provider like PostHog or Umami if you need event tracking).
+
+Create an extension at [dash.extport.dev](https://dash.extport.dev) to get its `ext_…` id, then add the provider to your `<srcDir>/app.config.ts`:
+
+```ts
+// <srcDir>/app.config.ts
+import { extport } from '@wxt-dev/analytics/providers/extport';
+
+export default defineAppConfig({
+  analytics: {
+    providers: [
+      extport({
+        extensionId: 'ext_...',
+      }),
+    ],
+  },
+});
+```
+
+The provider automatically respects Firefox's built-in data-collection consent (`technicalAndInteraction`) — no extra wiring needed. Self-hosted instances can point elsewhere with the `apiBase` option.
 
 ### Google Analytics 4 (Measurement Protocol)
 

--- a/packages/analytics/README.md
+++ b/packages/analytics/README.md
@@ -4,11 +4,11 @@ Report analytics events from your web extension extension.
 
 ## Supported Analytics Providers
 
-- [extport](#extport)
 - [Google Analytics 4 (Measurement Protocol)](#google-analytics-4-measurement-protocol)
 - [Moderok](#moderok)
 - [PostHog](#posthog)
 - [Umami](#umami)
+- [extport](#extport)
 
 ## Install With WXT
 
@@ -93,29 +93,6 @@ Report analytics events from your web extension extension.
    ```
 
 ## Providers
-
-### extport
-
-[extport](https://extport.dev) is an open, self-hostable platform for browser extension developers — publishing, licensing, and analytics across Chrome, Firefox, Edge, and Safari. Its analytics protocol is a single anonymous daily ping per install: actives, installs, and churn are all derived server-side, and there are no custom events by design (pair another provider like PostHog or Umami if you need event tracking).
-
-Create an extension at [dash.extport.dev](https://dash.extport.dev) to get its `ext_…` id, then add the provider to your `<srcDir>/app.config.ts`:
-
-```ts
-// <srcDir>/app.config.ts
-import { extport } from '@wxt-dev/analytics/providers/extport';
-
-export default defineAppConfig({
-  analytics: {
-    providers: [
-      extport({
-        extensionId: 'ext_...',
-      }),
-    ],
-  },
-});
-```
-
-The provider automatically respects Firefox's built-in data-collection consent (`technicalAndInteraction`) — no extra wiring needed. Self-hosted instances can point elsewhere with the `apiBase` option.
 
 ### Google Analytics 4 (Measurement Protocol)
 
@@ -240,6 +217,29 @@ export default defineAppConfig({
   },
 });
 ```
+
+### extport
+
+[extport](https://extport.dev) is an open, self-hostable platform for browser extension developers — publishing, licensing, and analytics across Chrome, Firefox, Edge, and Safari. Its analytics protocol is a single anonymous daily ping per install: actives, installs, and churn are all derived server-side, and there are no custom events by design (pair another provider like PostHog or Umami if you need event tracking).
+
+Create an extension at [dash.extport.dev](https://dash.extport.dev) to get its `ext_…` id, then add the provider to your `<srcDir>/app.config.ts`:
+
+```ts
+// <srcDir>/app.config.ts
+import { extport } from '@wxt-dev/analytics/providers/extport';
+
+export default defineAppConfig({
+  analytics: {
+    providers: [
+      extport({
+        extensionId: 'ext_...',
+      }),
+    ],
+  },
+});
+```
+
+The provider automatically respects Firefox's built-in data-collection consent (`technicalAndInteraction`) — no extra wiring needed. Self-hosted instances can point elsewhere with the `apiBase` option.
 
 ### Custom Provider
 

--- a/packages/analytics/modules/analytics/providers/extport.ts
+++ b/packages/analytics/modules/analytics/providers/extport.ts
@@ -1,0 +1,126 @@
+import { defineAnalyticsProvider } from '../client';
+import { browser } from '@wxt-dev/browser';
+import type { BaseAnalyticsEvent } from '../types';
+
+const DEFAULT_API_BASE = 'https://api.extport.dev';
+const PING_STORAGE_KEY = 'extport:last-ping-date';
+
+/**
+ * Internal event name used to route the daily ping through
+ * `analytics.track()`, so the module's consent gate (`enabled`) applies to
+ * it like any other event.
+ */
+const PING_EVENT = '__extport_ping';
+
+export interface ExtportProviderOptions {
+  /** The extension's extport id (`ext_…`), from https://dash.extport.dev. */
+  extensionId: string;
+  /** Override for self-hosted extport instances. */
+  apiBase?: string;
+}
+
+/**
+ * Firefox 140+ has a built-in data-collection consent mechanism: when
+ * `permissions.getAll()` reports a `data_collection` array,
+ * `technicalAndInteraction` must be present in it (the toggle shown in the
+ * install prompt and in about:addons). When the key is absent the browser
+ * has no such mechanism and the manifest disclosure governs. Read at ping
+ * time so revocation needs no listener — the next ping re-checks.
+ */
+async function browserConsentsToAnalytics(): Promise<boolean> {
+  try {
+    const all = (await browser.permissions.getAll()) as {
+      data_collection?: string[];
+    };
+    return (
+      all.data_collection === undefined ||
+      all.data_collection.includes('technicalAndInteraction')
+    );
+  } catch {
+    // Only environments without the permissions API get here — same
+    // treatment as the key being absent.
+    return true;
+  }
+}
+
+/**
+ * [extport](https://extport.dev)'s analytics protocol has exactly one
+ * event: an anonymous daily ping per install. Installs, actives, and churn
+ * are all derived from the ping stream server-side, so this provider
+ * reports nothing else — custom events are dropped (pair another provider
+ * like PostHog or Umami if you need event tracking).
+ */
+export const extport = defineAnalyticsProvider<ExtportProviderOptions>(
+  (analytics, config, options) => {
+    const apiBase = options.apiBase ?? DEFAULT_API_BASE;
+    const debug = config.debug ?? false;
+    let inflight: Promise<void> | undefined;
+
+    const ping = async (event: BaseAnalyticsEvent) => {
+      const today = new Date().toISOString().slice(0, 10);
+      const stored = await browser.storage.local.get(PING_STORAGE_KEY);
+      if (stored[PING_STORAGE_KEY] === today) return;
+      if (!(await browserConsentsToAnalytics())) return;
+
+      const payload = {
+        installId: event.user.id,
+        extensionId: options.extensionId,
+        version: event.user.properties.version ?? '0.0.0',
+        language: event.meta.language,
+      };
+      if (debug) {
+        console.debug('[@wxt-dev/analytics][extport] Sending:', payload);
+      }
+      const response = await fetch(`${apiBase}/api/v1/analytics/ping`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(payload),
+      });
+      // Only stamp the day on confirmed delivery — a failed send retries on
+      // the next background wake-up. The server is idempotent per install
+      // per UTC day, so a retry can never double-count.
+      if (response.ok) {
+        await browser.storage.local.set({ [PING_STORAGE_KEY]: today });
+      }
+    };
+
+    const maybePing = (event: BaseAnalyticsEvent) => {
+      inflight ??= ping(event)
+        .catch((error) => {
+          if (debug) {
+            console.debug('[@wxt-dev/analytics][extport] Ping failed:', error);
+          }
+        })
+        .finally(() => {
+          inflight = undefined;
+        });
+      return inflight;
+    };
+
+    // The provider is initialized from the background, so initialization
+    // itself marks a background wake-up — the natural moment for a daily
+    // ping. onInstalled makes install day exact instead of waiting for the
+    // next wake-up, and permissions.onAdded catches a Firefox user turning
+    // the data-collection toggle on later the same day.
+    browser.runtime.onInstalled.addListener(() => {
+      void analytics.track(PING_EVENT);
+    });
+    browser.permissions.onAdded?.addListener(() => {
+      void analytics.track(PING_EVENT);
+    });
+    void analytics.track(PING_EVENT);
+
+    return {
+      identify: () => Promise.resolve(),
+      page: () => Promise.resolve(),
+      track: async (event) => {
+        if (event.event.name === PING_EVENT) return maybePing(event);
+        if (debug) {
+          console.debug(
+            `[@wxt-dev/analytics][extport] No custom events in the extport protocol — "${event.event.name}" dropped`,
+          );
+        }
+      },
+    };
+  },
+);

--- a/packages/analytics/package.json
+++ b/packages/analytics/package.json
@@ -51,6 +51,10 @@
     "./types": {
       "types": "./dist/types.d.mts"
     },
+    "./providers/extport": {
+      "types": "./dist/providers/extport.d.mts",
+      "default": "./dist/providers/extport.mjs"
+    },
     "./providers/google-analytics-4": {
       "types": "./dist/providers/google-analytics-4.d.mts",
       "default": "./dist/providers/google-analytics-4.mjs"

--- a/packages/analytics/package.json
+++ b/packages/analytics/package.json
@@ -51,10 +51,6 @@
     "./types": {
       "types": "./dist/types.d.mts"
     },
-    "./providers/extport": {
-      "types": "./dist/providers/extport.d.mts",
-      "default": "./dist/providers/extport.mjs"
-    },
     "./providers/google-analytics-4": {
       "types": "./dist/providers/google-analytics-4.d.mts",
       "default": "./dist/providers/google-analytics-4.mjs"
@@ -70,6 +66,10 @@
     "./providers/posthog": {
       "types": "./dist/providers/posthog.d.mts",
       "default": "./dist/providers/posthog.mjs"
+    },
+    "./providers/extport": {
+      "types": "./dist/providers/extport.d.mts",
+      "default": "./dist/providers/extport.mjs"
     }
   },
   "module": "./dist/index.mjs",

--- a/packages/analytics/tsdown.config.ts
+++ b/packages/analytics/tsdown.config.ts
@@ -6,12 +6,12 @@ export default defineConfig({
     module: './modules/analytics/index.ts',
     'background-plugin': './modules/analytics/background-plugin.ts',
     types: './modules/analytics/types.ts',
-    'providers/extport': './modules/analytics/providers/extport.ts',
     'providers/google-analytics-4':
       './modules/analytics/providers/google-analytics-4.ts',
     'providers/umami': './modules/analytics/providers/umami.ts',
     'providers/moderok': './modules/analytics/providers/moderok.ts',
     'providers/posthog': './modules/analytics/providers/posthog.ts',
+    'providers/extport': './modules/analytics/providers/extport.ts',
   },
   deps: {
     neverBundle: ['#analytics'],

--- a/packages/analytics/tsdown.config.ts
+++ b/packages/analytics/tsdown.config.ts
@@ -6,6 +6,7 @@ export default defineConfig({
     module: './modules/analytics/index.ts',
     'background-plugin': './modules/analytics/background-plugin.ts',
     types: './modules/analytics/types.ts',
+    'providers/extport': './modules/analytics/providers/extport.ts',
     'providers/google-analytics-4':
       './modules/analytics/providers/google-analytics-4.ts',
     'providers/umami': './modules/analytics/providers/umami.ts',


### PR DESCRIPTION
## Overview

Adds an [extport](https://extport.dev) provider, following the same shape as the Moderok provider.

extport is an open, self-hostable platform for browser-extension developers (publishing, licensing, and analytics across Chrome/Firefox/Edge/Safari; ELv2 platform, MIT SDK). Its analytics protocol is deliberately minimal: **one anonymous ping per install per UTC day** — installs, actives, and churn are all derived server-side, and there are no custom events by design (the README section tells users to pair PostHog/Umami if they need event tracking).

## Implementation notes

- The daily ping is routed through `analytics.track('__extport_ping')` so the module's `enabled` consent gate applies to it like any other event (same pattern as Moderok's lifecycle events).
- Respects Firefox 140+'s built-in `data_collection` consent (`technicalAndInteraction`) by re-checking `permissions.getAll()` at ping time — revocation needs no listener, and `permissions.onAdded` catches a user turning the toggle on later the same day.
- The last-ping date stamp is only written after a confirmed 2xx, so a failed send retries on the next background wake-up; the server is idempotent per install per UTC day, so retries can never double-count.
- `event.user.id` is reused as the install identifier — no provider-side id storage.

Changes: provider file, `package.json` exports entry, `tsdown.config.ts` entry, README TOC + section.

I'm the author of extport and run it in production across the ~20 extensions I maintain — happy to adjust anything to fit the package's conventions.