### PR TITLE
fix: keep dev worker URLs same-origin

### DIFF
--- a/packages/wxt/e2e/tests/dev.test.ts
+++ b/packages/wxt/e2e/tests/dev.test.ts
@@ -84,4 +84,73 @@ describe('Dev Mode', () => {
       await freePort();
     }
   });
+
+  it.each(['firefox', 'safari'])(
+    'should leave Vite worker URLs unchanged for %s extension pages',
+    async (browser) => {
+      const project = TestProject.simple();
+      project.addFile('worker.ts', 'self.postMessage("ready")');
+
+      const server = await project.startServer({
+        browser,
+        webExt: { disabled: true },
+      });
+      try {
+        const response = await fetch(`${server.origin}/worker.ts?worker`);
+        expect(response.ok).toBe(true);
+        const code = await response.text();
+
+        expect(code).toContain(
+          `${server.origin}/worker.ts?worker_file&type=module`,
+        );
+        expect(code).not.toContain('URL.createObjectURL');
+      } finally {
+        await server.stop();
+      }
+    },
+  );
+
+  it('should use same-origin blob URLs for Vite workers in Chromium extension pages', async () => {
+    const project = TestProject.simple();
+    project.addFile('worker.ts', 'self.postMessage("ready")');
+
+    const server = await project.startServer({
+      webExt: { disabled: true },
+    });
+    const loadWorkerModule = async (query: string) => {
+      const response = await fetch(`${server.origin}/worker.ts${query}`);
+      expect(response.ok).toBe(true);
+      return await response.text();
+    };
+
+    try {
+      const workerConstructorModule = await loadWorkerModule('?worker');
+      const inlineWorkerModule = await loadWorkerModule('?worker&inline');
+      const workerUrlModule = await loadWorkerModule('?worker&url');
+      const workerUrl = `${server.origin}/worker.ts?worker_file&type=module`;
+      const workerConstructorScript = `URL.revokeObjectURL(self.location.href);import ${JSON.stringify(workerUrl)};`;
+
+      for (const code of [workerConstructorModule, inlineWorkerModule]) {
+        expect(code).toContain(JSON.stringify(workerConstructorScript));
+      }
+      expect(workerUrlModule).toContain('__wxtBufferMessage');
+      expect(workerUrlModule).toContain(workerUrl);
+      expect(workerUrlModule).not.toContain('URL.revokeObjectURL');
+      for (const code of [
+        workerConstructorModule,
+        inlineWorkerModule,
+        workerUrlModule,
+      ]) {
+        expect(code).toContain('URL.createObjectURL(new Blob');
+      }
+      expect(workerConstructorModule).not.toMatch(
+        /new Worker\(\s*"http:\/\/localhost:/,
+      );
+      expect(workerUrlModule).not.toMatch(
+        /export default "http:\/\/localhost:/,
+      );
+    } finally {
+      await server.stop();
+    }
+  });
 });

