### PR TITLE
docs: Add FlowPick extension details to showcase

### DIFF
--- a/docs/assets/extension-showcase.yml
+++ b/docs/assets/extension-showcase.yml
@@ -539,3 +539,8 @@
 
 - # GringaChange
   chromeId: amkfidglmdkclmhgnnkicocfcgoplanp
+
+- # FlowPick - https://github.com/ezwebtools/flowpick
+  chromeId: mfinfkkabangbkanlfhhbokgfekjklea
+  firefoxSlug: flowpick
+  edgeId: egbfhgcifljmeaomlbhggplohemjombb


### PR DESCRIPTION
Adds [FlowPick](https://github.com/ezwebtools/flowpick) to the extension showcase — A powerful, all-in-one media resource sniffer and downloader extension. Automatically detect and bulk download videos (M3U8/HLS to MP4), audio, and images from any webpage. Privacy-focused with local conversion, built with WXT + Vue 3.
