### PR TITLE
feat: Add apply option to addWxtPlugin to filter which endpoint plugin load

### DIFF
--- a/packages/analytics/modules/analytics/index.ts
+++ b/packages/analytics/modules/analytics/index.ts
@@ -73,9 +73,8 @@ export const analytics = createAnalytics(useAppConfig().analytics);
       }
     });
 
-    // Ensure analytics is initialized in every context, mainly the background.
-    // TODO: Once there's a way to filter which entrypoints a plugin is applied to, only apply this to the background
-    addWxtPlugin(wxt, pluginModuleId);
+    // Ensure analytics is initialized in the background only.
+    addWxtPlugin(wxt, pluginModuleId, (entry) => entry.type === 'background');
 
     // Fix issues with dependencies
     addViteConfig(wxt, () => ({

--- a/packages/wxt/e2e/tests/modules.test.ts
+++ b/packages/wxt/e2e/tests/modules.test.ts
@@ -243,6 +243,77 @@ describe('Module Helpers', () => {
 
       await expect(project.serializeOutput()).resolves.toContain(expectedText);
     });
+
+    it('should apply plugins only to entrypoints matching their filter', async () => {
+      const project = new TestProject();
+      project.addFile(
+        'entrypoints/background.ts',
+        'export default defineBackground(() => {})',
+      );
+      project.addFile(
+        'entrypoints/content.ts',
+        `
+          export default defineContentScript({
+            matches: ["*://*/*"],
+            main: () => {},
+          })
+        `,
+      );
+      project.addFile('entrypoints/popup/index.html', '<html></html>');
+      project.addFile('entrypoints/options/index.html', '<html></html>');
+
+      const backgroundPluginPath = project.addFile(
+        'modules/test/background-plugin.ts',
+        `export default defineWxtPlugin(() => console.log("BACKGROUND_PLUGIN"))`,
+      );
+      const popupPluginPath = project.addFile(
+        'modules/test/popup-plugin.ts',
+        `export default defineWxtPlugin(() => console.log("POPUP_PLUGIN"))`,
+      );
+      project.addFile(
+        'modules/test.ts',
+        `
+          import { defineWxtModule, addWxtPlugin } from 'wxt/modules';
+
+          export default defineWxtModule((wxt) => {
+            addWxtPlugin(wxt, "${normalizePath(backgroundPluginPath)}", (entrypoint) => entrypoint.type === 'background');
+            addWxtPlugin(wxt, "${normalizePath(popupPluginPath)}", (entrypoint) => entrypoint.name === 'popup');
+          });
+        `,
+      );
+
+      await project.build();
+
+      await expect(
+        project.serializeFile('.output/chrome-mv3/background.js'),
+      ).resolves.toContain('BACKGROUND_PLUGIN');
+      await expect(
+        project.serializeFile('.output/chrome-mv3/content-scripts/content.js'),
+      ).resolves.not.toContain('BACKGROUND_PLUGIN');
+
+      const getInjectedScript = async (htmlFile: string) => {
+        const html = await readFile(
+          project.resolvePath('.output/chrome-mv3', htmlFile),
+          'utf-8',
+        );
+        const match = html.match(/<script[^>]*\ssrc="([^"]+)"/);
+        if (!match) throw Error(`No script tag in ${htmlFile}`);
+        return readFile(
+          project.resolvePath(
+            '.output/chrome-mv3',
+            match[1].replace(/^\//, ''),
+          ),
+          'utf-8',
+        );
+      };
+
+      await expect(getInjectedScript('popup.html')).resolves.toContain(
+        'POPUP_PLUGIN',
+      );
+      await expect(getInjectedScript('options.html')).resolves.not.toContain(
+        'POPUP_PLUGIN',
+      );
+    });
   });
 
   describe('imports', () => {

--- a/packages/wxt/e2e/tests/output-structure.test.ts
+++ b/packages/wxt/e2e/tests/output-structure.test.ts
@@ -381,7 +381,7 @@ describe('Output Directory Structure', () => {
       .toMatchInlineSnapshot(`
         ".output/chrome-mv3/background.js
         ----------------------------------------
-        import { n as logHello } from "./chunks/_virtual_wxt-plugins-BdnAIYoG.js";
+        import { t as logHello } from "./chunks/log-DNePel8J.js";
         function defineBackground(arg) {
         	if (arg == null || typeof arg === "function") return { main: arg };
         	return arg;

--- a/packages/wxt/src/core/builders/vite/plugins/__tests__/wxtPluginLoader.test.ts
+++ b/packages/wxt/src/core/builders/vite/plugins/__tests__/wxtPluginLoader.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest';
+import { getPluginModules } from '../wxtPluginLoader';
+import {
+  fakeBackgroundEntrypoint,
+  fakeContentScriptEntrypoint,
+} from '../../../../utils/testing/fake-objects';
+import type { WxtPluginEntry } from '../../../../../types';
+
+describe('Plugin Loader', () => {
+  describe('getPluginModules', () => {
+    const background = fakeBackgroundEntrypoint();
+    const contentScript = fakeContentScriptEntrypoint();
+
+    it('includes plugins without an apply function', () => {
+      const plugins: WxtPluginEntry[] = [{ module: 'a' }];
+      expect(getPluginModules(plugins, background)).toEqual(['a']);
+    });
+
+    it('includes only plugins whose apply function returns true', () => {
+      const plugins: WxtPluginEntry[] = [
+        { module: 'a', apply: (entry) => entry.type === 'background' },
+        { module: 'b', apply: (entry) => entry.type === 'content-script' },
+      ];
+      expect(getPluginModules(plugins, background)).toEqual(['a']);
+      expect(getPluginModules(plugins, contentScript)).toEqual(['b']);
+    });
+
+    it('includes every plugin when the entrypoint is unresolved', () => {
+      const plugins: WxtPluginEntry[] = [
+        { module: 'a', apply: () => false },
+        { module: 'b' },
+      ];
+      expect(getPluginModules(plugins, undefined)).toEqual(['a', 'b']);
+    });
+  });
+});

--- a/packages/wxt/src/core/builders/vite/plugins/resolveVirtualModules.ts
+++ b/packages/wxt/src/core/builders/vite/plugins/resolveVirtualModules.ts
@@ -3,6 +3,7 @@ import { resolve } from 'path';
 import type { Plugin } from 'vite';
 import { ResolvedConfig } from '../../../../types';
 import { normalizePath } from '../../../utils';
+import { getEntrypointName } from '../../../utils/entrypoints';
 import {
   VirtualModuleId,
   virtualModuleNames,
@@ -40,7 +41,16 @@ export function resolveVirtualModules(config: ResolvedConfig): Plugin[] {
             resolve(config.wxtModuleDir, `dist/virtual/${name}.mjs`),
             'utf-8',
           );
-          return template.replace(`virtual:user-${name}`, inputPath);
+          const entrypointName = getEntrypointName(
+            config.entrypointsDir,
+            inputPath,
+          );
+          return template
+            .replace(`virtual:user-${name}`, inputPath)
+            .replace(
+              'virtual:wxt-plugins',
+              `virtual:wxt-plugins?entrypoint=${encodeURIComponent(entrypointName)}`,
+            );
         },
       },
     };

--- a/packages/wxt/src/core/builders/vite/plugins/wxtPluginLoader.ts
+++ b/packages/wxt/src/core/builders/vite/plugins/wxtPluginLoader.ts
@@ -2,8 +2,19 @@ import { parseHTML } from 'linkedom';
 import type * as vite from 'vite';
 import { normalizePath } from '../../../utils';
 import { getEntrypointName } from '../../../utils/entrypoints';
-import { Entrypoint, ResolvedConfig } from '../../../../types';
+import { Entrypoint, ResolvedConfig, WxtPluginEntry } from '../../../../types';
 import { wxt } from '../../../wxt';
+
+export function getPluginModules(
+  plugins: WxtPluginEntry[],
+  entrypoint: Entrypoint | undefined,
+): string[] {
+  return plugins
+    .filter(
+      (plugin) => entrypoint == null || (plugin.apply?.(entrypoint) ?? true),
+    )
+    .map((plugin) => plugin.module);
+}
 
 /**
  * Resolve and load plugins for each entrypoint. This handles both JS
@@ -27,14 +38,6 @@ export function wxtPluginLoader(config: ResolvedConfig): vite.Plugin {
     return wxt.entrypoints.find(
       (entry) => entry.name === entrypointNameFromQueryParam,
     );
-  }
-
-  function getPluginModules(entrypoint: Entrypoint | undefined): string[] {
-    return config.plugins
-      .filter(
-        (plugin) => entrypoint == null || (plugin.apply?.(entrypoint) ?? true),
-      )
-      .map((plugin) => plugin.module);
   }
 
   return {
@@ -66,7 +69,7 @@ export function wxtPluginLoader(config: ResolvedConfig): vite.Plugin {
           bareId.startsWith(`${virtualModuleId}?`)
         ) {
           // Import and init only the plugins that apply to this entrypoint
-          const modules = getPluginModules(entrypoint);
+          const modules = getPluginModules(config.plugins, entrypoint);
           const imports = modules
             .map(
               (module, i) =>

--- a/packages/wxt/src/core/builders/vite/plugins/wxtPluginLoader.ts
+++ b/packages/wxt/src/core/builders/vite/plugins/wxtPluginLoader.ts
@@ -1,12 +1,15 @@
 import { parseHTML } from 'linkedom';
 import type * as vite from 'vite';
 import { normalizePath } from '../../../utils';
-import { ResolvedConfig } from '../../../../types';
+import { getEntrypointName } from '../../../utils/entrypoints';
+import { Entrypoint, ResolvedConfig } from '../../../../types';
+import { wxt } from '../../../wxt';
 
 /**
  * Resolve and load plugins for each entrypoint. This handles both JS
  * entrypoints via the `virtual:wxt-plugins` import, and HTML files by adding
- * `virtual:wxt-html-plugins` to the document's `<head>`
+ * `virtual:wxt-html-plugins` to the document's `<head>`. Accepts an optional
+ * `?entrypoint=<name>` query to evaluate plugin `apply` hooks per request.
  */
 export function wxtPluginLoader(config: ResolvedConfig): vite.Plugin {
   const virtualModuleId = 'virtual:wxt-plugins';
@@ -14,45 +17,72 @@ export function wxtPluginLoader(config: ResolvedConfig): vite.Plugin {
   const virtualHtmlModuleId = 'virtual:wxt-html-plugins';
   const resolvedVirtualHtmlModuleId = '\0' + virtualHtmlModuleId;
 
+  function getEntrypointFromId(id: string): Entrypoint | undefined {
+    const queryIndex = id.indexOf('?');
+    if (queryIndex === -1) return undefined;
+    const entrypointNameFromQueryParam = new URLSearchParams(
+      id.slice(queryIndex),
+    ).get('entrypoint');
+    if (!entrypointNameFromQueryParam) return undefined;
+    return wxt.entrypoints.find(
+      (entry) => entry.name === entrypointNameFromQueryParam,
+    );
+  }
+
+  function getPluginModules(entrypoint: Entrypoint | undefined): string[] {
+    return config.plugins
+      .filter(
+        (plugin) => entrypoint == null || (plugin.apply?.(entrypoint) ?? true),
+      )
+      .map((plugin) => plugin.module);
+  }
+
   return {
     name: 'wxt:plugin-loader',
     resolveId: {
       filter: {
         id: [
-          new RegExp(`^${virtualModuleId}$`),
-          new RegExp(`^${virtualHtmlModuleId}$`),
+          new RegExp(`^${virtualModuleId}`),
+          new RegExp(`^${virtualHtmlModuleId}`),
         ],
       },
       handler(id) {
-        if (id === virtualModuleId) {
-          return resolvedVirtualModuleId;
-        }
-
-        return resolvedVirtualHtmlModuleId;
+        return '\0' + id;
       },
     },
     load: {
       filter: {
         id: [
-          new RegExp(`^${resolvedVirtualModuleId}$`),
-          new RegExp(`^${resolvedVirtualHtmlModuleId}$`),
+          new RegExp(`^${resolvedVirtualModuleId}`),
+          new RegExp(`^${resolvedVirtualHtmlModuleId}`),
         ],
       },
       handler(id) {
-        if (id === resolvedVirtualModuleId) {
-          // Import and init all plugins
-          const imports = config.plugins
+        const bareId = id.slice(1);
+        const entrypoint = getEntrypointFromId(bareId);
+
+        if (
+          bareId === virtualModuleId ||
+          bareId.startsWith(`${virtualModuleId}?`)
+        ) {
+          // Import and init only the plugins that apply to this entrypoint
+          const modules = getPluginModules(entrypoint);
+          const imports = modules
             .map(
-              (plugin, i) =>
-                `import initPlugin${i} from '${normalizePath(plugin)}';`,
+              (module, i) =>
+                `import initPlugin${i} from '${normalizePath(module)}';`,
             )
             .join('\n');
-          const initCalls = config.plugins
+          const initCalls = modules
             .map((_, i) => `  initPlugin${i}();`)
             .join('\n');
           return `${imports}\n\nexport function initPlugins() {\n${initCalls}\n}`;
         } else {
-          return `import { initPlugins } from '${virtualModuleId}';
+          // Forward resolved entrypoint to match the JS module.
+          const jsModuleId = entrypoint
+            ? `${virtualModuleId}?entrypoint=${encodeURIComponent(entrypoint.name)}`
+            : virtualModuleId;
+          return `import { initPlugins } from '${jsModuleId}';
             try {
               initPlugins();
             } catch (err) {
@@ -64,11 +94,24 @@ export function wxtPluginLoader(config: ResolvedConfig): vite.Plugin {
     transformIndexHtml: {
       // Use "pre" so the new script is added before vite bundles all the scripts
       order: 'pre',
-      handler(html, _ctx) {
+      // `_ctx` -> `ctx` To access entrypoint info for per-page plugin filtering.
+      handler(html, ctx) {
+        const entrypointName = getEntrypointName(
+          config.entrypointsDir,
+          ctx.filename,
+        );
+        const entrypoint = wxt.entrypoints.find(
+          (entry) => entry.name === entrypointName,
+        );
+        const query = entrypoint
+          ? `?entrypoint=${encodeURIComponent(entrypoint.name)}`
+          : '';
+        const htmlModuleId = `${virtualHtmlModuleId}${query}`;
+
         const src =
           config.command === 'serve'
-            ? `${config.dev.server?.origin}/@id/${virtualHtmlModuleId}`
-            : virtualHtmlModuleId;
+            ? `${config.dev.server?.origin}/@id/${htmlModuleId}`
+            : htmlModuleId;
 
         const { document } = parseHTML(html);
         const existing = document.querySelector(`script[src='${src}']`);

--- a/packages/wxt/src/core/utils/building/find-entrypoints.ts
+++ b/packages/wxt/src/core/utils/building/find-entrypoints.ts
@@ -150,6 +150,9 @@ export async function findEntrypoints(): Promise<Entrypoint[]> {
     skipped: isEntrypointSkipped(entry),
   }));
 
+  // Expose the latest entrypoints
+  wxt.entrypoints = entrypoints;
+
   await wxt.hooks.callHook('entrypoints:resolved', wxt, entrypoints);
 
   wxt.logger.debug('All entrypoints:', entrypoints);

--- a/packages/wxt/src/core/utils/testing/fake-objects.ts
+++ b/packages/wxt/src/core/utils/testing/fake-objects.ts
@@ -320,6 +320,7 @@ export const fakeWxt = fakeObjectCreator<Wxt>(() => ({
   pm: mock(),
   server: faker.helpers.arrayElement([undefined, fakeWxtDevServer()]),
   builder: mock(),
+  entrypoints: [],
 }));
 
 export const fakeWxtDevServer = fakeObjectCreator<WxtDevServer>(() => ({

--- a/packages/wxt/src/core/wxt.ts
+++ b/packages/wxt/src/core/wxt.ts
@@ -56,6 +56,7 @@ export async function registerWxt(
     pm,
     builder,
     server: undefined,
+    entrypoints: [],
   };
 
   await initWxtModules();

--- a/packages/wxt/src/modules.ts
+++ b/packages/wxt/src/modules.ts
@@ -129,16 +129,26 @@ export function addViteConfig(
  *
  * @example
  *   export default defineWxtModule((wxt) => {
- *     addWxtPlugin(wxt, 'wxt-module-analytics/client-plugin');
+ *     addWxtPlugin(
+ *       wxt,
+ *       'wxt-module-analytics/background-plugin',
+ *       (entrypoint) => entrypoint.type === 'background',
+ *     );
  *   });
  *
  * @param wxt The wxt instance provided by the module's setup function.
  * @param plugin An import from an NPM module, or an absolute file path to the
  *   file to load at runtime.
+ * @param apply Optional. Return `true` to load the plugin in the given
+ *   entrypoint. Defaults to loading the plugin in every entrypoint.
  */
-export function addWxtPlugin(wxt: Wxt, plugin: string): void {
+export function addWxtPlugin(
+  wxt: Wxt,
+  plugin: string,
+  apply?: (entrypoint: Entrypoint) => boolean,
+): void {
   wxt.hooks.hook('config:resolved', (wxt) => {
-    wxt.config.plugins.push(plugin);
+    wxt.config.plugins.push({ module: plugin, apply });
   });
 }
 

--- a/packages/wxt/src/types.ts
+++ b/packages/wxt/src/types.ts
@@ -1527,6 +1527,11 @@ export interface Wxt {
   server?: WxtDevServer;
   /** The module in charge of executing all the build steps. */
   builder: WxtBuilder;
+  /**
+   * Refreshed each time entrypoints are resolved. Empty until initial
+   * resolution.
+   */
+  entrypoints: Entrypoint[];
 }
 
 export interface ResolvedConfig {
@@ -1649,13 +1654,28 @@ export interface ResolvedConfig {
   builtinModules: WxtModule<any>[];
   userModules: WxtModuleWithMetadata<any>[];
   /**
-   * An array of string to import plugins from. These paths should be resolvable
-   * by vite, and they should `export default defineWxtPlugin(...)`.
+   * Plugins registered via `addWxtPlugin`. Each entry's `module` should be
+   * resolvable by vite, and should `export default defineWxtPlugin(...)`. An
+   * optional `apply` function restricts which entrypoints the plugin loads in.
    *
    * @example
-   *   ['@wxt-dev/module-vue/plugin', 'wxt-module-google-analytics/plugin'];
+   *   [{ module: '@wxt-dev/module-vue/plugin' }];
    */
-  plugins: string[];
+  plugins: WxtPluginEntry[];
+}
+
+/**
+ * A plugin registered via `addWxtPlugin`, along with an optional `apply`
+ * function controlling which entrypoints it's loaded in.
+ */
+export interface WxtPluginEntry {
+  /** Import path or absolute file path to the plugin module. */
+  module: string;
+  /**
+   * Return `true` to include the plugin in this entrypoint. When omitted, the
+   * plugin is included in every entrypoint.
+   */
+  apply?: (entrypoint: Entrypoint) => boolean;
 }
 
 export interface FsCache {


### PR DESCRIPTION
### Overview
By embedding the entrypoint identifier as a query parameter (`?entrypoint=<name>`) into the virtual module ID, the entrypoint is determined dynamically upon module resolution. Each plugin's apply hook is then evaluated using the extracted entrypoint to generate code containing only the matching plugins.

### Manual Testing
Prepare file which use `addWxtPlugin` and specify 'background' entry point.  After it, run build and this commant under /packages/qwxt-demo directory `grep -rl "test-plugin" .output/chrome-mv3`. This result confirms that the build process run  with the specifiled entrypoint.

### Before implementation
<img width="471" height="158" alt="image" src="https://github.com/user-attachments/assets/bbce4d90-e3c4-4819-9513-4247d3f2a0e7" />

### After implentation
<img width="348" height="30" alt="image" src="https://github.com/user-attachments/assets/66544ba1-d4ea-4040-9138-afcecde83552" />

### Related Issue

<!-- If this PR is related to an issue, please link it here -->

This PR closes #1627 
