### PR TITLE
fix: Change start point of wxt-demo

### DIFF
--- a/packages/wxt-demo/src/entrypoints/automount.content/index.ts
+++ b/packages/wxt-demo/src/entrypoints/automount.content/index.ts
@@ -2,14 +2,14 @@ import 'uno.css';
 import './style.css';
 
 export default defineContentScript({
-  matches: ['https://*.duckduckgo.com/*'],
+  matches: ['https://example.com/*'],
   cssInjectionMode: 'manifest',
 
   async main(ctx) {
     const dynamicUI = createIntegratedUi(ctx, {
       position: 'inline',
       append: 'after',
-      anchor: 'form[role=search]',
+      anchor: 'div',
       onMount: (container) => {
         const app = document.createElement('div');
         container.id = 'automount-anchor';
@@ -54,7 +54,7 @@ export default defineContentScript({
     const stopAutoMountButton = createIntegratedUi(ctx, {
       position: 'inline',
       append: 'last',
-      anchor: 'form[role=search]',
+      anchor: 'div',
       onMount: (container) => {
         const app = document.createElement('button');
         container.classList.add('flex', 'flex-justify-center');

--- a/packages/wxt-demo/src/entrypoints/automount.content/style.css
+++ b/packages/wxt-demo/src/entrypoints/automount.content/style.css
@@ -1,3 +1,3 @@
 :root {
-  color-scheme: dark;
+  color-scheme: light;
 }

--- a/packages/wxt-demo/src/entrypoints/ui.content/index.ts
+++ b/packages/wxt-demo/src/entrypoints/ui.content/index.ts
@@ -3,7 +3,7 @@ import './style.css';
 import manualStyle from './manual-style.css?inline';
 
 export default defineContentScript({
-  matches: ['https://*.duckduckgo.com/*'],
+  matches: ['https://example.com/*'],
   cssInjectionMode: 'ui',
 
   async main(ctx) {
@@ -15,7 +15,7 @@ export default defineContentScript({
       name: 'demo-ui',
       position: 'inline',
       append: 'before',
-      anchor: 'form[role=search]',
+      anchor: 'div',
       onMount: (container) => {
         const app = document.createElement('div');
         app.classList.add('m-4', 'text-red-500');

--- a/packages/wxt-demo/src/entrypoints/ui.content/manual-style.css
+++ b/packages/wxt-demo/src/entrypoints/ui.content/manual-style.css
@@ -1,4 +1,4 @@
 body {
   padding: 2rem;
-  background-color: blanchedalmond;
+  background-color: white;
 }

--- a/packages/wxt-demo/wxt.config.ts
+++ b/packages/wxt-demo/wxt.config.ts
@@ -21,7 +21,7 @@ export default defineConfig({
     open: true,
   },
   webExt: {
-    startUrls: ['https://duckduckgo.com'],
+    startUrls: ['https://example.com'],
   },
   example: {
     a: 'a',


### PR DESCRIPTION
### Overview
- **Startup URL migration**: Changed `webExt.startUrls` in `wxt.config.ts` from duckduckgo.com to example.com (done prior to this session).
- **Content script alignment**: Updated matches in ui.content/automount.content from duckduckgo to example.com. Replaced the duckduckgo-specific anchor 'form[role=search]' (search form) with div, which exists on example.com (the page's wrapping container).
- **Color scheme**: Replaced duckduckgo colors with a white base.

### Manual Testing

https://github.com/user-attachments/assets/70ed7823-52a1-4901-8c8e-5a39c2f4a114

### Related Issue
This PR fix #2564 
