### PR TITLE
fix: don't add an empty content_scripts array for runtime-only content scripts

### DIFF
--- a/packages/wxt/src/core/utils/__tests__/manifest.test.ts
+++ b/packages/wxt/src/core/utils/__tests__/manifest.test.ts
@@ -1369,7 +1369,57 @@ describe('Manifest Utils', () => {
             buildOutput,
           );
 
-          expect(actual.content_scripts).toEqual([]);
+          expect(actual.content_scripts).toBeUndefined();
+          expect(actual.host_permissions).toEqual(['*://google.com/*']);
+        });
+
+        it('should still add manifest-registered content scripts when other content scripts are runtime-registered', async () => {
+          const runtimeCs: ContentScriptEntrypoint = {
+            type: 'content-script',
+            name: 'one',
+            inputPath: 'entrypoints/one.content.ts',
+            outputDir: contentScriptOutDir,
+            options: {
+              matches: ['*://google.com/*'],
+              registration: 'runtime',
+            },
+            skipped: false,
+          };
+          const manifestCs: ContentScriptEntrypoint = {
+            type: 'content-script',
+            name: 'two',
+            inputPath: 'entrypoints/two.content.ts',
+            outputDir: contentScriptOutDir,
+            options: {
+              matches: ['*://bing.com/*'],
+            },
+            skipped: false,
+          };
+
+          const entrypoints = [runtimeCs, manifestCs];
+          const buildOutput: Omit<BuildOutput, 'manifest'> = {
+            publicAssets: [],
+            steps: [{ entrypoints, chunks: [] }],
+          };
+          setFakeWxt({
+            config: {
+              manifestVersion: 3,
+              outDir,
+              command: 'build',
+            },
+          });
+
+          const { manifest: actual } = await generateManifest(
+            entrypoints,
+            buildOutput,
+          );
+
+          expect(actual.content_scripts).toEqual([
+            {
+              js: ['content-scripts/two.js'],
+              matches: ['*://bing.com/*'],
+            },
+          ]);
           expect(actual.host_permissions).toEqual(['*://google.com/*']);
         });
       });

--- a/packages/wxt/src/core/utils/manifest.ts
+++ b/packages/wxt/src/core/utils/manifest.ts
@@ -434,7 +434,7 @@ function addEntrypoints(
           getContentScriptCssFiles(scripts, cssMap),
         ),
       );
-      if (manifestContentScripts.length >= 0) {
+      if (manifestContentScripts.length > 0) {
         manifest.content_scripts ??= [];
         manifest.content_scripts.push(...manifestContentScripts);
       }


### PR DESCRIPTION
## Summary

`manifestContentScripts.length >= 0` is a tautology (array length is never negative), so `manifest.content_scripts` was set to `[]` whenever a project had at least one content script entrypoint but **every one** of them used `registration: 'runtime'`.

Chrome and Firefox silently ignore the empty array, but Safari treats it as invalid. The build/convert step itself doesn't complain, but once the converted extension is run and inspected in Safari, its Extensions settings show:

```
Errors for "<Extension Name>":
❌ Empty or invalid content_scripts manifest entry.
```

<img width="541" height="231" alt="image" src="https://github.com/user-attachments/assets/581201d8-0bb3-4625-87fd-c484e6907f72" />

(Reproduced by building a project whose only content script uses `registration: 'runtime'`, converting it with `wxt zip -b safari`, then opening the extension in Safari.)

## Changes

- `manifestContentScripts.length >= 0` → `> 0`, so `content_scripts` is only added to the manifest when there's actually something to declare.
- Updated the existing test that asserted `content_scripts` equals `[]` for a runtime-only project — it now asserts `undefined`, matching the convention used elsewhere in the same file (e.g. the "skipped entrypoints" test).
- Added a test covering the mixed case (one runtime-registered + one manifest-registered content script) to confirm the fix doesn't regress the normal case.

## Test plan

- [x] `vitest run src/core/utils/__tests__/manifest.test.ts` — 92 tests passing, run repeatedly across several random `faker` seeds
- [x] `tsc --noEmit` — no new errors