--- a/packages/wxt/src/core/builders/vite/index.ts
+++ b/packages/wxt/src/core/builders/vite/index.ts
@@ -97,6 +97,7 @@ export async function createViteBuilder(
       wxtPlugins.devHtmlPrerender(wxtConfig, server),
       wxtPlugins.resolveVirtualModules(wxtConfig),
       wxtPlugins.devServerGlobals(wxtConfig, server),
+      wxtPlugins.devServerWorkers(wxtConfig),
       wxtPlugins.tsconfigPaths(wxtConfig),
       wxtPlugins.noopBackground(),
       wxtPlugins.globals(wxtConfig),

--- a/packages/wxt/src/core/builders/vite/plugins/__tests__/devServerWorkers.test.ts
+++ b/packages/wxt/src/core/builders/vite/plugins/__tests__/devServerWorkers.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from 'vitest';
+import { replaceDevServerWorkerUrl } from '../devServerWorkers';
+
+const devServerOrigin = 'http://localhost:3000';
+const workerUrl = `${devServerOrigin}/worker.ts?worker_file&type=module`;
+
+describe('Dev Server Workers Plugin', () => {
+  it('should replace constructor worker URLs with self-revoking blob URLs', () => {
+    const code = `export default function WorkerWrapper(options) {
+      return new Worker(${JSON.stringify(workerUrl)}, {
+        type: "module",
+        name: options?.name
+      });
+    }`;
+
+    const actual = replaceDevServerWorkerUrl(code, devServerOrigin, true);
+
+    expect(actual).toContain('URL.createObjectURL(new Blob');
+    expect(actual).toContain(
+      JSON.stringify(
+        `URL.revokeObjectURL(self.location.href);import ${JSON.stringify(workerUrl)};`,
+      ),
+    );
+    expect(actual).toContain('type: "module"');
+    expect(actual).not.toContain(`new Worker(${JSON.stringify(workerUrl)}`);
+  });
+
+  it('should keep imported worker URL blobs reusable', () => {
+    const code = `export default ${JSON.stringify(workerUrl)}`;
+
+    const actual = replaceDevServerWorkerUrl(code, devServerOrigin, false);
+
+    expect(actual).toContain('URL.createObjectURL(new Blob');
+    expect(actual).toContain('__wxtBufferMessage');
+    expect(actual).toContain('event.stopImmediatePropagation()');
+    expect(actual).toContain(workerUrl);
+    expect(actual).not.toContain('URL.revokeObjectURL');
+    expect(actual).not.toContain(`export default ${JSON.stringify(workerUrl)}`);
+  });
+
+  it('should only replace the generated worker URL expression', () => {
+    const code = `const unrelated = ${JSON.stringify(workerUrl)};\nexport default ${JSON.stringify(workerUrl)}`;
+
+    const actual = replaceDevServerWorkerUrl(code, devServerOrigin, false);
+
+    expect(actual).toContain(`const unrelated = ${JSON.stringify(workerUrl)}`);
+    expect(actual).not.toContain(`export default ${JSON.stringify(workerUrl)}`);
+    expect(replaceDevServerWorkerUrl(actual, devServerOrigin, false)).toBe(
+      actual,
+    );
+  });
+
+  it.each([
+    'https://example.com/worker.ts?worker_file&type=module',
+    `${devServerOrigin}/worker.ts`,
+    'http://127.0.0.1:3000/worker.ts?worker_file&type=module',
+  ])('should ignore non-dev-server worker URL %s', (url) => {
+    const code = `export default ${JSON.stringify(url)}`;
+
+    expect(replaceDevServerWorkerUrl(code, devServerOrigin, false)).toBe(code);
+  });
+});

--- a/packages/wxt/src/core/builders/vite/plugins/devServerWorkers.ts
+++ b/packages/wxt/src/core/builders/vite/plugins/devServerWorkers.ts
@@ -1,0 +1,130 @@
+import type * as vite from 'vite';
+import type { ResolvedConfig } from '../../../../types';
+
+const workerRequestRE = /(?:\?|&)worker(?:&|$)/;
+const urlRequestRE = /(?:\?|&)url(?:&|$)/;
+const workerConstructorUrlRE = /new Worker\(\s*("(?:[^"\\]|\\[\s\S])*")/;
+const workerUrlExportRE = /export default\s+("(?:[^"\\]|\\[\s\S])*")/;
+
+/**
+ * Ensures workers created by extension pages remain same-origin in dev mode.
+ *
+ * Vite normally points workers at its HTTP dev server. Chromium extension pages
+ * use a `chrome-extension://` origin, so Chromium 148+ rejects those
+ * cross-origin worker URLs. A blob script inherits the extension page's origin
+ * while still loading the source from Vite.
+ */
+export function devServerWorkers(wxtConfig: ResolvedConfig): vite.Plugin {
+  let devServerOrigin: string | undefined;
+
+  return {
+    name: 'wxt:dev-server-workers',
+    apply(_, { command }) {
+      // Keep other engines on their existing dev-server path; the reported
+      // same-origin enforcement regression is specific to Chromium.
+      return (
+        command === 'serve' &&
+        wxtConfig.browser !== 'firefox' &&
+        wxtConfig.browser !== 'safari'
+      );
+    },
+    configResolved(viteConfig) {
+      devServerOrigin = viteConfig.server.origin;
+    },
+    transform: {
+      order: 'post',
+      filter: {
+        id: workerRequestRE,
+      },
+      handler(code, id) {
+        if (devServerOrigin == null || !workerRequestRE.test(id)) return;
+
+        const transformed = replaceDevServerWorkerUrl(
+          code,
+          devServerOrigin,
+          !urlRequestRE.test(id),
+        );
+        if (transformed === code) return;
+
+        return {
+          code: transformed,
+          map: null,
+        };
+      },
+    },
+  };
+}
+
+export function replaceDevServerWorkerUrl(
+  code: string,
+  devServerOrigin: string,
+  shouldRevokeBlobUrl: boolean,
+) {
+  const match = (
+    shouldRevokeBlobUrl ? workerConstructorUrlRE : workerUrlExportRE
+  ).exec(code);
+  const urlLiteral = match?.[1];
+  if (match == null || urlLiteral == null) return code;
+
+  let value: unknown;
+  try {
+    value = JSON.parse(urlLiteral);
+  } catch {
+    return code;
+  }
+  if (
+    typeof value !== 'string' ||
+    !isDevServerWorkerUrl(value, devServerOrigin)
+  ) {
+    return code;
+  }
+
+  const workerScript = createWorkerScript(value, shouldRevokeBlobUrl);
+  const blobUrl = `URL.createObjectURL(new Blob([${JSON.stringify(workerScript)}], { type: "text/javascript" }))`;
+  const start = match.index + match[0].length - urlLiteral.length;
+  return code.slice(0, start) + blobUrl + code.slice(start + urlLiteral.length);
+}
+
+function createWorkerScript(url: string, shouldRevokeBlobUrl: boolean) {
+  if (shouldRevokeBlobUrl) {
+    // Constructor imports create a fresh blob on every call, so the worker can
+    // release it immediately after startup.
+    return `URL.revokeObjectURL(self.location.href);import ${JSON.stringify(url)};`;
+  }
+
+  // `?worker&url` does not expose Vite's `{ type: "module" }` constructor
+  // option. Dynamic import keeps the blob valid for both classic and module
+  // workers. Buffer early messages until the imported module is ready, and
+  // recreate them because stopped events cannot be dispatched again.
+  return [
+    'const __wxtMessages=[];',
+    'const __wxtBufferMessage=(event)=>{',
+    'event.stopImmediatePropagation();',
+    '__wxtMessages.push(new MessageEvent("message",{',
+    'data:event.data,origin:event.origin,lastEventId:event.lastEventId,',
+    'source:event.source,ports:event.ports',
+    '}));',
+    '};',
+    'self.addEventListener("message",__wxtBufferMessage);',
+    `import(${JSON.stringify(url)}).then(()=>{`,
+    'self.removeEventListener("message",__wxtBufferMessage);',
+    'for(const event of __wxtMessages)self.dispatchEvent(event);',
+    '__wxtMessages.length=0;',
+    '},(error)=>{',
+    'self.removeEventListener("message",__wxtBufferMessage);',
+    'setTimeout(()=>{throw error});',
+    '});',
+  ].join('');
+}
+
+function isDevServerWorkerUrl(value: string, devServerOrigin: string) {
+  try {
+    const url = new URL(value);
+    return (
+      url.origin === new URL(devServerOrigin).origin &&
+      url.searchParams.has('worker_file')
+    );
+  } catch {
+    return false;
+  }
+}

