### PR TITLE
fix: don't set use_dynamic_url on browsers that don't support it

### DIFF
--- a/packages/wxt/src/core/utils/__tests__/manifest.test.ts
+++ b/packages/wxt/src/core/utils/__tests__/manifest.test.ts
@@ -1231,6 +1231,7 @@ describe('Manifest Utils', () => {
               outDir,
               command: 'build',
               manifestVersion: 3,
+              browser: 'chrome',
             },
           });
 
@@ -1315,6 +1316,7 @@ describe('Manifest Utils', () => {
               outDir,
               command: 'build',
               manifestVersion: 3,
+              browser: 'chrome',
             },
           });
 
@@ -1330,6 +1332,53 @@ describe('Manifest Utils', () => {
               use_dynamic_url: true,
             },
           ]);
+        });
+
+        it("should not add `use_dynamic_url` for Firefox or Safari, which don't support it", async () => {
+          const cs: ContentScriptEntrypoint = {
+            type: 'content-script',
+            name: 'one',
+            inputPath: 'entrypoints/one.content.ts',
+            outputDir: contentScriptOutDir,
+            options: {
+              matches: ['*://google.com/*'],
+              cssInjectionMode: 'ui',
+            },
+            skipped: false,
+          };
+          const styles: OutputAsset = {
+            type: 'asset',
+            fileName: 'content-scripts/one.css',
+          };
+
+          const entrypoints = [cs];
+          const buildOutput: Omit<BuildOutput, 'manifest'> = {
+            publicAssets: [],
+            steps: [{ entrypoints: cs, chunks: [styles] }],
+          };
+
+          for (const browser of ['firefox', 'safari']) {
+            setFakeWxt({
+              config: {
+                outDir,
+                command: 'build',
+                manifestVersion: 3,
+                browser,
+              },
+            });
+
+            const { manifest: actual } = await generateManifest(
+              entrypoints,
+              buildOutput,
+            );
+
+            expect(actual.web_accessible_resources).toEqual([
+              {
+                matches: ['*://google.com/*'],
+                resources: ['content-scripts/one.css'],
+              },
+            ]);
+          }
         });
       });
 
@@ -1473,6 +1522,7 @@ describe('Manifest Utils', () => {
             outDir,
             command: 'build',
             manifestVersion: 3,
+            browser: 'chrome',
             manifest: {
               web_accessible_resources: [
                 { resources: ['one.png'], matches: ['*://one.com/*'] },

--- a/packages/wxt/src/core/utils/manifest.ts
+++ b/packages/wxt/src/core/utils/manifest.ts
@@ -590,7 +590,12 @@ export function getContentScriptCssWebAccessibleResources(
 
     resources.push({
       resources: [cssFile],
-      use_dynamic_url: true,
+      // Chrome-only MV3 field (obscures the resource URL behind a per-session
+      // token); Firefox ignores it, and Safari's web extension converter
+      // rejects it as an unsupported key.
+      ...(wxt.config.browser !== 'firefox' && wxt.config.browser !== 'safari'
+        ? { use_dynamic_url: true }
+        : {}),
       matches:
         script.options.matches?.map((matchPattern) =>
           stripPathFromMatchPattern(matchPattern),


### PR DESCRIPTION
## Summary

Content scripts using `cssInjectionMode: 'ui'` unconditionally get `use_dynamic_url: true` on their generated `web_accessible_resources` entry, regardless of target browser.

`use_dynamic_url` is a Chrome-only MV3 field (obscures the resource URL behind a per-session token to prevent fingerprinting) — [MDN's browser-compatibility table](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/web_accessible_resources#browser_compatibility) lists it as unsupported in Firefox and Safari. Firefox silently ignores the unknown key, but Safari's web extension converter warns about it:

```
Warning: The following keys in your manifest.json are not supported by your current version of Safari...
	use_dynamic_url
```

(It's a warning, not a build failure — the converter still produces a working Xcode project. Reproduced by building a project with a `cssInjectionMode: 'ui'` content script and running `wxt zip -b safari`.)

## Changes

- `use_dynamic_url: true` is now only added when `wxt.config.browser` is neither `'firefox'` nor `'safari'`. The `resources`/`matches` entry itself is still added on every browser — only this one field is conditional.
- Pinned `browser: 'chrome'` in the three existing tests that asserted `use_dynamic_url: true` — they previously passed only because the test fixture's default browser is randomly `chrome` or `firefox` (`faker.helpers.arrayElement(['chrome', 'firefox'])`), so after this fix they'd become flaky without an explicit browser.
- Added a test asserting the field is omitted for both `firefox` and `safari`.

## Test plan

- [x] `vitest run src/core/utils/__tests__/manifest.test.ts` — 92 tests passing, run repeatedly across several random `faker` seeds
- [x] `tsc --noEmit` — no new errors

Related: #2580 (same file, unrelated root cause — split into two PRs per CONTRIBUTING.md's per-PR changelog convention).