### PR TITLE
fix: Generate high resolution sourcemaps when injecting auto-imports

### DIFF
--- a/packages/wxt/src/builtin-modules/__tests__/unimport.test.ts
+++ b/packages/wxt/src/builtin-modules/__tests__/unimport.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it } from 'vitest';
+import { unimportPlugin } from '../unimport';
+import type { WxtResolvedUnimportOptions } from '../../types';
+
+const options = (): WxtResolvedUnimportOptions => ({
+  disabled: false,
+  eslintrc: { enabled: false, filePath: '', globalsPropValue: true },
+  presets: [{ from: 'wxt/browser', imports: ['browser'] }],
+});
+
+const transform = (
+  plugin: ReturnType<typeof unimportPlugin>,
+  code: string,
+  id: string,
+) => {
+  const transform = plugin.transform;
+  const handler =
+    typeof transform === 'function' ? transform : transform!.handler;
+  return handler.call({} as any, code, id) as Promise<
+    { code: string; map: { mappings: string; sources: string[] } } | undefined
+  >;
+};
+
+/**
+ * Sourcemap `mappings` are grouped by generated line (`;`), then by segment
+ * (`,`). A line-level sourcemap only has one segment per line, so counting
+ * segments tells us whether column information was included.
+ */
+const segmentsPerLine = (mappings: string) =>
+  mappings.split(';').map((line) => (line === '' ? 0 : line.split(',').length));
+
+describe('Unimport Module', () => {
+  describe('unimportPlugin', () => {
+    const id = '/src/utils/example.ts';
+    const code = [
+      'export function getExtensionId() {',
+      '  const id = browser.runtime.id;',
+      '  return id.toUpperCase();',
+      '}',
+      '',
+    ].join('\n');
+
+    it('should inject auto-imports', async () => {
+      const res = await transform(unimportPlugin(options()), code, id);
+
+      expect(res?.code).toContain("import { browser } from 'wxt/browser';");
+      expect(res?.code).toContain('browser.runtime.id');
+    });
+
+    it('should generate a sourcemap with column-level mappings', async () => {
+      const res = await transform(unimportPlugin(options()), code, id);
+
+      // Without `hires`, every line collapses to a single segment, which makes
+      // coverage tools treat the entire module as one statement.
+      // See https://github.com/wxt-dev/wxt/issues/2604
+      expect(Math.max(...segmentsPerLine(res!.map.mappings))).toBeGreaterThan(
+        1,
+      );
+    });
+
+    it('should include the module ID as the sourcemap source', async () => {
+      const res = await transform(unimportPlugin(options()), code, id);
+
+      expect(res!.map.sources).toEqual([id]);
+    });
+
+    it('should not transform files that do not use auto-imports', async () => {
+      const res = await transform(
+        unimportPlugin(options()),
+        'export const one = 1;\n',
+        id,
+      );
+
+      expect(res).toBeUndefined();
+    });
+
+    it('should not transform excluded files', async () => {
+      const res = await transform(
+        unimportPlugin(options()),
+        code,
+        '/node_modules/example/index.js',
+      );
+
+      expect(res).toBeUndefined();
+    });
+
+    it('should not transform non-JS files', async () => {
+      const res = await transform(
+        unimportPlugin(options()),
+        code,
+        '/src/a.css',
+      );
+
+      expect(res).toBeUndefined();
+    });
+  });
+});

--- a/packages/wxt/src/builtin-modules/unimport.ts
+++ b/packages/wxt/src/builtin-modules/unimport.ts
@@ -8,7 +8,8 @@ import type {
   EslintConfigVersion,
 } from '../types';
 import { type Unimport, createUnimport, toExports } from 'unimport';
