### PR TITLE
[Fix] app.config.ts of wxt-demo doesn't reload

### DIFF
--- a/packages/wxt-demo/src/entrypoints/content.ts
+++ b/packages/wxt-demo/src/entrypoints/content.ts
@@ -2,6 +2,7 @@ export default defineContentScript({
   matches: ['*://*.example.com/*'],
 
   async main() {
+    console.log(getAppConfig());
     console.log('Injecting...');
     await injectScript('/unlisted.js', {
       keepInDom: true,

--- a/packages/wxt/src/core/utils/create-file-reloader.ts
+++ b/packages/wxt/src/core/utils/create-file-reloader.ts
@@ -124,9 +124,8 @@ export function createFileReloader(server: WxtDevServer) {
 
         // Perform reloads
         if (hasNewEntrypoints || changes.type === 'extension-reload') {
-          // `server.reloadExtension()` only reloads the background/manifest -
-          // it doesn't re-inject content scripts into tabs that are already
-          // open, so tell those to reload too.
+          // `server.reloadExtension()` only reloads the background/manifest
+          // reload content scripts into tabs which are already open.
           reloadContentScripts(newOutput.steps, server);
           server.reloadExtension();
           wxt.logger.success(`Reloaded extension`);

--- a/packages/wxt/src/core/utils/create-file-reloader.ts
+++ b/packages/wxt/src/core/utils/create-file-reloader.ts
@@ -124,6 +124,10 @@ export function createFileReloader(server: WxtDevServer) {
 
         // Perform reloads
         if (hasNewEntrypoints || changes.type === 'extension-reload') {
+          // `server.reloadExtension()` only reloads the background/manifest -
+          // it doesn't re-inject content scripts into tabs that are already
+          // open, so tell those to reload too.
+          reloadContentScripts(newOutput.steps, server);
           server.reloadExtension();
           wxt.logger.success(`Reloaded extension`);
         } else if (changes.type === 'html-reload') {

--- a/packages/wxt/src/utils/inject-script.ts
+++ b/packages/wxt/src/utils/inject-script.ts
@@ -24,17 +24,7 @@ export async function injectScript(
 ): Promise<InjectScriptResult> {
   // @ts-expect-error: getURL is defined per-project, but not inside the package
   const url = browser.runtime.getURL(path);
-
-  // If a previous call left this same script in the DOM (`keepInDom`),
-  // remove it first. Otherwise, calling `injectScript` again for the same
-  // path - e.g. because the content script that called it got re-run -
-  // would leave multiple copies of it running side by side.
-  document.querySelectorAll('script').forEach((el) => {
-    if (el.dataset.wxtInjectedPath === path) el.remove();
-  });
-
   const script = document.createElement('script');
-  script.dataset.wxtInjectedPath = path;
 
   const isManifestV2 = browser.runtime.getManifest().manifest_version === 2;
 

--- a/packages/wxt/src/utils/inject-script.ts
+++ b/packages/wxt/src/utils/inject-script.ts
@@ -24,7 +24,17 @@ export async function injectScript(
 ): Promise<InjectScriptResult> {
   // @ts-expect-error: getURL is defined per-project, but not inside the package
   const url = browser.runtime.getURL(path);
+
+  // If a previous call left this same script in the DOM (`keepInDom`),
+  // remove it first. Otherwise, calling `injectScript` again for the same
+  // path - e.g. because the content script that called it got re-run -
+  // would leave multiple copies of it running side by side.
+  document.querySelectorAll('script').forEach((el) => {
+    if (el.dataset.wxtInjectedPath === path) el.remove();
+  });
+
   const script = document.createElement('script');
+  script.dataset.wxtInjectedPath = path;
 
   const isManifestV2 = browser.runtime.getManifest().manifest_version === 2;
 

--- a/packages/wxt/src/utils/internal/dev-server-websocket.ts
+++ b/packages/wxt/src/utils/internal/dev-server-websocket.ts
@@ -1,3 +1,4 @@
+import type { Browser } from '@wxt-dev/browser';
 import { logger } from './logger';
 
 interface WebSocketMessage {
@@ -76,5 +77,6 @@ export interface ReloadContentScriptPayload {
     matches: string[];
     js?: string[];
     css?: string[];
+    world?: Browser.scripting.RegisteredContentScript['world'];
   };
 }

--- a/packages/wxt/src/virtual/background-entrypoint.ts
+++ b/packages/wxt/src/virtual/background-entrypoint.ts
@@ -4,23 +4,21 @@ import { getDevServerWebSocket } from '../utils/internal/dev-server-websocket';
 import { logger } from '../utils/internal/logger';
 import { browser } from 'wxt/browser';
 import { keepServiceWorkerAlive } from './utils/keep-service-worker-alive';
-import { reloadContentScript } from './utils/reload-content-scripts';
+import {
+  reloadContentScript,
+  waitForPendingContentScriptReloads,
+} from './utils/reload-content-scripts';
 
 if (import.meta.env.COMMAND === 'serve') {
-  // Content script reloads for an `extension-reload` are sent as separate,
-  // unawaited messages just before it. Track them so `runtime.reload()`
-  // doesn't tear down the background (and its message handling) before
-  // they've had a chance to finish injecting into open tabs.
-  const pendingContentScriptReloads: Promise<unknown>[] = [];
-
   try {
     const ws = getDevServerWebSocket();
     ws.addWxtEventListener('wxt:reload-extension', async () => {
-      await Promise.allSettled(pendingContentScriptReloads);
+      // Wait for content script reloads to finish before killing the background.
+      await waitForPendingContentScriptReloads();
       browser.runtime.reload();
     });
     ws.addWxtEventListener('wxt:reload-content-script', (event) => {
-      pendingContentScriptReloads.push(reloadContentScript(event.detail));
+      reloadContentScript(event.detail);
     });
 
     if (import.meta.env.MANIFEST_VERSION === 3) {

--- a/packages/wxt/src/virtual/background-entrypoint.ts
+++ b/packages/wxt/src/virtual/background-entrypoint.ts
@@ -7,13 +7,20 @@ import { keepServiceWorkerAlive } from './utils/keep-service-worker-alive';
 import { reloadContentScript } from './utils/reload-content-scripts';
 
 if (import.meta.env.COMMAND === 'serve') {
+  // Content script reloads for an `extension-reload` are sent as separate,
+  // unawaited messages just before it. Track them so `runtime.reload()`
+  // doesn't tear down the background (and its message handling) before
+  // they've had a chance to finish injecting into open tabs.
+  const pendingContentScriptReloads: Promise<unknown>[] = [];
+
   try {
     const ws = getDevServerWebSocket();
-    ws.addWxtEventListener('wxt:reload-extension', () => {
+    ws.addWxtEventListener('wxt:reload-extension', async () => {
+      await Promise.allSettled(pendingContentScriptReloads);
       browser.runtime.reload();
     });
     ws.addWxtEventListener('wxt:reload-content-script', (event) => {
-      reloadContentScript(event.detail);
+      pendingContentScriptReloads.push(reloadContentScript(event.detail));
     });
 
     if (import.meta.env.MANIFEST_VERSION === 3) {

--- a/packages/wxt/src/virtual/utils/reload-content-scripts.ts
+++ b/packages/wxt/src/virtual/utils/reload-content-scripts.ts
@@ -3,13 +3,20 @@ import { logger } from '../../utils/internal/logger';
 import { MatchPattern } from 'wxt/utils/match-patterns';
 import type { ReloadContentScriptPayload } from '../../utils/internal/dev-server-websocket';
 
-export function reloadContentScript(
-  payload: ReloadContentScriptPayload,
-): Promise<void> {
+const pendingReloads = new Set<Promise<unknown>>();
+
+export function reloadContentScript(payload: ReloadContentScriptPayload): void {
   const manifest = browser.runtime.getManifest();
-  return manifest.manifest_version == 2
-    ? reloadContentScriptMv2(payload)
-    : reloadContentScriptMv3(payload);
+  const promise =
+    manifest.manifest_version == 2
+      ? reloadContentScriptMv2(payload)
+      : reloadContentScriptMv3(payload);
+  pendingReloads.add(promise);
+  promise.finally(() => pendingReloads.delete(promise));
+}
+
+export async function waitForPendingContentScriptReloads(): Promise<void> {
+  await Promise.allSettled(pendingReloads);
 }
 
 export async function reloadContentScriptMv3({
@@ -55,7 +62,7 @@ export async function reloadManifestContentScriptMv3(
     ]);
   }
 
-  await reExecuteInMatchingTabs(contentScript);
+  await reloadTabsForContentScript(contentScript);
 }
 
 export async function reloadRuntimeContentScriptMv3(
@@ -80,24 +87,14 @@ export async function reloadRuntimeContentScriptMv3(
   }
 
   await browser.scripting.updateContentScripts(matches);
-  await reExecuteInMatchingTabs(contentScript);
+  await reloadTabsForContentScript(contentScript);
 }
 
-/**
- * Re-runs a content script's JS files inside tabs that already have it
- * injected, instead of doing a full `tabs.reload()`. A full reload works, but
- * it navigates the page, which clears devtools console output - making it hard
- * to tell whether the reload actually picked up the change. Running the updated
- * files in-place keeps the page (and previous logs) around, so the new console
- * output shows up right next to the old output.
- */
-async function reExecuteInMatchingTabs(contentScript: ContentScript) {
-  if (!contentScript.js?.length) return;
-
+async function reloadTabsForContentScript(contentScript: ContentScript) {
+  const allTabs = await browser.tabs.query({});
   const matchPatterns = contentScript.matches.map(
     (match) => new MatchPattern(match),
   );
-  const allTabs = await browser.tabs.query({});
   const matchingTabs = allTabs.filter((tab) => {
     const url = tab.url;
     if (!url) return false;

--- a/packages/wxt/src/virtual/utils/reload-content-scripts.ts
+++ b/packages/wxt/src/virtual/utils/reload-content-scripts.ts
@@ -3,13 +3,13 @@ import { logger } from '../../utils/internal/logger';
 import { MatchPattern } from 'wxt/utils/match-patterns';
 import type { ReloadContentScriptPayload } from '../../utils/internal/dev-server-websocket';
 
-export function reloadContentScript(payload: ReloadContentScriptPayload) {
+export function reloadContentScript(
+  payload: ReloadContentScriptPayload,
+): Promise<void> {
   const manifest = browser.runtime.getManifest();
-  if (manifest.manifest_version == 2) {
-    void reloadContentScriptMv2(payload);
-  } else {
-    void reloadContentScriptMv3(payload);
-  }
+  return manifest.manifest_version == 2
+    ? reloadContentScriptMv2(payload)
+    : reloadContentScriptMv3(payload);
 }
 
 export async function reloadContentScriptMv3({
@@ -55,7 +55,7 @@ export async function reloadManifestContentScriptMv3(
     ]);
   }
 
-  await reloadTabsForContentScript(contentScript);
+  await reExecuteInMatchingTabs(contentScript);
 }
 
 export async function reloadRuntimeContentScriptMv3(
@@ -80,14 +80,24 @@ export async function reloadRuntimeContentScriptMv3(
   }
 
   await browser.scripting.updateContentScripts(matches);
-  await reloadTabsForContentScript(contentScript);
+  await reExecuteInMatchingTabs(contentScript);
 }
 
-async function reloadTabsForContentScript(contentScript: ContentScript) {
-  const allTabs = await browser.tabs.query({});
+/**
+ * Re-runs a content script's JS files inside tabs that already have it
+ * injected, instead of doing a full `tabs.reload()`. A full reload works, but
+ * it navigates the page, which clears devtools console output - making it hard
+ * to tell whether the reload actually picked up the change. Running the updated
+ * files in-place keeps the page (and previous logs) around, so the new console
+ * output shows up right next to the old output.
+ */
+async function reExecuteInMatchingTabs(contentScript: ContentScript) {
+  if (!contentScript.js?.length) return;
+
   const matchPatterns = contentScript.matches.map(
     (match) => new MatchPattern(match),
   );
+  const allTabs = await browser.tabs.query({});
   const matchingTabs = allTabs.filter((tab) => {
     const url = tab.url;
     if (!url) return false;
@@ -96,7 +106,11 @@ async function reloadTabsForContentScript(contentScript: ContentScript) {
   await Promise.all(
     matchingTabs.map(async (tab) => {
       try {
-        await browser.tabs.reload(tab.id!);
+        await browser.scripting.executeScript({
+          target: { tabId: tab.id! },
+          files: contentScript.js!,
+          world: contentScript.world,
+        });
       } catch (err) {
         logger.warn('Failed to reload tab:', err);
       }


### PR DESCRIPTION
### Overview

**Root cause**
When updating `app.config.ts`, the reload command for the extension was executed before the update process for the tabs finished, causing the Service Worker to be destroyed and the process to terminate midway.

**Changed**
Changed the structure to manage asynchronous processing with `Promises` and use `Promise.allSettled` to wait for the processing on all tabs to complete before reloading.

### Manual Testing

https://github.com/user-attachments/assets/142328f3-c84f-4a5d-b113-fee3e92216f8

### Related Issue
This PR closes #2131 