--- a/packages/wxt/src/core/builders/vite/plugins/index.ts
+++ b/packages/wxt/src/core/builders/vite/plugins/index.ts
@@ -1,5 +1,6 @@
 export * from './devHtmlPrerender';
 export * from './devServerGlobals';
+export * from './devServerWorkers';
 export * from './resolveVirtualModules';
 export * from './tsconfigPaths';
 export * from './noopBackground';


### PR DESCRIPTION
### Overview

In Chromium dev mode, Vite's `?worker` and `?worker&url` transforms expose localhost worker URLs to extension pages. Those pages have a `chrome-extension://` origin, so Chrome 148+ rejects the cross-origin dedicated worker URL and can terminate the render process.

Add a Chromium-only Vite dev plugin that replaces Vite's generated worker URL with an extension-origin Blob shim while loading the worker module from the dev server. Constructor imports revoke their one-shot Blob URL; reusable `?worker&url` imports keep their URL alive and buffer early messages until the module is ready. Firefox and Safari retain their existing dev-server path because their extension Blob-worker/CSP behavior differs.

Production builds are unchanged.

### Manual Testing

- `bun run --filter wxt test run src/core/builders/vite/plugins/__tests__/devServerWorkers.test.ts e2e/tests/dev.test.ts`
- `bun run --filter wxt test run`
- `bun run --filter wxt check`
- Tested an unpacked Chromium MV3 extension with `?worker`, two reused `?worker&url` workers, immediate messages, and transferred `MessagePort`s; all returned `ready`.
- Tested the unchanged Firefox MV2 direct-worker path with the same message/port flow.

### Related Issue

This PR closes #2599