-import UnimportPlugin from 'unimport/unplugin';
+import { defaultExcludes, defaultIncludes } from 'unimport/unplugin';
+import { createFilter, type FilterPattern, type Plugin } from 'vite';
 
 export default defineWxtModule({
   name: 'wxt:built-in:unimport',
@@ -64,10 +65,60 @@ export default defineWxtModule({
 
     // Add vite plugin
     addViteConfig(wxt, () => ({
-      plugins: [UnimportPlugin.vite(wxt.config.imports)],
+      plugins: [unimportPlugin(wxt.config.imports)],
     }));
   },
 });
+
+/**
+ * Vite plugin that injects auto-imports into modules.
+ *
+ * Equivalent to `UnimportPlugin.vite(options)`, but it generates a high
+ * resolution sourcemap. Unimport's unplugin calls `MagicString#generateMap()`
+ * with no options, which produces a line-level map with no `source`. Since
+ * auto-imports are injected at the top of the file, tools that rely on columns
+ * (like V8 code coverage) then see the entire module as a single statement,
+ * silently dropping it from coverage reports.
+ *
+ * `hires: 'boundary'` keeps columns accurate and is cheaper than `hires: true`.
+ *
+ * If unimport passes these options itself, this plugin can be dropped in favor
+ * of `UnimportPlugin.vite(options)` again.
+ *
+ * @see https://github.com/wxt-dev/wxt/issues/2604
+ * @see https://github.com/unjs/unimport/issues/562
+ */
+export function unimportPlugin(options: WxtResolvedUnimportOptions): Plugin {
+  // `include`/`exclude` aren't part of `UnimportOptions`, but unimport's
+  // unplugin accepts them, so keep honoring them.
+  const { include = defaultIncludes, exclude = defaultExcludes } = options as {
+    include?: FilterPattern;
+    exclude?: FilterPattern;
+  };
+  const filter = createFilter(include, exclude);
+  const unimport = createUnimport(options);
+  let initialized: Promise<void> | undefined;
+  const init = () => (initialized ??= unimport.init());
+
+  return {
+    name: 'wxt:unimport',
+    // Run after plugins that compile files to JS, like `@vitejs/plugin-vue`.
+    enforce: 'post',
+    buildStart: init,
+    async transform(code, id) {
+      if (!filter(id)) return;
+
+      await init();
+      const injected = await unimport.injectImports(code, id);
+      if (!injected.s.hasChanged()) return;
+
+      return {
+        code: injected.code,
+        map: injected.s.generateMap({ hires: 'boundary', source: id }),
+      };
+    },
+  };
+}
 
 async function getImportsDeclarationEntry(
   unimport: Unimport,

--- a/packages/wxt/src/testing/wxt-vitest-plugin.ts
+++ b/packages/wxt/src/testing/wxt-vitest-plugin.ts
@@ -13,7 +13,7 @@ import {
   resolveAppConfig,
 } from '../core/builders/vite/plugins';
 import { InlineConfig } from '../types';
-import UnimportPlugin from 'unimport/unplugin';
+import { unimportPlugin } from '../builtin-modules/unimport';
 import { registerWxt, wxt } from '../core/wxt';
 
 /**
@@ -44,7 +44,7 @@ export async function WxtVitest(
     resolveAppConfig(wxt.config),
     extensionApiMock(wxt.config),
   ];
-  plugins.push(UnimportPlugin.vite(wxt.config.imports));
+  plugins.push(unimportPlugin(wxt.config.imports));
 
   return plugins;
 }


### PR DESCRIPTION
### Overview

`unimport/unplugin` calls `MagicString#generateMap()` with no options, which defaults to `hires: false` — a line-level sourcemap. Because auto-imports are injected at the top of the file, every mapping points back at the first line of the original module, so tools that rely on columns (like V8 code coverage) see the whole module as a single statement.

The result: any module referencing an auto-imported variable (`browser`, `storage`, …) silently drops out of coverage reports, inflating the reported percentage and letting thresholds pass when they shouldn't.

This was originally fixed for the build path in #381, but #1412 replaced WXT's own `wxt:unimport` plugin with `UnimportPlugin.vite()` in **both** the build path and `WxtVitest()`, dropping the `hires` option along the way. So today both paths are affected, not just testing.

This PR restores the `wxt:unimport` plugin with the sourcemap options from #381 — `generateMap({ hires: 'boundary', source: id })`. `hires: 'boundary'` is enough to keep columns accurate and is cheaper than a full `hires: true` map.

To keep the maintenance surface minimal, the plugin is the pre-#1412 one plus the two things #1412 actually needed: `enforce: 'post'` and a regex `include`/`exclude` filter. The filter defaults are imported from `unimport/unplugin` (`defaultIncludes`/`defaultExcludes`) rather than copied, so they can't drift out of sync. Everything else — `dts` generation, the `autoImport` toggle — was unused by WXT and isn't reimplemented.

The plugin is shared by `packages/wxt/src/builtin-modules/unimport.ts` and `packages/wxt/src/testing/wxt-vitest-plugin.ts`, so build and test are fixed with one change.

The root cause is filed upstream as [unjs/unimport#562](https://github.com/unjs/unimport/issues/562) — the bare `s.generateMap()` is still on `main`, so every unplugin consumer is affected. If unimport changes its default, this plugin can go back to being `UnimportPlugin.vite(options)`; the JSDoc says so and links the ticket.

### Manual Testing

Added `packages/wxt/src/builtin-modules/__tests__/unimport.test.ts`, which asserts the generated sourcemap has more than one segment per line and that `sources` contains the module ID. Both assertions fail when `hires: 'boundary'`/`source` are removed.

End-to-end check with a probe module in `packages/wxt-demo` that uses `browser.runtime.id` across four branches, with a test covering only one of them:

```ts
// src/utils/coverage-probe.ts
export function probe(input: number) {
  const id = browser.runtime.id;
  if (input > 10) return `big:${id}`;
  if (input > 5) return `medium:${id}`;
  if (input > 0) return `small:${id}`;
  return `zero:${id}`;
}
```

```sh
bun run test run --coverage --coverage.include='src/utils/coverage-probe.ts' \
  --coverage.reporter=text src/utils/__tests__/coverage-probe.test.ts
```

Before — the module is invisible to the coverage reporter and reports a perfect score:

```
File               | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s
-------------------|---------|----------|---------|---------|------------------
-------------------|---------|----------|---------|---------|------------------
Statements   : 100% ( 0/0 )
Branches     : 100% ( 0/0 )
```

After — real numbers, with the uncovered branches correctly attributed:

```
File               | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s
-------------------|---------|----------|---------|---------|------------------
 coverage-probe.ts |    37.5 |    16.66 |     100 |    37.5 | 6-12
-------------------|---------|----------|---------|---------|------------------
Statements   : 37.5% ( 3/8 )
Branches     : 16.66% ( 1/6 )
```

(The probe files were only used for verification and are not part of this PR.)

Also ran the full `wxt` package suite (`bun run test run` → 53 files / 554 tests passing) and `bun run check` (ESLint, Oxlint, Publint, TypeScript) in `packages/wxt`.

### Related Issue

This PR closes #2604
