### PR TITLE
feat: add getDebugInfo utility for browser and platform information

### DIFF
--- a/packages/wxt/package.json
+++ b/packages/wxt/package.json
@@ -135,6 +135,10 @@
       "types": "./dist/utils/content-script-context.d.mts",
       "default": "./dist/utils/content-script-context.mjs"
     },
+    "./utils/debug-info": {
+      "types": "./dist/utils/debug-info.d.mts",
+      "default": "./dist/utils/debug-info.mjs"
+    },
     "./utils/content-script-ui/types": {
       "types": "./dist/utils/content-script-ui/types.d.mts",
       "default": "./dist/utils/content-script-ui/types.mjs"

--- a/packages/wxt/src/utils/debug-info.ts
+++ b/packages/wxt/src/utils/debug-info.ts
@@ -1,0 +1,53 @@
+/** @module wxt/utils/debug-info */
+import { browser } from 'wxt/browser';
+
+/**
+ * Collect debug information about the current browser and platform.
+ *
+ * @example
+ *   ```ts
+ *   const info = await getDebugInfo();
+ *   // {
+ *   //   "extensionVersion": "1.0.0",
+ *   //   "browser": [
+ *   //     {
+ *   //       "brand": "Google Chrome",
+ *   //       "version": "..."
+ *   //     },
+ *   //     {
+ *   //       "brand": "Chromium",
+ *   //       "version": "..."
+ *   //     }
+ *   //   ],
+ *   //   "platform": {
+ *   //     "os": "Windows",
+ *   //     "arch": "x86"
+ *   //   }
+ *   // }
+ *   ```;
+ */
+export async function getDebugInfo() {
+  const debugInfo: Record<string, unknown> = {
+    extensionVersion: browser.runtime.getManifest().version,
+  };
+
+  if (import.meta.env.FIREFOX) {
+    // @ts-ignore
+    debugInfo.browser = await browser.runtime.getBrowserInfo();
+    debugInfo.platform = await browser.runtime.getPlatformInfo();
+  }
+
+  if (import.meta.env.CHROME) {
+    // @ts-ignore
+    const ua = await navigator.userAgentData.getHighEntropyValues([
+      'fullVersionList',
+      'architecture',
+      'platform',
+    ]);
+
+    debugInfo.browser = ua.fullVersionList;
+    debugInfo.platform = { os: ua.platform, arch: ua.architecture };
+  }
+
+  return debugInfo;
+}


### PR DESCRIPTION
### Overview

This PR adds a `getDebugInfo()` helper to make bug reports easier. 

I'm not sure if WXT accepts adding new helper functions to its api.

Few issues/doubts:
* Is `wxt/src/utils` the right place for it?
* I can unify the return types if you like. 
* `navigator.userAgentData` may not be available for privacy settings.

### Manual Testing

idk

### Related Issue

N/A