### PR TITLE
fix(wxt): tolerate the content script reload race in MV3 dev

### DIFF
--- a/packages/wxt/src/virtual/utils/reload-content-scripts.ts
+++ b/packages/wxt/src/virtual/utils/reload-content-scripts.ts
@@ -46,13 +46,30 @@ export async function reloadManifestContentScriptMv3(
     ]);
   } else {
     logger.debug('Registering new content script...');
-    await browser.scripting.registerContentScripts([
-      {
-        ...contentScript,
+    try {
+      await browser.scripting.registerContentScripts([
+        {
+          ...contentScript,
+          id,
+          css: contentScript.css ?? [],
+        },
+      ]);
+    } catch (err) {
+      // Two reload events for the same entrypoint can both read an empty
+      // registration above and both register; the loser throws "Duplicate
+      // script ID". The winner is registering this same script and reloads
+      // the tabs once it lands, so the loser has nothing left to do. It must
+      // not fall back to updateContentScripts (the winner's registration is
+      // not complete yet, so that throws "not fully registered") and must not
+      // reload tabs (they would come back before the script is registered).
+      const message = String((err as Error)?.message ?? err);
+      if (!message.includes('Duplicate script ID')) throw err;
+      logger.debug(
+        'Lost a registration race, the concurrent register owns it',
         id,
-        css: contentScript.css ?? [],
-      },
-    ]);
+      );
+      return;
+    }
   }
 
   await reloadTabsForContentScript(contentScript);


### PR DESCRIPTION
### Overview

In MV3 dev, `reloadManifestContentScriptMv3` registers a content script with a check-then-act sequence: `getRegisteredContentScripts()`, then `registerContentScripts()` if the id is absent. When two `wxt:reload-content-script` events for the same entrypoint arrive close together, both read an empty registration and both register; the loser throws `Duplicate script ID 'wxt:content-scripts/<name>.js'`.

Nothing catches it. `reloadContentScript` calls `void reloadContentScriptMv3(payload)`, and the WebSocket listener does not await it, so the rejection lands as an **unhandled promise rejection in the service worker**.

This PR catches the duplicate-id rejection inside `reloadManifestContentScriptMv3` and returns. The winner is registering the identical script and reloads the matching tabs once its registration lands, so the loser has nothing left to do.

Two alternatives that look reasonable and are not — both tried against a real dev session:

- **Falling back to `updateContentScripts`** throws `Script with ID '…' does not exist or is not fully registered`, because the winner's registration is still in flight. That rejection aborts before `reloadTabsForContentScript`, and the script is left unregistered.
- **Swallowing the error and continuing to `reloadTabsForContentScript`** reloads the tab before the winner's registration lands, so the page comes back without the content script.

The comment in the diff records both so neither gets reintroduced.

### Manual Testing

The race is timing-dependent, so it does not reproduce on demand. It shows up on an MV3 project in `wxt dev` where several content script entrypoints share source, so one save emits multiple reload events in quick succession.

I have been running this change as a local patch against `wxt@0.21.4` in a project whose Playwright suite records service-worker unhandled rejections and fails any test that sees one. Before the change, `Duplicate script ID` fired roughly twice per 23-spec run. After it, three consecutive runs recorded no `Duplicate script ID`, no `not fully registered`, and no other rejection; all 23 specs passed each time.

There are no existing tests under `packages/wxt/src/virtual/`, so none were added here. Happy to add one if there is a preferred harness for the virtual entrypoints.

### Related Issue

This PR closes #2609
