### PR TITLE
docs: Added Edge ID for SiteData to showcase

### DIFF
--- a/docs/assets/extension-showcase.yml
+++ b/docs/assets/extension-showcase.yml
@@ -374,6 +374,7 @@
 - # SiteData - Free Website Traffic Checker & Reverse AdSense Tool
   chromeId: emeakbgdecgmdjgegnejpppcnkcnoaen
   firefoxSlug: sitedata
+  edgeId: amlclomoobpjnacnfiilnmkkdhaceohi
 
 - # Livestream Chat Reader - Text-to-Speech for YouTube/Twitch chat
   chromeId: gpnckbhgpnjciklpoehkmligeaebigaa


### PR DESCRIPTION
## Summary

- Add the Microsoft Edge Add-ons ID to the existing SiteData showcase entry.
- Keep the existing Chrome and Firefox identifiers unchanged.

Edge listing: https://microsoftedge.microsoft.com/addons/detail/amlclomoobpjnacnfiilnmkkdhaceohi

## Testing

- Not run (YAML-only documentation update).