### PR TITLE
fix: create missing Chromium profile before launch

### DIFF
--- a/packages/wxt/src/core/runners/__tests__/web-ext.test.ts
+++ b/packages/wxt/src/core/runners/__tests__/web-ext.test.ts
@@ -1,0 +1,42 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import webExt from 'web-ext';
+import { setFakeWxt } from '../../utils/testing/fake-objects';
+import { createWebExtRunner } from '../web-ext';
+
+vi.mock('web-ext', () => ({
+  default: {
+    cmd: {
+      run: vi.fn().mockResolvedValue({ exit: vi.fn() }),
+    },
+  },
+}));
+vi.mock('web-ext/util/logger', () => ({ consoleStream: {} }));
+
+describe('createWebExtRunner', () => {
+  beforeEach(() => {
+    setFakeWxt({
+      config: {
+        browser: 'chrome',
+        outDir: '/root/.output/chrome-mv3',
+        webExt: {
+          config: {
+            chromiumProfile: '/root/.wxt/chrome-data',
+            keepProfileChanges: true,
+          },
+        },
+      },
+    });
+  });
+
+  it('creates a missing custom Chromium profile before launching', async () => {
+    await createWebExtRunner().openBrowser();
+
+    expect(webExt.cmd.run).toHaveBeenCalledWith(
+      expect.objectContaining({
+        chromiumProfile: '/root/.wxt/chrome-data',
+        profileCreateIfMissing: true,
+      }),
+      { shouldExitProgram: false },
+    );
+  });
+});

--- a/packages/wxt/src/core/runners/web-ext.ts
+++ b/packages/wxt/src/core/runners/web-ext.ts
@@ -40,6 +40,7 @@ export function createWebExtRunner(): ExtensionRunner {
           : {
               chromiumBinary: wxtUserConfig?.binaries?.[wxt.config.browser],
               chromiumProfile: wxtUserConfig?.chromiumProfile,
+              profileCreateIfMissing: !!wxtUserConfig?.chromiumProfile,
               chromiumPref: defu(
                 wxtUserConfig?.chromiumPref,
                 DEFAULT_CHROMIUM_PREFS,


### PR DESCRIPTION
Summary

Pass `profileCreateIfMissing` to `web-ext` when a custom Chromium profile is configured.
Add regression coverage for the web-ext runner configuration.

Testing

bun run --filter wxt test run web-ext.test.ts
bun run --filter wxt check:default
bun run --filter wxt check:tsc-virtual

Fixes #2593