### PR TITLE
fix(analytics): make autoTrack's cleanup function actually remove the click listener

### DIFF
--- a/packages/analytics/modules/analytics/client.ts
+++ b/packages/analytics/modules/analytics/client.ts
@@ -270,7 +270,7 @@ function createFrontendAnalytics(): Analytics {
       };
       root.addEventListener('click', onClick, { capture: true, passive: true });
       return () => {
-        root.removeEventListener('click', onClick);
+        root.removeEventListener('click', onClick, { capture: true });
       };
     },
   };


### PR DESCRIPTION
### Overview

<!-- Describe your changes and why you made them -->
`autoTrack()` returns a cleanup function that is [documented as removing the listeners it set up](https://github.com/wxt-dev/wxt/blob/9b46da88416042291bf63acc3a35bb12bcd61621/packages/analytics/modules/analytics/types.ts#L14-L18), but the returned function never removes anything.
```ts
root.addEventListener('click', onClick, { capture: true, passive: true });
return () => {
  root.removeEventListener('click', onClick); // capture defaults to false
};
```

The listener is registered with `capture: true` but removal is attempted with the default `capture: false`, so no listener matches and nothing is removed.

<details>
<summary>Related spec references</summary>
<div markdown="1">

[MDN, `removeEventListener()` Parameters](https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/removeEventListener#parameters),

> `options.capture`: A boolean value that specifies whether the event listener **to be removed** is registered as a capturing listener or not. If this parameter is absent, the default value `false` is assumed.

[DOM Standard, `removeEventListener()` method steps](https://dom.spec.whatwg.org/#dom-eventtarget-removeeventlistener):

> 1. Let capture be the result of flattening options.
> 2. If this's event listener list contains an event listener whose type is type, callback is callback, **and capture is capture**, then remove an event listener with this and that event listener.

[MDN, "Matching event listeners for removal"](https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/removeEventListener#matching_event_listeners_for_removal):

> the only option `removeEventListener()` checks is the `capture`/`useCapture` flag

</div>
</details>

So `capture` is the only option used for matching, and omitting it means `false`. `passive` is discarded by the "flatten options" step, so it does not need to be passed to `removeEventListener()`.


### Manual Testing

<!-- Describe how to test your changes to make sure the PR works as intended -->
Paste into any page's DevTools console (verified on Chrome 151):

```js
const btn = document.createElement('button');
document.body.append(btn);
let tracked = 0;
const onClick = () => tracked++;

document.addEventListener('click', onClick, { capture: true, passive: true });
const cleanup = () => document.removeEventListener('click', onClick); // before
// const cleanup = () => document.removeEventListener('click', onClick, { capture: true }); // after

btn.click();
cleanup();
btn.click();
console.log(tracked); // before: 2 (listener still attached), after: 1
```

### Related Issue

<!-- If this PR is related to an issue, please link it here -->

No existing issue.