### PR TITLE
docs: flatten content script UI options

### DIFF
--- a/docs/public/_redirects
+++ b/docs/public/_redirects
@@ -4,6 +4,11 @@
 # Old URLs -> New URLs
 
 # OLD
+# https://github.com/wxt-dev/wxt/issues/1452
+/api/reference/wxt/utils/content-script-ui/integrated/type-aliases/IntegratedContentScriptUiOptions.html /api/reference/wxt/utils/content-script-ui/integrated/interfaces/IntegratedContentScriptUiOptions.html
+/api/reference/wxt/utils/content-script-ui/iframe/type-aliases/IframeContentScriptUiOptions.html /api/reference/wxt/utils/content-script-ui/iframe/interfaces/IframeContentScriptUiOptions.html
+/api/reference/wxt/utils/content-script-ui/shadow-root/type-aliases/ShadowRootContentScriptUiOptions.html /api/reference/wxt/utils/content-script-ui/shadow-root/interfaces/ShadowRootContentScriptUiOptions.html
+
 /config.html                    /api/reference/wxt/interfaces/InlineConfig.html
 /api/config.html                /api/reference/wxt/interfaces/InlineConfig.html
 /api/config                     /api/reference/wxt/interfaces/InlineConfig.html

--- a/packages/wxt/src/utils/content-script-ui/iframe.ts
+++ b/packages/wxt/src/utils/content-script-ui/iframe.ts
@@ -57,6 +57,11 @@ export interface IframeContentScriptUi<
   wrapper: HTMLDivElement;
 }
 
+/**
+ * {@inheritDoc wxt/utils/content-script-ui/types!ContentScriptUiOptions}
+ *
+ * @interface
+ */
 export type IframeContentScriptUiOptions<TMounted> =
   ContentScriptUiOptions<TMounted> & {
     /**

--- a/packages/wxt/src/utils/content-script-ui/integrated.ts
+++ b/packages/wxt/src/utils/content-script-ui/integrated.ts
@@ -60,6 +60,11 @@ export interface IntegratedContentScriptUi<
   wrapper: HTMLElement;
 }
 
+/**
+ * {@inheritDoc wxt/utils/content-script-ui/types!ContentScriptUiOptions}
+ *
+ * @interface
+ */
 export type IntegratedContentScriptUiOptions<TMounted> =
   ContentScriptUiOptions<TMounted> & {
     /**

--- a/packages/wxt/src/utils/content-script-ui/shadow-root.ts
+++ b/packages/wxt/src/utils/content-script-ui/shadow-root.ts
@@ -153,6 +153,11 @@ export interface ShadowRootContentScriptUi<
   shadow: ShadowRoot;
 }
 
+/**
+ * {@inheritDoc wxt/utils/content-script-ui/types!ContentScriptUiOptions}
+ *
+ * @interface
+ */
 export type ShadowRootContentScriptUiOptions<TMounted> =
   ContentScriptUiOptions<TMounted> & {
     /**

--- a/packages/wxt/src/utils/content-script-ui/types.ts
+++ b/packages/wxt/src/utils/content-script-ui/types.ts
@@ -4,6 +4,13 @@ export interface ContentScriptUi<TMounted> extends MountFunctions {
   mounted: TMounted | undefined;
 }
 
+/**
+ * Options shared by integrated, shadow root, and iframe UIs.
+ *
+ * `position` selects `"inline"`, `"overlay"`, or `"modal"` positioning.
+ * `zIndex` controls the positioning element's stacking level for overlays and
+ * modals. `alignment` is available for overlays.
+ */
 export type ContentScriptUiOptions<TMounted> = ContentScriptPositioningOptions &
   ContentScriptAnchoredOptions & {
     /**
@@ -35,20 +42,27 @@ export type ContentScriptAppendMode =
   | 'after'
   | ((anchor: Element, ui: Element) => void);
 
+// Keep unsupported fields on each branch so TypeDoc can flatten the union
+// without accepting invalid position/option combinations.
+/** Inline positioning does not support `zIndex` or `alignment`. */
 export interface ContentScriptInlinePositioningOptions {
+  /** Choose between `"inline"`, `"overlay"`, or `"modal"` positioning. */
   position: 'inline';
+  zIndex?: never;
+  alignment?: never;
 }
 
 export interface ContentScriptOverlayPositioningOptions {
   position: 'overlay';
   /**
-   * The `z-index` used on the `wrapper` element. Set to a positive number to
+   * The `z-index` used on the positioning element. Set to a positive number to
    * show your UI over website content.
    */
   zIndex?: number;
   /**
-   * When using `type: "overlay"`, the mounted element is 0px by 0px in size.
-   * Alignment specifies which corner is aligned with that 0x0 pixel space.
+   * When using `position: "overlay"`, the mounted element is 0px by 0px in
+   * size. Alignment specifies which corner is aligned with that 0x0 pixel
+   * space.
    *
    * [Visualization of alignment
    * options](https://wxt.dev/content-script-ui-alignment.png)
@@ -58,13 +72,17 @@ export interface ContentScriptOverlayPositioningOptions {
   alignment?: ContentScriptOverlayAlignment;
 }
 
+/**
+ * Modal positioning options.
+ *
+ * @property zIndex The `z-index` used on the `shadowHost` element. Set to a
+ *   positive number to show your UI over website content.
+ * @property alignment Only available when `position` is `"overlay"`.
+ */
 export interface ContentScriptModalPositioningOptions {
   position: 'modal';
-  /**
-   * The `z-index` used on the `shadowHost`. Set to a positive number to show
-   * your UI over website content.
-   */
   zIndex?: number;
+  alignment?: never;
 }
 
 /**


### PR DESCRIPTION
### Overview

The factory-specific options pages currently render as `ContentScriptUiOptions<T> & object`, so shared options—especially `append`—are still hidden behind another API page after #2497.

- Render the integrated, iframe, and shadow-root option aliases as TypeDoc interfaces so shared and factory-specific properties appear together.
- Keep every positioning key present on each discriminated-union branch with optional `never` fields. This lets TypeDoc retain `zIndex` and `alignment` without accepting unsupported position/option combinations.
- Inherit the shared options summary and correct the alignment docs to reference `position: "overlay"`.
- Redirect the previous type-alias URLs to the new interface pages so existing links keep working.

The generated pages now expose all 8 integrated, 9 iframe, and 12 shadow-root options directly. TypeDoc 0.25 emits its generic union-to-interface warning for these aliases, so I also verified the generated Markdown and rendered HTML to ensure no properties are discarded.

### Manual Testing

- `bun run check`
- `bun run docs:build`
- Type-checked valid inline/overlay/modal configurations and invalid inline `zIndex` / modal `alignment` configurations.
- Asserted the complete property set in all three generated Markdown pages and their rendered HTML output.
- Verified the legacy URL redirects are included in the built site.

### Related Issue

Closes #1452
